### PR TITLE
feat(TRI001): skip parameter check for @model_validator methods

### DIFF
--- a/src/pre_commit_hooks/ast_checks/forbid_vars.py
+++ b/src/pre_commit_hooks/ast_checks/forbid_vars.py
@@ -380,9 +380,30 @@ class ForbiddenNameVisitor(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
+    @staticmethod
+    def _has_decorator_named(
+        node: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+    ) -> bool:
+        """Return True if the function has a decorator identified by *name*.
+
+        Handles both bare decorators (``@model_validator``) and called
+        decorators (``@model_validator(mode="before")``).
+        """
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Name) and dec.id == name:
+                return True
+            if (
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Name)
+                and dec.func.id == name
+            ):
+                return True
+        return False
+
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         """Visit function definition nodes: def foo(data):."""
-        self._check_function_args(node)
+        if not self._has_decorator_named(node, "model_validator"):
+            self._check_function_args(node)
         # Push scope before visiting function body
         self.current_scope.append(node)
         self.generic_visit(node)
@@ -391,7 +412,8 @@ class ForbiddenNameVisitor(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         """Visit async function definition nodes: async def foo(data):."""
-        self._check_function_args(node)
+        if not self._has_decorator_named(node, "model_validator"):
+            self._check_function_args(node)
         # Push scope before visiting function body
         self.current_scope.append(node)
         self.generic_visit(node)

--- a/tests/test_forbid_vars.py
+++ b/tests/test_forbid_vars.py
@@ -67,6 +67,94 @@ class Config:
     assert len(violations) == 0, "Regular class attributes should not be analyzed"
 
 
+def test_pydantic_model_validator_data_param_not_flagged() -> None:
+    """Test that 'data' in a @model_validator parameter is not flagged.
+
+    Pydantic's @model_validator(mode="before") requires the parameter to be
+    named 'data'; flagging it would produce a false positive.
+    """
+    source = """
+from pydantic import BaseModel, model_validator
+from typing import Any
+
+class Email(BaseModel):
+
+    @model_validator(mode="before")
+    @classmethod
+    def content_is_provided(cls, data: Any) -> Any:
+        return data
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 0
+
+
+def test_pydantic_model_validator_bare_not_flagged() -> None:
+    """Test that bare @model_validator (without call) also suppresses the check."""
+    source = """
+from pydantic import BaseModel, model_validator
+from typing import Any
+
+class MyModel(BaseModel):
+
+    @model_validator
+    @classmethod
+    def validate_all(cls, data: Any) -> Any:
+        return data
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 0
+
+
+def test_pydantic_model_validator_body_still_checked() -> None:
+    """Test that the body of a @model_validator is still analysed for violations."""
+    source = """
+from pydantic import BaseModel, model_validator
+from typing import Any
+
+class MyModel(BaseModel):
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_all(cls, data: Any) -> Any:
+        result = do_something(data)  # 'result =' in body should still be flagged
+        return result
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 1
+    assert "result" in violations[0].message
+
+
+def test_non_validator_method_data_param_still_flagged() -> None:
+    """Test that 'data' is still flagged in regular (non-validator) methods."""
+    source = """
+from pydantic import BaseModel
+
+class MyModel(BaseModel):
+
+    def process(self, data: dict) -> dict:
+        return data
+"""
+
+    tree = ast.parse(source)
+    check = ForbidVarsCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert len(violations) == 1
+    assert "data" in violations[0].message
+
+
 def test_function_variables_are_analyzed() -> None:
     """Test that function-level variables ARE still analyzed."""
     source = """


### PR DESCRIPTION
Pydantic's @model_validator(mode="before") requires the first parameter to be named 'data' (the raw input). Flagging it is a false positive.

Add _has_decorator_named() helper that matches both bare decorators (@model_validator) and called decorators (@model_validator(mode=...)). Skip _check_function_args() for methods carrying that decorator. The method body is still fully analysed, so assignments like 'result = ...' inside the validator body remain flagged.