### PR TITLE
Improve messages

### DIFF
--- a/docs/adr/0036-check-unavailable-error-isolated-per-check.md
+++ b/docs/adr/0036-check-unavailable-error-isolated-per-check.md
@@ -20,6 +20,8 @@
 
 ## Consequences
 
+**Amended by `docs/adr/0039-tri006-unavailable-message-scope-and-wording.md`:** "one-time" below means once per process, not once per run — prek/pre-commit's default parallelism runs a non-`require_serial` hook as multiple worker processes, each with its own fresh state, so a consumer can see the message once per worker process in a single run.
+
 - A consumer without `ty` installed still gets a clear, actionable, one-time failure message for TRI006 specifically, and exit code 1 — but every other enabled check's violations are still reported for every file, exactly as if TRI006 weren't enabled at all. Enabling a new check that depends on an optional external prerequisite can no longer silently break every other check for a consumer who hasn't installed it.
 - `CheckOrchestrator.process_files()` no longer raises `CheckUnavailableError` at all; `_cli.py`'s own `try`/`except` around it is gone, replaced by `report()` consulting `orchestrator.unavailable_checks` the same way it already consults `unprocessable_files` and `rule_failures`.
 - This is now the general contract for any check that can raise `CheckUnavailableError`, not a TRI006-specific carve-out — a future check with its own external prerequisite gets the same isolation for free.

--- a/docs/adr/0039-tri006-unavailable-message-scope-and-wording.md
+++ b/docs/adr/0039-tri006-unavailable-message-scope-and-wording.md
@@ -1,0 +1,43 @@
+# TRI006 unavailable/self-test messages: accept per-process repetition, drop dev-only wording
+
+## Context
+
+`docs/adr/0036-check-unavailable-error-isolated-per-check.md` made `CheckOrchestrator` record a `CheckUnavailableError` once per `check_id` and skip re-invoking that check for every later file in the same process, so `_diagnostics.report()` only ever prints one line per process. That guarantee held, but consumers still reported seeing TRI006's unavailable-`ty` message more than once during a single `prek run` or commit.
+
+Confirmed empirically: neither `prek` nor pre-commit runs a non-`require_serial` hook as a single process. By default they partition the file list across multiple worker processes sized to CPU count, independent of argv-length limits — a throwaway repo with 12 files and a stand-in hook produced 3 separate subprocess invocations on an 8-core machine; adding `require_serial: true` to that hook collapsed it to exactly 1. `.pre-commit-hooks.yaml` does not set `require_serial`, and this codebase has no internal multiprocessing of its own, so every worker process gets its own fresh Python global state and independently discovers `ty` is missing — ADR-0036's per-process dedup is correct but was never sufficient, on its own, to bound the message to once per run.
+
+Separately, the two messages `CheckUnavailableError` carries here (`_INSTALL_HINT`, `_SELF_TEST_FAILED_HINT` in `session.py`) had their own content problems: `_INSTALL_HINT` told every consumer to run `uvx --from ty ty --version` "to warm the uvx cache," advice that only makes sense for this repo's own maintainers benchmarking the linter, not an end user who just wants `ty` on `PATH`. `_SELF_TEST_FAILED_HINT` told a consumer to "try a different installed `ty` version" with no direction — unhelpful given `ty` is pre-1.0 and can change diagnostics either way between releases, and given this repo's own compatibility floor (`pyproject.toml`'s `ty>=X.Y.Z`) only advances when Dependabot's monthly-cadence bump lands, so a consumer's freshly-installed `ty` can already be ahead of what the running release last validated.
+
+## Considered Options
+
+For the repetition itself:
+
+- **`require_serial: true`** on the `ruff-extra-rules` hook: would collapse every worker process into one, making ADR-0036's per-process guarantee also a per-run guarantee. Rejected: this hook entry point bundles every check in `ALL_CHECKS` (forbid-vars, validate-function-name, redundant-type-conversion, ...), not just TRI006, so this would remove prek/pre-commit's parallelism for the whole hook, on every commit, forever — not only on the runs where `ty` happens to be missing. Nothing in this codebase replaces that parallelism internally.
+- **Cross-process shared state** (e.g. a sentinel/lockfile so worker processes agree to print only once): rejected. It would need real scoping and lifetime rules (per run? per commit?), has races between workers that start concurrently, and can go stale (a sentinel written before `ty` gets installed mid-session would keep suppressing the hint after the prerequisite is already fixed) — meaningful complexity for what is otherwise a cosmetic repeat.
+- **Accept the repeat, bounded by worker count**: adopted.
+
+For the message content, once the above put a floor under how "actionable" this text needs to be:
+
+- **Keep `_SELF_TEST_FAILED_HINT`'s remediation direction-specific** ("try a different installed `ty` version" or similar): rejected as unhelpful given the direction genuinely can't be known from inside the check — the failure looks identical whether the consumer's `ty` is older or newer than what this release validated.
+- **Detect and report the consumer's actual installed `ty` version** (via the LSP `initialize` response's `serverInfo`, not currently read, or shelling `ty --version`) to state the direction definitively: rejected as disproportionate — a real addition to the failure path for a message that already gives the consumer everything they need to check themselves.
+- **State a floor version derived from `pyproject.toml` at message-construction time** (parsing the `ty>=X.Y.Z` pin live, e.g. via `packaging.requirements.Requirement`): rejected — `packaging` is not a direct dependency of this project today (only an undeclared transitive of `pytest`), and TOML-parsing plus requirement-parsing on a failure path this rarely hit isn't worth the code for one version string.
+- **A hardcoded floor version constant, kept honest by a test**: adopted.
+
+## Decision
+
+`CheckOrchestrator`'s per-process dedup (ADR-0036) is unchanged. No cross-process coordination was added. A consumer may see the TRI006 unavailable/self-test message once per prek/pre-commit worker process for a given run — bounded by CPU count under default parallelism, or exactly once if the consumer's own hook config sets `require_serial: true` — rather than a hard guarantee of exactly once per run.
+
+Both `CheckUnavailableError` messages in `session.py` were rewritten:
+
+- `_INSTALL_HINT` drops the uvx-cache-warming instruction entirely; it now only points to `uv tool install ty` or adding `ty` as the consumer's own dev dependency.
+- `_SELF_TEST_FAILED_HINT` no longer asserts a direction. It states the `ty` floor this release validated against (a new `_MIN_TY_VERSION` constant) and offers both possibilities: upgrade if the consumer's `ty` predates that floor, or pin to an older `ty` (or wait for a `ruff-extra-rules` update) if it doesn't.
+- Both messages now mention `--ignore=redundant-type-conversion` as an explicit opt-out, so a consumer who doesn't want to deal with `ty` at all has a stated escape hatch instead of having to discover `--ignore` exists on their own.
+- `_MIN_TY_VERSION` is a plain hardcoded string, not derived from `pyproject.toml` at runtime. `test_min_ty_version_matches_pyproject_pin` (`tests/redundant_type_conversion/test_session.py`) parses `pyproject.toml`'s `dependency-groups.dev` `ty>=X.Y.Z` pin with stdlib `tomllib` plus a small regex and asserts it matches the constant, so a future pin bump that forgets the constant fails CI instead of drifting silently.
+
+## Consequences
+
+- The unavailable/self-test message repeating across a single `prek run`/commit — bounded by CPU count, not file count — is expected behavior, not a bug to file against this repo; a future report of "it prints more than once" should be closed against this ADR unless the repeat scales with file count instead of worker count.
+- Both messages are shorter and free of advice relevant only to this repo's own maintainers.
+- `_SELF_TEST_FAILED_HINT` can only ever state both remediation directions, never diagnose which one actually applies, since no dynamic version detection was added — a consumer still has to run `ty --version` themselves to tell which side of `_MIN_TY_VERSION` they're on.
+- `_MIN_TY_VERSION` duplicates `pyproject.toml`'s own `ty` pin; the guard test is the only thing preventing drift, so removing or skipping that test silently reopens the duplication risk.
+- `docs/adr/0036-check-unavailable-error-isolated-per-check.md`'s "one-time failure message" consequence predates this ADR and is now known to mean "once per worker process," not "once per run" — amended there with a pointer to this document rather than rewritten in place.

--- a/docs/adr/0039-tri006-unavailable-message-scope-and-wording.md
+++ b/docs/adr/0039-tri006-unavailable-message-scope-and-wording.md
@@ -30,7 +30,7 @@ For the message content, once the above put a floor under how "actionable" this 
 Both `CheckUnavailableError` messages in `session.py` were rewritten:
 
 - `_INSTALL_HINT` drops the uvx-cache-warming instruction entirely; it now only points to `uv tool install ty` or adding `ty` as the consumer's own dev dependency.
-- `_SELF_TEST_FAILED_HINT` no longer asserts a direction. It states the `ty` floor this release validated against (a new `_MIN_TY_VERSION` constant) and offers both possibilities: upgrade if the consumer's `ty` predates that floor, or pin to an older `ty` (or wait for a `ruff-extra-rules` update) if it doesn't.
+- `_SELF_TEST_FAILED_HINT` no longer asserts a direction. It states the `ty` floor this release validated against (a new `_MIN_TY_VERSION` constant) and offers both possibilities: upgrade if the consumer's `ty` predates that floor, or pin to an older `ty` (or wait for a `ruff-extra-rules` update) if it's newer than that floor — the exact validated version itself is never told to pin older, since that would only move away from the known-good state.
 - Both messages now mention `--ignore=redundant-type-conversion` as an explicit opt-out, so a consumer who doesn't want to deal with `ty` at all has a stated escape hatch instead of having to discover `--ignore` exists on their own.
 - `_MIN_TY_VERSION` is a plain hardcoded string, not derived from `pyproject.toml` at runtime. `test_min_ty_version_matches_pyproject_pin` (`tests/redundant_type_conversion/test_session.py`) parses `pyproject.toml`'s `dependency-groups.dev` `ty>=X.Y.Z` pin with stdlib `tomllib` plus a small regex and asserts it matches the constant, so a future pin bump that forgets the constant fails CI instead of drifting silently.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "polyfactory>=3.3.0",
   "slotscheck>=0.20.1",
   "pytest-cov>=7.1.0",
-  "ty>=0.0.63",
+  "ty>=0.0.64",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
@@ -27,18 +27,24 @@ _TY_COMMAND = ("ty", "server")
 # See ADR-0035's "Detection method" for why this separator is stripped.
 _HOVER_DOC_SEPARATOR = re.compile(r"\n-{3,}\n")
 
+# Kept in lockstep with pyproject.toml's `dependency-groups.dev` `ty>=X.Y.Z` pin by
+# test_min_ty_version_matches_pyproject_pin() -- see docs/adr/0039-tri006-unavailable-message-scope-and-wording.md.
+_MIN_TY_VERSION = "0.0.64"
+
 _INSTALL_HINT = (
-    "redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH, but it could not be "
-    "started. Install it with `uv tool install ty`, `uvx --from ty ty --version` once to warm the uvx cache "
-    "and then ensure `ty` resolves on PATH, or add `ty` as a dev dependency of your own project. "
-    "See https://github.com/astral-sh/ty."
+    "redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH. Install it with "
+    "`uv tool install ty` or add `ty` as a dev dependency of your own project, or opt out with "
+    "`--ignore=redundant-type-conversion`. See https://github.com/astral-sh/ty."
 )
 
 _SELF_TEST_FAILED_HINT = (
     "redundant-type-conversion (TRI006) found `ty` on PATH, but it failed this check's own compatibility "
     "self-test: a known redundant/necessary type-conversion pair didn't produce the diagnostics this check "
-    "expects. `ty` is pre-1.0 and its own diagnostics may change between versions — try a different "
-    "installed `ty` version. See docs/rules/redundant-type-conversion.md."
+    f"expects. `ty` is pre-1.0 and its diagnostics can change between versions in either direction. This "
+    f"release of ruff-extra-rules was validated against ty>={_MIN_TY_VERSION} -- if your `ty` predates that, "
+    "upgrade it; if not, it may be newer than validated, so pinning to an older `ty` (or waiting for a "
+    "ruff-extra-rules update) may help instead -- or opt out with `--ignore=redundant-type-conversion`. "
+    "See docs/rules/redundant-type-conversion.md."
 )
 
 _REDUNDANT_CONTROL_BEFORE = """\

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
@@ -33,8 +33,8 @@ _MIN_TY_VERSION = "0.0.64"
 
 _INSTALL_HINT = (
     "redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH. Install it with "
-    "`uv tool install ty`, or add `ty` as a dev dependency of your own project and run this hook from that "
-    "active environment (e.g. via `uv run`), or opt out with `--ignore=redundant-type-conversion`. "
+    "`uv tool install ty`, or add `ty` as a dev dependency of your own project and commit with that virtual "
+    "environment active, or opt out with `--ignore=redundant-type-conversion`. "
     "See https://github.com/astral-sh/ty."
 )
 

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
@@ -33,8 +33,9 @@ _MIN_TY_VERSION = "0.0.64"
 
 _INSTALL_HINT = (
     "redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH. Install it with "
-    "`uv tool install ty` or add `ty` as a dev dependency of your own project, or opt out with "
-    "`--ignore=redundant-type-conversion`. See https://github.com/astral-sh/ty."
+    "`uv tool install ty`, or add `ty` as a dev dependency of your own project and run this hook from that "
+    "active environment (e.g. via `uv run`), or opt out with `--ignore=redundant-type-conversion`. "
+    "See https://github.com/astral-sh/ty."
 )
 
 _SELF_TEST_FAILED_HINT = (
@@ -42,8 +43,8 @@ _SELF_TEST_FAILED_HINT = (
     "self-test: a known redundant/necessary type-conversion pair didn't produce the diagnostics this check "
     f"expects. `ty` is pre-1.0 and its diagnostics can change between versions in either direction. This "
     f"release of ruff-extra-rules was validated against ty>={_MIN_TY_VERSION} -- if your `ty` predates that, "
-    "upgrade it; if not, it may be newer than validated, so pinning to an older `ty` (or waiting for a "
-    "ruff-extra-rules update) may help instead -- or opt out with `--ignore=redundant-type-conversion`. "
+    "upgrade it; if it's newer than that, pinning to an older `ty` (or waiting for a ruff-extra-rules update) "
+    "may help instead -- or opt out with `--ignore=redundant-type-conversion`. "
     "See docs/rules/redundant-type-conversion.md."
 )
 

--- a/tests/redundant_type_conversion/test_session.py
+++ b/tests/redundant_type_conversion/test_session.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+import tomllib
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -19,7 +22,6 @@ from ._helpers import FakeSession
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -353,3 +355,12 @@ def test_close_file_forgets_the_file_even_when_the_didclose_notification_fails(t
     session.close_file(filepath)  # must not raise
 
     assert uri not in session._open_versions
+
+
+def test_min_ty_version_matches_pyproject_pin() -> None:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    dev_dependencies = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["dependency-groups"]["dev"]
+    (ty_pin,) = (dep for dep in dev_dependencies if re.match(r"^ty(?:[<>=~!]|$)", dep))
+    match = re.fullmatch(r"ty>=([\d.]+)", ty_pin)
+    assert match is not None, f"unexpected `ty` pin syntax in pyproject.toml: {ty_pin!r}"
+    assert match.group(1) == session_module._MIN_TY_VERSION

--- a/uv.lock
+++ b/uv.lock
@@ -109,14 +109,14 @@ wheels = [
 
 [[package]]
 name = "faker"
-version = "40.31.0"
+version = "40.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/e1/adf05724d5838fa9fe2ada64bf390bbf37b77e3714189ae9f17a2c6d0470/faker-40.31.0.tar.gz", hash = "sha256:af163a937aec99dca5abaeb94dd5008c51c26c6e9af1a26c8db4b3c4e7ca4403", size = 2024136, upload-time = "2026-07-14T15:33:32.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f5/e427b19d79e241a51ce6fcd69a47e7a9ca791a8bc3da00d91d5be05e1456/faker-40.31.0-py3-none-any.whl", hash = "sha256:bedc97c292a48a6a1bbe471a9076d7395a196421ede1cedde99d5719f6b91027", size = 2061930, upload-time = "2026-07-14T15:33:29.004Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "slotscheck", specifier = ">=0.20.1" },
-    { name = "ty", specifier = ">=0.0.63" },
+    { name = "ty", specifier = ">=0.0.64" },
     { name = "types-pexpect", specifier = ">=4.9.0.20260518" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
@@ -332,36 +332,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.63"
+version = "0.0.64"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/ce/cbeaa5c7576fec643609dfbf200d59493523b1cc0481d4e7a5effcbf0630/ty-0.0.63.tar.gz", hash = "sha256:c2f66439393b3acac69306c117d4ae44638ce5fffa4a20c21046e85bd473359f", size = 6280695, upload-time = "2026-07-23T11:41:39.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/aa/14c9965d3b173105692473897cc89c34cd91241368b2044e43167e1c17ff/ty-0.0.64.tar.gz", hash = "sha256:d12ddbb05f15158bb518af619378b385486450def95fb06f8ab98037febe9f2c", size = 6350966, upload-time = "2026-07-27T18:32:45.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/e4/d17a8e113ab15c692fe6fb9c422112d4bee7e829d80ced35826b45d98d98/ty-0.0.63-py3-none-linux_armv6l.whl", hash = "sha256:9a4ef7782e3af314fb63d006bec5ac3025bd70fee774b4dcfb5e44e8564f1994", size = 12056302, upload-time = "2026-07-23T11:41:03.5Z" },
-    { url = "https://files.pythonhosted.org/packages/be/0b/357234c815dc4bfcc88c3f860aa0983fe4228c8aa2a5bb16c35ee08a94af/ty-0.0.63-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:01eab0ab70d51ad10298aa2d4b058b387a1fe93e5ee52d2a1ee23e9c69ba8354", size = 11737674, upload-time = "2026-07-23T11:41:05.862Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/13/193d9aeeb6774690351cff9fafabd3ae9b54cc225d125e07fa004ce23bdc/ty-0.0.63-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a671b61eaad16178389e05b9c108c9cb75ae8d84968fe55906484f55d6268338", size = 11264191, upload-time = "2026-07-23T11:41:07.963Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/c5843e16759a2b25fc8a7197473474038e585ac9fdaa6fa16aeb6384bf6a/ty-0.0.63-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b255cc83d95c51bb9ee4931303fdbece8cb1d6d7c655eb77a3f2c8f349fb64d6", size = 11818890, upload-time = "2026-07-23T11:41:09.885Z" },
-    { url = "https://files.pythonhosted.org/packages/06/20/adf83ae1fc570d9bb449605e1eeeaa523ad2329ca838a636698b5c135d11/ty-0.0.63-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0da1e8183aa4f893421a173904478021498f542ee41273660538da6649a9631c", size = 11853141, upload-time = "2026-07-23T11:41:12.151Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/90/f8effd846e3ee13486ea08257c13094d58b9f188c5641bf609d6a7d5c09f/ty-0.0.63-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128f38eb5a67199e3811426386f7ec96f41251ddf45e04ddc0bcbb29d4853245", size = 12545184, upload-time = "2026-07-23T11:41:14.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/76/aac3a30d40431eb1d329acea016b248f5b6255e30ef3d28e19447e344be2/ty-0.0.63-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bedf34aff8b0557f2a7119b314a68a9c9e58c1d21554d0e2748f2c5fe6a1f638", size = 13062375, upload-time = "2026-07-23T11:41:16.441Z" },
-    { url = "https://files.pythonhosted.org/packages/62/3d/0158733932893e17f6008dadd74c8d7aed422fefc66e47fe77888014fe8c/ty-0.0.63-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7328d63c34587606dce02935a25404f54cd0161bfe413b8f7fc21d174aead612", size = 12619461, upload-time = "2026-07-23T11:41:18.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/be/e280ad095b050778f16f493d49a073fa5f6d8f301d3e2e59be6a672ba05c/ty-0.0.63-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504c4457f3a62afe836c1f26a2c9a12549299095f9cc4146778558df51a7515c", size = 12376402, upload-time = "2026-07-23T11:41:20.482Z" },
-    { url = "https://files.pythonhosted.org/packages/57/57/619788bf335cb86b090470b557ae1eed33613dc24e12142505d32b462e58/ty-0.0.63-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:7394ed39424b027c89d5f0c818871c791e33958b88f5bb13e14bd4a12a3ca631", size = 12671377, upload-time = "2026-07-23T11:41:22.489Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a2/0aff2cdd3c98e2c4729337542b8da0ce1980790e1600e0c4a717a1f46293/ty-0.0.63-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:94c3f155230490f8fb505911655e940c630c25cc0c35a76690cb413254fb4437", size = 11768090, upload-time = "2026-07-23T11:41:24.558Z" },
-    { url = "https://files.pythonhosted.org/packages/43/4a/cdb5f1d26154144dfee08e1bd671daf827238170f7cee9dad43990bb2016/ty-0.0.63-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c16e1d8b4f0ae99106d5f13a894034a202baf6cdab61e2bb1a239de82904f839", size = 11867747, upload-time = "2026-07-23T11:41:26.794Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/26/ecc09ecb70bc9fbfdf42fa57ff29568f173e8200df575a0d72dc2b8486f9/ty-0.0.63-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b66293dad89eaed4b9fbf3b661614dbeb85b59ba037178a3f9a0adedf264da5c", size = 12120000, upload-time = "2026-07-23T11:41:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/14/07/862822f9c2c397785b69b25cf79b4dfc3c0d55684b9adf11ac194450f8e1/ty-0.0.63-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8b29cc832e2ec73502c97dd7325d6ae0e085b34a33529a0f785192317d9862fc", size = 12477862, upload-time = "2026-07-23T11:41:30.847Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c2/50b08b641578d6f48e8aa28a91d0de32c91aa24dd926ed199e8afd2d37ea/ty-0.0.63-py3-none-win32.whl", hash = "sha256:f0a8fbfd1f990c0c5d85cce018d438969ac79e49247e2192c9745394bb7d17ab", size = 11433155, upload-time = "2026-07-23T11:41:33.28Z" },
-    { url = "https://files.pythonhosted.org/packages/92/2d/d422a5568f0d1f317186be22241288dc6e08b71dc24aca223f22038ac2d2/ty-0.0.63-py3-none-win_amd64.whl", hash = "sha256:2aa2370bdd6f42e9f37518c812379bef70b9162f9e5aad511495229b0b71cb93", size = 12450036, upload-time = "2026-07-23T11:41:35.559Z" },
-    { url = "https://files.pythonhosted.org/packages/35/97/2c9748e28ead0650c7ad3e5f74f178832ceabd7cb5c272a882f29eb32ee4/ty-0.0.63-py3-none-win_arm64.whl", hash = "sha256:95ac1a62162c3c7ac204731e95ebf766d62a46a7bfa238a6acbe923fcb772cb1", size = 11826243, upload-time = "2026-07-23T11:41:37.749Z" },
-]
-
-[[package]]
-name = "types-docutils"
-version = "0.22.3.20260712"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/24/f50d49be6d5ebbae29ff83418b6788fc9897fdfb54d56555c9ae4b15fb53/types_docutils-0.22.3.20260712.tar.gz", hash = "sha256:bed54a50136c8e7613c03ee1c51eb958b42754915df83535de356b974ca05877", size = 57848, upload-time = "2026-07-12T05:13:36.059Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/50/2b408d249cc7260b2296af68c395d90267c23288d1eb96765637eb6c1490/types_docutils-0.22.3.20260712-py3-none-any.whl", hash = "sha256:4bbc5cf949f8b1b1c7e1befa5a4d1c3bcad9f22f823538eea26ba7ff694fa38e", size = 91970, upload-time = "2026-07-12T05:13:35.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4c/c54937e4ff3fa7b34a99ea3387ec766bf0ad98dc8df8d792e89b388e658e/ty-0.0.64-py3-none-linux_armv6l.whl", hash = "sha256:3830a6675ab43635ced1c4c557f380ac4a49e9414e03975e4e4e8db644c64944", size = 12118357, upload-time = "2026-07-27T18:32:08.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/a839ee2bc78e943d079e6abe199a97b4eeffb7e5c9a57326d69de452186a/ty-0.0.64-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3ff07d7bc32a2135f58afe57393789a32ea2fed1a66216129a8e535e76043903", size = 11790882, upload-time = "2026-07-27T18:32:10.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/19f14357888a7198438926303753cf749428e3d62e8980ff1e9a72a78402/ty-0.0.64-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4f6d1c7f897cca05d12bacbf1435150d5ffa496099515aa6ed303c8b29e1d0bb", size = 11317394, upload-time = "2026-07-27T18:32:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2f/f54462300535ab99b551eda733177be2eef5dbc2997d3fdb357c4ddd760a/ty-0.0.64-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:138d6c37ad4bf8583aa7a9b29d90954151d7856f9910a03eae3eb34b34c57215", size = 11863042, upload-time = "2026-07-27T18:32:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/95/dbecf745520ebe8bd7b02fc55eee6441c9be312ebf6addce605eb52740dd/ty-0.0.64-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ed9719d1b7b66fb8efe073d860208a44c40af1f6cd5c2364aa9b323a1e579b4", size = 11910730, upload-time = "2026-07-27T18:32:17.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/26/12cfd40028e51ceed7b3cb645281c61c02eb64ff9fb0c09231d65c30ff25/ty-0.0.64-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68b23e5169e2137b5f1de7169ab0cebecab6c8eda374c34c1f6394308f58242", size = 12631936, upload-time = "2026-07-27T18:32:19.533Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d0/65ffc2b0a686347193c6f98e9421a7fc2a96fc3cd0b1001cf7cf284baff9/ty-0.0.64-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f41cb07d89d32626fcaf3ed4d262778fcb28b2628b6ed1e172cd7b18820668d8", size = 13171049, upload-time = "2026-07-27T18:32:22.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a4/975a5961842dcd6fa60f0770a102c0bba7509da909ab652919bfcdcd4fc7/ty-0.0.64-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f24e1504ab9e212f92356b82fe088fdeb3a39f9a2f4ff25e505d2e1d0db9056", size = 12826438, upload-time = "2026-07-27T18:32:24.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ef/dfb9b7f9bcc032d3b540b0d1f55f532a336e2fb41b1bd539c05ae81a151a/ty-0.0.64-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86db830cb914bb33bb8247b66ccea58de4496c2391bd42658aba744b439f3290", size = 12440880, upload-time = "2026-07-27T18:32:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/bedac20505e8a8f5501ad73d7d15d8e421a563fef59993909a23036929a4/ty-0.0.64-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:652ee3d6d03bea76cd2fe8949c78bb5970394ebd7c5fd270e9518c0dee1b931d", size = 12782439, upload-time = "2026-07-27T18:32:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/795733f13ceff1378f08b3de0c49d0f518df220ed856b0dfac869f3b7c81/ty-0.0.64-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4838768295774a86e95f9ec5633e739d016adbbb69dcbdc62f3549578a11f624", size = 11814821, upload-time = "2026-07-27T18:32:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3e/9d99cd1e1831003434f508ed9f258a56543194afc3bbe051eba2545fa676/ty-0.0.64-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5a3d700669868599edf39ce5125196682f15a8880cc8c669bc2a83b99984d99b", size = 11928678, upload-time = "2026-07-27T18:32:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3d/448f49a3503fb119a34348a5714bb92001f252fadbbb12d645f2e744b557/ty-0.0.64-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b161f0a82a8e2f2432db3bf7702b4d3924fa9486ba0014f6710a160fc157df0d", size = 12202249, upload-time = "2026-07-27T18:32:34.905Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/75768e562cec990d189dc05807ae72890b20ffbd1e1f43597bb98db63c60/ty-0.0.64-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:39b9dd42908df47c2dc57dda87e656fab97097ffd2618474bbdea986af0d6a9d", size = 12548817, upload-time = "2026-07-27T18:32:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/34/89/44cc276ea6ca0245495014758ffeadde1798fb0b5840c9cf36d8d2ed3250/ty-0.0.64-py3-none-win32.whl", hash = "sha256:d0676ab0e0935795e5843baa28dd5e366dc343d7c0945a996df9eab8e0644885", size = 11545474, upload-time = "2026-07-27T18:32:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7e/d1c8a871a38d17c8f168b9a6975f6247f7660f8334e517656a5e4b4a4858/ty-0.0.64-py3-none-win_amd64.whl", hash = "sha256:dcb9bd31f54097e362b776c26ab4564d4564cdd1355cb883481167a26c03cc3f", size = 12542987, upload-time = "2026-07-27T18:32:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/6d18640d0204cacd69abbaca95ad6a34c6d7e9169e9051d0117b17b827ec/ty-0.0.64-py3-none-win_arm64.whl", hash = "sha256:82cc34c1ad9a8feb6059aef193bebcecc656e548f6fab3d518bcd8b57d198d39", size = 11899263, upload-time = "2026-07-27T18:32:43.366Z" },
 ]
 
 [[package]]
@@ -375,14 +366,11 @@ wheels = [
 
 [[package]]
 name = "types-pygments"
-version = "2.20.0.20260518"
+version = "2.20.0.20260728"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-docutils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/66/3e27e8dbe72947d51355d1fcba222a55bf5f0770ee660e9cc9df0d1ce5d7/types_pygments-2.20.0.20260518.tar.gz", hash = "sha256:bcab233d0389cb0a91146eb860e7bdcbceaa0f30bee73cefc7b367129cc4a330", size = 21152, upload-time = "2026-05-18T06:07:26.927Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/99/0cee9f28ce2c1b8ce6619a6fc4e92bed751d2afc82f27c4e2682b080e3e3/types_pygments-2.20.0.20260728.tar.gz", hash = "sha256:dd0a49d84fd9e3f08ab3a3191779e4732a91bb1fad2e80178cf4574e8f35684d", size = 21362, upload-time = "2026-07-28T04:51:27.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/d6/5f19f5b633af6a7666c6096fdd06b70f0d4a8f585af5e18a3ef58ad47ec1/types_pygments-2.20.0.20260518-py3-none-any.whl", hash = "sha256:e40728efd00c9da5936366648d5b3c55e72ed52bdd80495a96577b4d717c4fcb", size = 29002, upload-time = "2026-05-18T06:07:26.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/29/394fd32bc24c95fd957f8ec0916b54846eb6e1d416c333272aa32b4e25df/types_pygments-2.20.0.20260728-py3-none-any.whl", hash = "sha256:22974ff0b06fcf752e5d91039a2a6bfd93607f13862b6dc1320a576506144df6", size = 29060, upload-time = "2026-07-28T04:51:26.835Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified that unavailable-check messaging may repeat once per worker process during parallel runs, with serial execution yielding a single message.
  - Refreshed TRI006 install/upgrade/pinning guidance, including the `--ignore=redundant-type-conversion` opt-out and a validated `ty` minimum version.
- **Documentation**
  - Updated ADRs for the corrected one-time behavior wording and TRI006 message scope.
- **Tests**
  - Added a guard test ensuring the minimum `ty` floor matches the `pyproject.toml` pin.
- **Chores**
  - Bumped the development dependency to `ty>=0.0.64`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->