### PR TITLE
fix(TRI001): detect result = variables skipped by prefilter

### DIFF
--- a/src/pre_commit_hooks/ast_checks/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/__init__.py
@@ -136,9 +136,9 @@ class CheckOrchestrator:
         # Step 1: Aggregate pre-filter patterns from all checks
         patterns = []
         for check in self.checks:
-            pattern = check.get_prefilter_pattern()
-            if pattern:
-                patterns.append(pattern)
+            check_patterns = check.get_prefilter_pattern()
+            if check_patterns:
+                patterns.extend(check_patterns)
 
         # Step 2: Pre-filter files (OR logic: file matches if it contains ANY pattern)
         if patterns:

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -61,19 +61,21 @@ class ASTCheck(Protocol):
         """
         ...
 
-    def get_prefilter_pattern(self) -> str | None:
-        """Pattern for git grep pre-filtering.
+    def get_prefilter_pattern(self) -> list[str] | None:
+        """Patterns for git grep pre-filtering.
 
-        Return a fixed string pattern that identifies files that might
+        Return fixed string patterns that identify files that might
         contain violations for this check. If None, all files will be
-        checked (no pre-filtering).
+        checked (no pre-filtering). Multiple patterns are combined with
+        OR logic — a file is a candidate if it contains ANY of the patterns.
 
         Returns:
-            Pattern string for git grep, or None for no filtering
+            List of pattern strings for git grep, or None for no filtering
 
         Examples:
-            - "def get_" for validate-function-name
-            - "super().__init__" for redundant-super-init
+            - ["def get_"] for validate-function-name
+            - ["super().__init__"] for redundant-super-init
+            - ["data", "result"] for forbid-vars
             - None for excessive-blank-lines (check all files)
         """
         ...

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -205,7 +205,7 @@ class ExcessiveBlankLinesCheck:
     def error_code(self) -> str:
         return "TRI002"
 
-    def get_prefilter_pattern(self) -> str | None:
+    def get_prefilter_pattern(self) -> list[str] | None:
         """Returns None because all files should be checked."""
         return None
 

--- a/src/pre_commit_hooks/ast_checks/forbid_vars.py
+++ b/src/pre_commit_hooks/ast_checks/forbid_vars.py
@@ -665,10 +665,10 @@ class ForbidVarsCheck:
     def error_code(self) -> str:
         return "TRI001"
 
-    def get_prefilter_pattern(self) -> str | None:
-        """Returns the first forbidden name as a simple pattern."""
+    def get_prefilter_pattern(self) -> list[str] | None:
+        """Returns all forbidden names as prefilter patterns."""
         if self.forbidden_names:
-            return next(iter(sorted(self.forbidden_names)))
+            return sorted(self.forbidden_names)
         # pragma: no cover (constructor defaults to DEFAULT_FORBIDDEN_NAMES)
         return None
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -110,13 +110,13 @@ class RedundantAssignmentCheck:
     def error_code(self) -> str:
         return ERROR_CODE
 
-    def get_prefilter_pattern(self) -> str | None:
+    def get_prefilter_pattern(self) -> list[str] | None:
         """Return pattern for git grep pre-filtering.
 
         Returns:
             Pattern to match assignment statements
         """
-        return " = "
+        return [" = "]
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
         """Run redundancy check on a file.

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -151,8 +151,8 @@ class RedundantSuperInitCheck:
     def error_code(self) -> str:
         return "TRI003"
 
-    def get_prefilter_pattern(self) -> str | None:
-        return "super().__init__"
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return ["super().__init__"]
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
         checker = SuperInitChecker(str(filepath))

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -250,8 +250,8 @@ def _make_check_class() -> type:
         def error_code(self) -> str:
             return ERROR_CODE
 
-        def get_prefilter_pattern(self) -> str | None:
-            return "def get_"
+        def get_prefilter_pattern(self) -> list[str] | None:
+            return ["def get_"]
 
         def check(
             self, filepath: Path, tree: ast.Module, source: str

--- a/tests/test_forbid_vars.py
+++ b/tests/test_forbid_vars.py
@@ -419,12 +419,36 @@ def test_no_violations_when_all_suppressed() -> None:
 
 
 def test_prefilter_pattern() -> None:
-    """Test that prefilter pattern is returned."""
+    """Test that prefilter pattern includes all forbidden names."""
     check = ForbidVarsCheck()
-    pattern = check.get_prefilter_pattern()
+    patterns = check.get_prefilter_pattern()
 
-    # Should return one of the forbidden names
-    assert pattern in {"data", "result"}
+    # Should return ALL forbidden names so that files with only 'result ='
+    # are not silently skipped during pre-filtering
+    assert patterns is not None
+    assert "data" in patterns
+    assert "result" in patterns
+
+
+def test_result_variable_detected() -> None:
+    """Regression test: files containing only 'result =' must be detected.
+
+    Previously, get_prefilter_pattern() returned only 'data' (the first
+    sorted forbidden name), so files with only 'result =' were silently
+    skipped by the prefilter and never reached the AST check.
+    """
+    source = """
+def compute():
+    result = get_value()
+    return result
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 1
+    assert "result" in violations[0].message
 
 
 def test_custom_forbidden_names() -> None:
@@ -534,8 +558,10 @@ def test_different_forbidden_names() -> None:
     assert len(violations) == 1, "Should only flag the configured names"
     assert "temp" in violations[0].message
 
-    # Prefilter should return one of the configured names
-    assert check.get_prefilter_pattern() in {"temp", "tmp"}
+    # Prefilter should return ALL configured names
+    patterns = check.get_prefilter_pattern()
+    assert patterns is not None
+    assert set(patterns) == {"temp", "tmp"}
 
 
 def test_keyword_only_parameters() -> None:

--- a/tests/test_redundant_assignment.py
+++ b/tests/test_redundant_assignment.py
@@ -259,8 +259,8 @@ def test_check_id_and_error_code() -> None:
 def test_prefilter_pattern() -> None:
     """Test that prefilter pattern is defined."""
     check = RedundantAssignmentCheck()
-    pattern = check.get_prefilter_pattern()
-    assert pattern == " = "
+    patterns = check.get_prefilter_pattern()
+    assert patterns == [" = "]
 
 
 def test_fixable_marked_correctly() -> None:


### PR DESCRIPTION
get_prefilter_pattern() was returning only the first sorted forbidden name ('data'), so files containing only 'result =' were never passed to the AST check.

Change the protocol and all check implementations to return list[str] | None, and update ForbidVarsCheck to return all forbidden names. The CheckOrchestrator now flattens each check's pattern list before calling batch_filter_files.