### PR TITLE
fix(TRI001): detect result = inside class methods

### DIFF
--- a/src/pre_commit_hooks/ast_checks/forbid_vars.py
+++ b/src/pre_commit_hooks/ast_checks/forbid_vars.py
@@ -399,13 +399,16 @@ class ForbiddenNameVisitor(ast.NodeVisitor):
         self.current_scope.pop()
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        """Don't descend into class definitions.
+        """Visit class body but only descend into method definitions.
 
-        Class attributes, NamedTuple fields, and dataclass fields are excluded
-        from analysis because the class name provides sufficient context.
+        Class-level attribute assignments (NamedTuple fields, dataclass fields,
+        plain class attributes) are excluded because the class name provides
+        sufficient context.  Method bodies ARE analysed — a 'result =' inside
+        a test method is just as meaningless as one in a standalone function.
         """
-        # Don't visit the class body - skip class attribute analysis
-        pass
+        for stmt in node.body:
+            if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                self.visit(stmt)
 
     def _check_function_args(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef

--- a/tests/test_forbid_vars.py
+++ b/tests/test_forbid_vars.py
@@ -451,6 +451,28 @@ def compute():
     assert "result" in violations[0].message
 
 
+def test_result_variable_in_class_method_detected() -> None:
+    """Regression test: 'result =' inside a class method must be detected.
+
+    Previously, visit_ClassDef() did 'pass', skipping the entire class body
+    including all method definitions. Variables like 'result =' inside test
+    class methods were silently missed.
+    """
+    source = """
+class TestSomething:
+    def test_query(self, conn):
+        result = conn.execute("SELECT COUNT(*) FROM t").fetchone()
+        assert result is not None
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 1
+    assert "result" in violations[0].message
+
+
 def test_custom_forbidden_names() -> None:
     """Test that custom forbidden names can be configured."""
     check = ForbidVarsCheck(forbidden_names={"foo", "bar"})


### PR DESCRIPTION
visit_ClassDef() was doing 'pass', silently skipping the entire class body including all method definitions. Variables such as 'result =' in test-class methods were never reaching the AST check.

Fix by iterating over the class body and visiting only FunctionDef, AsyncFunctionDef, and nested ClassDef nodes — identical to how VariableTracker (TRI005) already handles class bodies. Class-level attribute assignments remain excluded.

Add regression test covering the class-method case.