### PR TITLE
Add pytest cov

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,19 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
+      - run: npm ci --ignore-scripts
 
-      - name: Check formatting
-        run: npm run format:check
+      - run: npm run format:check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,5 +1,9 @@
 name: Prettier
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:
@@ -9,6 +13,7 @@ permissions:
 
 jobs:
   prettier:
+    name: Prettier
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,12 +1,11 @@
 name: Prettier
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:
   pull_request:
-  push:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: Run tests and upload coverage
+
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          enable-cache: true
+
+      - run: uv run pytest --cov --cov-report=xml
+
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,6 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,9 @@
 name: Run tests and upload coverage
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on: push
 
 permissions:
@@ -7,7 +11,9 @@ permissions:
 
 jobs:
   test:
+    name: Test + Coverage
     runs-on: ubuntu-latest
+    environment: development
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -20,7 +20,7 @@ jobs:
 
       - run: uv run pytest --cov --cov-report=xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ env/
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # IDE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ npm run format --silent
 uv run -- python -m slotscheck src tests
 ```
 
+If edited CI:
+
+```bash
+ZIZMOR_OFFLINE=true zizmor --fix=all --persona=auditor --collect=all .
+```
+
 ### Test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Extra Python rule checks and fixups for pre-commit/prek, meant to run alongside 
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
+[![codecov](https://codecov.io/github/alessio-locatelli/ruff-extra-rules/graph/badge.svg?token=TMZ7VAVVUL)](https://codecov.io/github/alessio-locatelli/ruff-extra-rules)
 
 ## Disclaimer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "types-pexpect>=4.9.0.20260518",
   "polyfactory>=3.3.0",
   "slotscheck>=0.20.1",
+  "pytest-cov>=7.1.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -269,6 +269,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "ruff-extra-rules"
 version = "0.0.37"
 source = { editable = "." }
@@ -280,6 +294,7 @@ dev = [
     { name = "mypy" },
     { name = "polyfactory" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "slotscheck" },
     { name = "types-pexpect" },
     { name = "types-pygments" },
@@ -296,6 +311,7 @@ dev = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "polyfactory", specifier = ">=3.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "slotscheck", specifier = ">=0.20.1" },
     { name = "types-pexpect", specifier = ">=4.9.0.20260518" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a CI workflow that runs the test suite on pull requests and pushes to `main`, generating XML coverage and uploading it to Codecov.
- **Chores**
  - Updated formatting CI to use pinned tooling and improved run handling by canceling in-progress checks.
  - Added development support for coverage reporting (`pytest-cov`).
  - Updated version control ignores to exclude `coverage.xml`.
- **Documentation**
  - Added a Codecov badge to the README.
  - Expanded lint guidance with an additional offline command option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->