### PR TITLE
Shorten inline-suppression syntax to `# pytriage: TR<N>`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,13 @@
 ci:
-  # Using `language: python` + `additional_dependencies: - .` will fail on CI with:
-  # /pc/clone/Th2rTdeQQtSpBbUHOU74cQ/py_env-python3.14/bin/python: Error while finding module specification for 'pre_commit_hooks.ast_checks' (ModuleNotFoundError: No module named 'pre_commit_hooks')
-  # Using `uv` requires a custom workflow (not https://pre-commit.ci/).
-  skip: [local-ruff-extra-rules-default, local-ruff-extra-rules-aggressive]
+  skip: [
+      # Using `language: python` + `additional_dependencies: - .` will fail on CI with:
+      # /pc/clone/Th2rTdeQQtSpBbUHOU74cQ/py_env-python3.14/bin/python: Error while finding module specification for 'pre_commit_hooks.ast_checks' (ModuleNotFoundError: No module named 'pre_commit_hooks')
+      # Using `uv` requires a custom workflow (not https://pre-commit.ci/).
+      local-ruff-extra-rules-default,
+      local-ruff-extra-rules-aggressive,
+      # redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH
+      ruff-extra-rules,
+    ]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,17 +66,14 @@ repos:
           ]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.0.36
+    rev: v0.0.37
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/
-        # rev v0.0.36 accepts --forbid-vars-level, not --meaningless-vars-level
-        # (used by the local hook above): this pin tracks a tagged release,
-        # never the working tree.
         args:
           [
             --fix,
-            --forbid-vars-level=permissive,
+            --meaningless-vars-level=permissive,
             --redundant-assignment-level=permissive,
           ]
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ An installable unit registered in `.pre-commit-hooks.yaml` that pre-commit/prek 
 _Avoid_: linter, tool
 
 **Check**:
-A single, independently toggleable rule (e.g. `meaningless-vars`, `redundant-assignment`, `misplaced-comment`) implementing the `ASTCheck` protocol, identified by a `check_id` and an error code (`TRI00N` or `STYLE-001`). Many checks run inside one hook invocation, orchestrated by `CheckOrchestrator`.
+A single, independently toggleable rule (e.g. `meaningless-vars`, `redundant-assignment`, `misplaced-comment`) implementing the `ASTCheck` protocol, identified by a `check_id` and an error code (e.g. `TR1`). Many checks run inside one hook invocation, orchestrated by `CheckOrchestrator`.
 _Avoid_: rule, linter, hook — a check is not a hook; several checks share one hook
 
 **Violation**:
@@ -21,7 +21,7 @@ A fixed string a check declares via `get_prefilter_pattern()` so `git grep` can 
 _Avoid_: filter — the user-facing `--exclude` glob is a distinct, unrelated concept (excludes files outright; a prefilter pattern only skips _checking_, never skips reporting if matched)
 
 **Inline ignore comment**:
-A `# pytriage: ignore=TRI00N` (or `=STYLE-001`) comment suppressing one violation on the line it appears on. Detected via `tokenize`, never text/regex matching, so a string or byte literal containing the same text can't be mistaken for one.
+A `# pytriage: TR1` comment, or a comma-separated list (`# pytriage: TR1,TR5`) to suppress more than one check's violation on the same line. Detected via `tokenize`, never text/regex matching, so a string or byte literal containing the same text can't be mistaken for one.
 _Avoid_: pragma — this repo's own suppression comment is distinct from the _third-party_ linter pragmas (`noqa`, `type: ignore`, `pylint:`, etc.) that `misplaced-comment` recognizes and refuses to ever move; don't conflate the two.
 
 **Fix**:

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Individual checks are toggled with `--select`/`--ignore`, and `--fix` applies wh
 - `--select=<id>,<id>` restricts the hook to **only** the listed check(s).
 - `--ignore=<id>,<id>` excludes the listed check(s) — it composes with `--select` rather than replacing it, just like `ruff check --select`/`--ignore`.
 
-| Rule                                                                 | Code      | Description                                                                                                                                                                       |
-| -------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [meaningless-vars](docs/rules/meaningless-vars.md)                   | TRI001    | Flags meaningless variable names like `data`, `result`, and `results`.                                                                                                            |
-| [excessive-blank-lines](docs/rules/excessive-blank-lines.md)         | TRI002    | Collapses multiple blank lines after a module header to a single one.                                                                                                             |
-| [redundant-super-init](docs/rules/redundant-super-init.md)           | TRI003    | Flags `**kwargs` forwarded to a parent `__init__` that accepts none.                                                                                                              |
-| [validate-function-name](docs/rules/validate-function-name.md)       | TRI004    | Flags functions where `get_*` is misused or inappropriate and suggests a more specific verb.                                                                                      |
-| [redundant-assignment](docs/rules/redundant-assignment.md)           | TRI005    | Flags (and optionally inlines) variable assignments that add no clarity.                                                                                                          |
-| [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TRI006    | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
-| [misplaced-comment](docs/rules/misplaced-comment.md)                 | STYLE-001 | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
+| Rule                                                                 | Code | Description                                                                                                                                                                       |
+| -------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [meaningless-vars](docs/rules/meaningless-vars.md)                   | TR1  | Flags meaningless variable names like `data`, `result`, and `results`.                                                                                                            |
+| [excessive-blank-lines](docs/rules/excessive-blank-lines.md)         | TR2  | Collapses multiple blank lines after a module header to a single one.                                                                                                             |
+| [redundant-super-init](docs/rules/redundant-super-init.md)           | TR3  | Flags `**kwargs` forwarded to a parent `__init__` that accepts none.                                                                                                              |
+| [validate-function-name](docs/rules/validate-function-name.md)       | TR4  | Flags functions where `get_*` is misused or inappropriate and suggests a more specific verb.                                                                                      |
+| [redundant-assignment](docs/rules/redundant-assignment.md)           | TR5  | Flags (and optionally inlines) variable assignments that add no clarity.                                                                                                          |
+| [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TR6  | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
+| [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
 
 ## Installation
 
@@ -44,7 +44,7 @@ repos:
 
 ### Inline Suppression
 
-Use `# pytriage: ignore=<code>` (e.g., `# pytriage: ignore=TRI001`).
+Use `# pytriage: <code>` (e.g., `# pytriage: TR1`), or a comma-separated list to suppress more than one check on the same line (`# pytriage: TR1,TR5`).
 
 ---
 

--- a/docs/adding-a-check.md
+++ b/docs/adding-a-check.md
@@ -6,7 +6,7 @@ Checks live under `src/pre_commit_hooks/ast_checks/` and plug into the grouped `
 
 - Purpose: one check, one responsibility.
 - Check id: kebab-case (e.g. `no-bare-except`).
-- Error code: `TRI00N` (next unused number), or `STYLE-00N` for a purely stylistic, always-safe-to-autofix check like `misplaced-comment`. `test_all_checks_have_unique_check_ids_and_error_codes` (`tests/test_orchestrator.py`) fails loudly if a new check's id or code collides with an existing one — see `docs/adr/0021-behavioral-contract-audit-rule-isolation-python-compat.md`.
+- Error code: `TR<N>` (next unused number). `test_all_checks_have_unique_check_ids_and_error_codes` (`tests/test_orchestrator.py`) fails loudly if a new check's id or code collides with an existing one — see `docs/adr/0021-behavioral-contract-audit-rule-isolation-python-compat.md`.
 - Violation message format and whether the check needs an autofix mode.
 
 For the general prefilter-then-parse pipeline shape, see AGENTS.md's "Suggested Check Architecture". Concretely for this repo: almost nothing qualifies for a grep-only check, because every existing check needs to distinguish syntax context that only an AST gives you — e.g. `meaningless-vars` must tell `data = 1` (violation) apart from `obj.data = 1` (attribute, fine) and `"data = 1"` (inside a string, fine), and must catch `def foo(data):` (a parameter, not an assignment) that grep would miss entirely. Use `get_prefilter_pattern()` for a cheap `git grep` pass to skip files that can't possibly match, then do the real detection with `ast`.
@@ -21,7 +21,7 @@ class ASTCheck(Protocol):
     def check_id(self) -> str: ...  # e.g. "meaningless-vars"
 
     @property
-    def error_code(self) -> str: ...  # e.g. "TRI001"
+    def error_code(self) -> str: ...  # e.g. "TR1"
 
     def get_prefilter_pattern(self) -> list[str] | None: ...  # git-grep fast path, None = check every file
 
@@ -51,7 +51,7 @@ Create `src/pre_commit_hooks/ast_checks/your_check.py` (or a package with `__ini
 
 - Standard library only, no external runtime dependencies.
 - Never touch text inside string/byte literals or comments when writing an autofix — locate targets via AST node positions (`node.lineno`/`node.col_offset`/`node.end_lineno`/`node.end_col_offset`), not blind regex substitution over the whole file. See `validate_function_name/autofix.py` for a worked example of AST-scoped renaming.
-- Support inline suppression: `# pytriage: ignore=TRI00N`.
+- Support inline suppression: `# pytriage: TR<N>` (also matches as one entry in a comma-separated list, e.g. `# pytriage: TR1,TR5`).
 - If the check is experimental or prone to false positives, keep it out of the default-enabled set via `args: [--ignore=your-check-id]` in `.pre-commit-hooks.yaml`.
 - Write fixed content via `atomic_write_text()` (`_base.py`), never a direct `open()`/`Path.write_text()` — it validates the content parses as Python before committing, refusing (via `FixValidationError`) rather than ever writing broken syntax to disk. If your `fix()` writes once per call (most checks), let `FixValidationError` propagate uncaught — `CheckOrchestrator._apply_fixes` attributes the rejection to the check's violations for you. If it writes more than once per call, looping over violations individually (like `validate_function_name`), catch `FixValidationError` around each write and call `mark_fix_rejected()` on that specific violation so a later write in the same call still gets attempted. See `docs/adr/0010-fix-validation-before-write.md`.
 - Catch `OSError` around your own `atomic_write_text()` call (missing parent directory, permission denied, disk full) and return `False` — don't let it propagate. `ASTCheck.fix()`'s contract is "`True` if fixes were applied, `False` otherwise," not "or raises"; every shipped check with autofix follows this (see `meaningless_vars.fix()`, `excessive_blank_lines.fix()`, or `validate_function_name/autofix.apply_fix()` for the pattern). `CheckOrchestrator._apply_fixes`'s own outer `except Exception` will mask a missed case when running through the full pipeline, but calling your check's `fix()` directly (as unit tests do) will raise instead of returning `False`. See `docs/adr/0011-behavioral-contract-audit-fix-engine.md`.
@@ -63,7 +63,7 @@ Create `tests/test_your_check.py` using `tmp_path` and `pytest.mark.parametrize`
 
 - Detection: true positives across the patterns the check targets.
 - No false positives on idiomatic code the check should leave alone.
-- Inline suppression (`# pytriage: ignore=TRI00N`).
+- Inline suppression (`# pytriage: TR<N>`).
 - Autofix, if implemented — including that it never mutates unrelated text (string literals, comments, identically-named symbols in unrelated scopes).
 
 For larger example files, add fixtures under `tests/fixtures/your_check/`, following the `good/`/`bad/`/`ignore/` (and `autofix/`, if relevant) convention used by `tests/fixtures/validate_function_name/`.

--- a/docs/rules/excessive-blank-lines.md
+++ b/docs/rules/excessive-blank-lines.md
@@ -1,4 +1,4 @@
-# excessive-blank-lines (TRI002)
+# excessive-blank-lines (TR2)
 
 Collapses multiple consecutive blank lines after module headers (copyright, docstrings, or comments) to a single blank line.
 
@@ -35,4 +35,4 @@ import os  # Good - 1 blank line
 - Preserves copyright comment spacing (1 blank line after copyright)
 - Only affects module-level blank lines, preserves function/class spacing
 - Maintains file encoding and handles different line ending styles
-- Inline suppression with `# pytriage: ignore=TRI002`, placed on the first code line after the blank run (the violation's own line is blank and can't carry a trailing comment)
+- Inline suppression with `# pytriage: TR2`, placed on the first code line after the blank run (the violation's own line is blank and can't carry a trailing comment)

--- a/docs/rules/meaningless-vars.md
+++ b/docs/rules/meaningless-vars.md
@@ -29,13 +29,13 @@ Meaningless variable names reduce code clarity and maintainability. See [Peter H
 
 ## Suggest mode (default)
 
-```
+```text
 src/process.py:2: TR1: 'data' is a meaningless variable name — 'user' is more descriptive. Or add '# pytriage: TR1' to suppress.
 ```
 
 **Permissive mode**, reporting a `result` binding the conservative default left out because no replacement could be suggested for it:
 
-```
+```text
 src/process.py:3: TR1: Meaningless variable name 'result' found. Use a more descriptive name. Or add '# pytriage: TR1' to suppress.
 ```
 

--- a/docs/rules/meaningless-vars.md
+++ b/docs/rules/meaningless-vars.md
@@ -1,4 +1,4 @@
-# meaningless-vars (TRI001)
+# meaningless-vars (TR1)
 
 Flags meaningless variable names like `data` and `result`.
 
@@ -16,7 +16,7 @@ Meaningless variable names reduce code clarity and maintainability. See [Peter H
 
 - Detects meaningless names in assignments, function parameters, and async functions
 - **Autofixing**: derives names from file-local semantics such as concrete annotations, imported standard APIs, producers, and consumers (`--fix`). The rename is scope-aware — it replaces only the AST `Name` nodes for that specific binding within its scope, not every textual occurrence in the file. `--fix` applies only high-confidence local renames; weaker evidence is reported as a suggestion without changing the file.
-- Inline suppression with `# pytriage: ignore=TRI001`
+- Inline suppression with `# pytriage: TR1`
 
 ## Reporting level
 
@@ -30,13 +30,13 @@ Meaningless variable names reduce code clarity and maintainability. See [Peter H
 ## Suggest mode (default)
 
 ```
-src/process.py:2: TRI001: 'data' is a meaningless variable name — 'user' is more descriptive. Or add '# pytriage: ignore=TRI001' to suppress.
+src/process.py:2: TR1: 'data' is a meaningless variable name — 'user' is more descriptive. Or add '# pytriage: TR1' to suppress.
 ```
 
 **Permissive mode**, reporting a `result` binding the conservative default left out because no replacement could be suggested for it:
 
 ```
-src/process.py:3: TRI001: Meaningless variable name 'result' found. Use a more descriptive name. Or add '# pytriage: ignore=TRI001' to suppress.
+src/process.py:3: TR1: Meaningless variable name 'result' found. Use a more descriptive name. Or add '# pytriage: TR1' to suppress.
 ```
 
 ## Fix mode
@@ -56,6 +56,6 @@ src/process.py:3: TRI001: Meaningless variable name 'result' found. Use a more d
 
 ```python
 def process():
-    data = get_user()  # pytriage: ignore=TRI001
+    data = get_user()  # pytriage: TR1
     return data
 ```

--- a/docs/rules/misplaced-comment.md
+++ b/docs/rules/misplaced-comment.md
@@ -1,4 +1,4 @@
-# misplaced-comment (STYLE-001)
+# misplaced-comment (TR7)
 
 Automatically fixes trailing comments on closing brackets by moving them to the expression line.
 
@@ -25,7 +25,7 @@ result = func(
 - Automatically moves comments from closing bracket lines to expression lines
 - Places comments inline if they fit within 88 characters, matching this project's own line-length convention; otherwise places them as preceding comments on their own line
 - Never moves linter pragma comments (`noqa`, `type: ignore`, `pragma:`, etc.)
-- Inline suppression with `# pytriage: ignore=STYLE-001`
+- Inline suppression with `# pytriage: TR7`
 - Preserves the source file's PEP 263 declared encoding; lines untouched by a fix also keep their original newline style (CRLF/LF) — a line a fix rewrites gets a plain `\n`
 
 Its fix is a purely mechanical text move that never changes semantics, so it's always safe to include in a `--fix` run alongside every other check:

--- a/docs/rules/redundant-assignment.md
+++ b/docs/rules/redundant-assignment.md
@@ -1,4 +1,4 @@
-# redundant-assignment (TRI005)
+# redundant-assignment (TR5)
 
 Detects and optionally auto-fixes redundant variable assignments where the variable doesn't add meaningful clarity or simplification to the code.
 
@@ -50,7 +50,7 @@ print(msg)
   - Multi-part descriptive names (`user_email_address`)
   - Type annotations
 - **Safe autofix mode**: automatically inlines simple, low-value assignments when mechanically safe — see [ADR-0032](../adr/0032-redundant-assignment-autofix-safety-criteria.md) for the exact safety criteria
-- Inline suppression with `# pytriage: ignore=TRI005`
+- Inline suppression with `# pytriage: TR5`
 - **Test-file relaxation**: a file under a `tests`/`test` directory, or named `test_*.py`/`*_test.py`, gets a higher semantic-value score for descriptive variable names — test code idiomatically uses named intermediates (`mock_response`, `expected_total`) for readability far more than production code does, so fewer of them get flagged
 - Gracefully handles:
   - Augmented assignments (`x += 1`)
@@ -100,6 +100,6 @@ func(x="foo")
 ## Suppression
 
 ```python
-result = expensive_calculation()  # pytriage: ignore=TRI005
+result = expensive_calculation()  # pytriage: TR5
 return result
 ```

--- a/docs/rules/redundant-super-init.md
+++ b/docs/rules/redundant-super-init.md
@@ -1,4 +1,4 @@
-# redundant-super-init (TRI003)
+# redundant-super-init (TR3)
 
 Detects when a class forwards `**kwargs` to a parent `__init__` that accepts no arguments.
 
@@ -32,5 +32,5 @@ class Child(Base):
 - Analyzes class hierarchies and method signatures
 - Handles multiple inheritance correctly
 - Limited to same-file parent classes — an imported or stdlib parent is skipped rather than guessed at
-- Inline suppression with `# pytriage: ignore=TRI003`, placed on the `__init__` definition line
+- Inline suppression with `# pytriage: TR3`, placed on the `__init__` definition line
 - No autofix — this check flags a design decision the caller has to make

--- a/docs/rules/redundant-type-conversion.md
+++ b/docs/rules/redundant-type-conversion.md
@@ -1,4 +1,4 @@
-# redundant-type-conversion (TRI006)
+# redundant-type-conversion (TR6)
 
 Flags a builtin type/collection conversion call — `str(...)`, `list(...)`, and similar — that `ty` considers redundant given the real, statically-known type of the value it wraps, including when that value's type is declared in a different file.
 
@@ -72,7 +72,7 @@ Catching a redundant conversion at a call site whose parameter type is declared 
 
 ```python
 def echo(value: str) -> str:
-    return str(value)  # pytriage: ignore=TRI006
+    return str(value)  # pytriage: TR6
 ```
 
 A line already carrying a third-party type-checker suppression comment — `# type: ignore`, `# pyright: ignore`, `# ty: ignore` — is never flagged either, so a suppression you've already placed for an unrelated reason can't get misreported as a redundant conversion.

--- a/docs/rules/validate-function-name.md
+++ b/docs/rules/validate-function-name.md
@@ -1,4 +1,4 @@
-# validate-function-name (TRI004)
+# validate-function-name (TR4)
 
 Detects functions where `get_` prefix is misused or inappropriate and suggests a more specific verb based on their behavior patterns.
 
@@ -55,7 +55,7 @@ Applies equally to `async def get_*` functions.
 - Detects 15+ behavioral patterns using AST analysis
 - Suggests appropriate function names based on what the function actually does
 - **Safe autofix mode**: automatically renames small, simple functions. The rename is AST-scoped — it renames the definition plus true call-site references (`self.x`/`cls.x` within the same class for methods, or `Name` references across the module for free functions), and never touches string/byte literals, comments, or identically-named symbols in unrelated scopes (e.g. a same-named method on a different class). See [ADR-0033](../adr/0033-validate-function-name-safe-autofix-criteria.md) for the exact safety criteria.
-- Inline suppression with `# pytriage: ignore=TRI004`
+- Inline suppression with `# pytriage: TR4`
 - Automatically skips:
   - `@property` decorators
   - `@override` / `@abstractmethod` decorators
@@ -72,7 +72,7 @@ Applies equally to `async def get_*` functions.
 ## Suppression
 
 ```python
-def get_user(id: int) -> User:  # pytriage: ignore=TRI004
+def get_user(id: int) -> User:  # pytriage: TR4
     """Legacy API - name cannot be changed."""
     return User.objects.get(id=id)
 ```

--- a/src/pre_commit_hooks/_cache.py
+++ b/src/pre_commit_hooks/_cache.py
@@ -184,9 +184,7 @@ class CacheManager:
             logger.warning("Cache directory %s is unavailable, running without cache: %s", self.cache_dir, repr(error))
             self._cache_dir_unavailable = True
 
-    def get_cached_result(  # pytriage: ignore=TRI004,TR4 -- fixed by ADR-0037, pending a released pin bump
-        self, filepath: Path, hook_name: str | None = None
-    ) -> dict[str, Any] | None:
+    def get_cached_result(self, filepath: Path, hook_name: str | None = None) -> dict[str, Any] | None:
         """Uses mtime fast-path: if mtime unchanged, skip expensive hash computation.
         If mtime changed, verify with content hash.
 

--- a/src/pre_commit_hooks/_cache.py
+++ b/src/pre_commit_hooks/_cache.py
@@ -184,7 +184,7 @@ class CacheManager:
             logger.warning("Cache directory %s is unavailable, running without cache: %s", self.cache_dir, repr(error))
             self._cache_dir_unavailable = True
 
-    def get_cached_result(  # pytriage: ignore=TRI004 -- fixed by ADR-0037, pending a released pin bump
+    def get_cached_result(  # pytriage: ignore=TRI004,TR4 -- fixed by ADR-0037, pending a released pin bump
         self, filepath: Path, hook_name: str | None = None
     ) -> dict[str, Any] | None:
         """Uses mtime fast-path: if mtime unchanged, skip expensive hash computation.

--- a/src/pre_commit_hooks/ast_checks/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/__init__.py
@@ -6,21 +6,22 @@ AST parsing operations.
 
 Error Codes
 -----------
-  - TRI001: Meaningless variable names (meaningless-vars)
-  - TRI002: Excessive blank lines (excessive-blank-lines)
-  - TRI003: Redundant super init (redundant-super-init)
-  - TRI004: Function naming violations (validate-function-name)
-  - TRI005: Redundant variable assignments (redundant-assignment)
-  - TRI006: Redundant builtin type conversions (redundant-type-conversion)
-  - STYLE-001: Comment misplaced on closing bracket line (misplaced-comment)
+  - TR1: Meaningless variable names (meaningless-vars)
+  - TR2: Excessive blank lines (excessive-blank-lines)
+  - TR3: Redundant super init (redundant-super-init)
+  - TR4: Function naming violations (validate-function-name)
+  - TR5: Redundant variable assignments (redundant-assignment)
+  - TR6: Redundant builtin type conversions (redundant-type-conversion)
+  - TR7: Comment misplaced on closing bracket line (misplaced-comment)
 
 Inline Ignore Comments
 ----------------------
-Use `# pytriage: ignore=<code>` to suppress specific violations.
+Use `# pytriage: <code>` to suppress a specific violation, or a
+comma-separated list to suppress more than one on the same line.
 
 Example:
-    data = [1, 2, 3]  # pytriage: ignore=TRI001
-    def get_users():  # pytriage: ignore=TRI004
+    data = [1, 2, 3]  # pytriage: TR1
+    def get_users():  # pytriage: TR4
         return []
 """
 

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -51,7 +51,7 @@ class ASTCheck(Protocol):
 
     @property
     def error_code(self) -> str:
-        """Error code prefix for this check's violations, e.g. "TRI001"."""
+        """Error code prefix for this check's violations, e.g. "TR1"."""
         ...
 
     @property
@@ -376,14 +376,15 @@ def atomic_write_text(path: Path, content: str, encoding: str) -> None:
 
 
 def ignore_pattern_for(error_code: str) -> re.Pattern[str]:
-    """Compile the inline-ignore regex for a check's error code.
+    """Compile the inline-suppression regex for a check's error code.
 
-    Every check that supports `# pytriage: ignore=<code>` suppression
-    compiled a near-identical pattern by hand; this is the single place that
-    pattern is defined, so all checks agree on its syntax (case-insensitive,
-    optional whitespace around `:`).
+    Matches `# pytriage: TR1` alone or as one entry in a comma-separated
+    list (`# pytriage: TR1,TR5`), in any position. The trailing `(?!\\w)`
+    stops a short code from matching inside a longer one that starts with
+    the same digits (`TR1` inside `TR10`).
     """
-    return re.compile(rf"#\s*pytriage:\s*ignore={re.escape(error_code)}", re.IGNORECASE)
+    escaped = re.escape(error_code)
+    return re.compile(rf"#\s*pytriage:\s*(?:[^,\s]+\s*,\s*)*{escaped}(?!\w)", re.IGNORECASE)
 
 
 def find_ignored_lines(source: str, pattern: re.Pattern[str]) -> set[int]:

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -1,9 +1,9 @@
 """Check and fix excessive blank lines after module headers.
 
-TRI002: Collapse 2+ consecutive blank lines after module headers (copyright,
+TR2: Collapse 2+ consecutive blank lines after module headers (copyright,
 docstring, or comments) to a single blank line.
 
-Inline ignore: # pytriage: ignore=TRI002, placed on the first code line after
+Inline ignore: # pytriage: TR2, placed on the first code line after
 the blank run (the violation's own line is blank, so it can't carry a
 trailing comment itself).
 """
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("excessive_blank_lines")
 
-IGNORE_PATTERN = ignore_pattern_for("TRI002")
+IGNORE_PATTERN = ignore_pattern_for("TR2")
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,7 +42,7 @@ class _BlankRunViolation:
 def _format_message(blank_count: int, target: int) -> str:
     return (
         f"Excessive blank lines ({blank_count}) should be collapsed to {target}. "
-        "Add '# pytriage: ignore=TRI002' to the line following the blank run "
+        "Add '# pytriage: TR2' to the line following the blank run "
         "to suppress."
     )
 
@@ -206,7 +206,7 @@ class ExcessiveBlankLinesCheck(BaseCheck):
 
     @property
     def error_code(self) -> str:
-        return "TRI002"
+        return "TR2"
 
     def get_prefilter_pattern(self) -> list[str] | None:
         return None

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -1,9 +1,9 @@
 """Check for meaningless variable names like 'data', 'result', and 'results'.
 
-TRI001: Detects and suggests replacements for meaningless variable names that
+TR1: Detects and suggests replacements for meaningless variable names that
 reduce code maintainability.
 
-Inline ignore: # pytriage: ignore=TRI001
+Inline ignore: # pytriage: TR1
 """
 
 from __future__ import annotations
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("meaningless_vars")
 
-# Format: # pytriage: ignore=TRI001
-IGNORE_PATTERN = ignore_pattern_for("TRI001")
+# Format: # pytriage: TR1
+IGNORE_PATTERN = ignore_pattern_for("TR1")
 
 type VariableName = str
 type _ComprehensionNode = ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp
@@ -807,7 +807,7 @@ class MeaninglessVarsCheck(BaseCheck):
 
     @property
     def error_code(self) -> str:
-        return "TRI001"
+        return "TR1"
 
     def get_prefilter_pattern(self) -> list[str] | None:
         return sorted(self.meaningless_names)
@@ -819,7 +819,7 @@ class MeaninglessVarsCheck(BaseCheck):
             choices=["conservative", "permissive"],
             default="conservative",
             help=(
-                "Whether meaningless-vars (TRI001) reports a meaningless name "
+                "Whether meaningless-vars (TR1) reports a meaningless name "
                 "that has no suggested replacement. 'conservative' "
                 "(default) reports a name only when a rename can be "
                 "suggested; 'permissive' reports every meaningless name "
@@ -856,7 +856,7 @@ class MeaninglessVarsCheck(BaseCheck):
                 message = f"'{v['name']}' is a meaningless variable name — '{v['suggestion']}' is more descriptive."
             else:
                 message = f"Meaningless variable name '{v['name']}' found. Use a more descriptive name."
-            message += " Or add '# pytriage: ignore=TRI001' to suppress."
+            message += " Or add '# pytriage: TR1' to suppress."
 
             violations.append(
                 Violation(

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -1,11 +1,11 @@
 """misplaced-comment - move trailing comments off closing-bracket-only lines.
 
-STYLE-001: a comment trailing a line that contains only closing brackets
+TR7: a comment trailing a line that contains only closing brackets
 should move to the expression line instead (inline if it fits within 88
 chars, otherwise as a preceding comment). Linter pragma comments (noqa,
 type-checker ignores, coverage pragmas, etc.) are never moved.
 
-Inline ignore: # pytriage: ignore=STYLE-001
+Inline ignore: # pytriage: TR7
 """
 
 from __future__ import annotations
@@ -36,9 +36,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("misplaced_comment")
 
 CHECK_ID = "misplaced-comment"
-ERROR_CODE = "STYLE-001"
+ERROR_CODE = "TR7"
 
-IGNORE_PATTERN = ignore_pattern_for("STYLE-001")
+IGNORE_PATTERN = ignore_pattern_for("TR7")
 
 # Linter pragma patterns that should NEVER be moved
 LINTER_PRAGMA_PATTERNS = [
@@ -172,7 +172,7 @@ class MisplacedCommentCheck(BaseCheck):
                 message=(
                     f"Comment on line {item.comment_line} should not be on "
                     "closing bracket line. Or add "
-                    "'# pytriage: ignore=STYLE-001' to suppress."
+                    "'# pytriage: TR7' to suppress."
                 ),
                 fixable=True,
             )

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -1,6 +1,6 @@
-"""Check for redundant variable assignments (TRI005).
+"""Check for redundant variable assignments (TR5).
 
-TRI005: Detects redundant variable assignments where the variable doesn't add
+TR5: Detects redundant variable assignments where the variable doesn't add
 clarity, transformation, or simplification to the code.
 
 Patterns detected:
@@ -8,7 +8,7 @@ Patterns detected:
 2. Single-use variables: x = calc(); return x
 3. Literal identity: foo = "foo"
 
-Inline ignore: # pytriage: ignore=TRI005
+Inline ignore: # pytriage: TR5
 
 Examples:
     # ❌ Redundant
@@ -49,10 +49,10 @@ if TYPE_CHECKING:
     import ast
     from pathlib import Path
 
-# Format: # pytriage: ignore=TRI005
-IGNORE_PATTERN = ignore_pattern_for("TRI005")
+# Format: # pytriage: TR5
+IGNORE_PATTERN = ignore_pattern_for("TR5")
 
-ERROR_CODE = "TRI005"
+ERROR_CODE = "TR5"
 CHECK_ID = "redundant-assignment"
 
 
@@ -61,22 +61,22 @@ def format_message(var_name: str, pattern_type: str) -> str:
         "IMMEDIATE_SINGLE_USE": (
             f"Redundant assignment '{var_name}' used only once immediately "
             f"after. Consider inlining the value. Or add "
-            f"'# pytriage: ignore={ERROR_CODE}' to suppress."
+            f"'# pytriage: {ERROR_CODE}' to suppress."
         ),
         "SINGLE_USE": (
             f"Variable '{var_name}' assigned and used only once. "
             f"Consider inlining the expression. Or add "
-            f"'# pytriage: ignore={ERROR_CODE}' to suppress."
+            f"'# pytriage: {ERROR_CODE}' to suppress."
         ),
         "LITERAL_IDENTITY": (
             f"Identity assignment '{var_name}' is redundant. "
             f"Consider using literal directly. Or add "
-            f"'# pytriage: ignore={ERROR_CODE}' to suppress."
+            f"'# pytriage: {ERROR_CODE}' to suppress."
         ),
     }
     return messages.get(
         pattern_type,
-        f"Redundant assignment '{var_name}'. Or add '# pytriage: ignore={ERROR_CODE}' to suppress.",
+        f"Redundant assignment '{var_name}'. Or add '# pytriage: {ERROR_CODE}' to suppress.",
     )
 
 
@@ -104,7 +104,7 @@ class RedundantAssignmentCheck(BaseCheck):
             choices=["conservative", "permissive"],
             default="conservative",
             help=(
-                "How eagerly redundant-assignment (TRI005) reports a "
+                "How eagerly redundant-assignment (TR5) reports a "
                 "violation. 'conservative' (default) flags only the "
                 "clearest, safest-to-inline cases; 'permissive' flags a "
                 "broader range. Either way, --fix applies to whatever is "

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -1,4 +1,4 @@
-"""Variable tracking and redundancy pattern detection for TRI005."""
+"""Variable tracking and redundancy pattern detection for TR5."""
 
 from __future__ import annotations
 
@@ -808,7 +808,7 @@ class VariableTracker(ast.NodeVisitor):
     def _track_rebinding_use(self, var_name: str, line: int, col: int, scope_id: int, stmt_index: int) -> None:
         """Records that `var_name` was rebound (augmented-assignment or
         walrus) at this point — not a fresh `AssignmentInfo` (neither is a
-        standalone statement TRI005 could itself flag as redundant), but a
+        standalone statement TR5 could itself flag as redundant), but a
         "use" `_rhs_reference_reassigned` recognizes as disqualifying a
         snapshot taken from `var_name` earlier in the same scope.
         """
@@ -1219,7 +1219,7 @@ def detect_redundancy(lifecycle: VariableLifecycle) -> PatternType | None:
     # Augmented-assignment targets (x += 1) can never be inlined: the "use"
     # IS an assignment target, and replacing it with the RHS expression
     # produces invalid syntax (`x = 5; x += 1` -> `5 += 1`). This also isn't
-    # the read-then-pass-through pattern TRI005 targets — the variable is
+    # the read-then-pass-through pattern TR5 targets — the variable is
     # being mutated, not merely forwarded.
     for use in lifecycle.uses:
         if use.context == "augmented_assignment":

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
@@ -1,4 +1,4 @@
-"""Auto-fix implementation for TRI005 redundant assignments."""
+"""Auto-fix implementation for TR5 redundant assignments."""
 
 from __future__ import annotations
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -639,7 +639,7 @@ def should_report_violation(
     # deliberately documenting what that call returns — e.g. `warning =
     # conn.recv()` or `ci_headers = CIMultiDict(headers)` — rather than a
     # redundant restatement of it. Doesn't apply to the permissive level,
-    # which reports the same broader set TR5 always used to.
+    # which instead falls through to the semantic-value ceiling below.
     if (
         level is AggressivenessLevel.CONSERVATIVE
         and isinstance(assignment.rhs_node, ast.Call)
@@ -725,12 +725,10 @@ def _is_generic_call_result_name(var_name: str, rhs_node: ast.Call) -> bool:
 
 
 # Score ceiling a violation's `calculate_semantic_value` must be at or under
-# to be reported. The conservative-level ceilings reuse the exact numbers
-# `should_autofix` used to gate autofix eligibility on before issue #76 — so
-# the conservative level now reports only what the old default used to
-# auto-fix, and reporting alone (no separate, softer autofix-specific
-# ceiling) decides what's eligible for --fix. The permissive ceiling (49,
-# i.e. score < 50) reproduces TR5's old, single default reporting bar.
+# to be reported. At the conservative level, `should_autofix()` doesn't
+# narrow these further with a separate, stricter semantic-value ceiling of
+# its own — see ADR-0032. The permissive ceiling (49, i.e. score < 50)
+# reports every case up to that bar.
 _CONSERVATIVE_REPORT_CEILING = {
     PatternType.IMMEDIATE_SINGLE_USE: 10,
     PatternType.LITERAL_IDENTITY: 10,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -1,4 +1,4 @@
-"""Semantic value analysis for variable names in TRI005."""
+"""Semantic value analysis for variable names in TR5."""
 
 from __future__ import annotations
 
@@ -639,7 +639,7 @@ def should_report_violation(
     # deliberately documenting what that call returns — e.g. `warning =
     # conn.recv()` or `ci_headers = CIMultiDict(headers)` — rather than a
     # redundant restatement of it. Doesn't apply to the permissive level,
-    # which reports the same broader set TRI005 always used to.
+    # which reports the same broader set TR5 always used to.
     if (
         level is AggressivenessLevel.CONSERVATIVE
         and isinstance(assignment.rhs_node, ast.Call)
@@ -730,7 +730,7 @@ def _is_generic_call_result_name(var_name: str, rhs_node: ast.Call) -> bool:
 # the conservative level now reports only what the old default used to
 # auto-fix, and reporting alone (no separate, softer autofix-specific
 # ceiling) decides what's eligible for --fix. The permissive ceiling (49,
-# i.e. score < 50) reproduces TRI005's old, single default reporting bar.
+# i.e. score < 50) reproduces TR5's old, single default reporting bar.
 _CONSERVATIVE_REPORT_CEILING = {
     PatternType.IMMEDIATE_SINGLE_USE: 10,
     PatternType.LITERAL_IDENTITY: 10,

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -1,10 +1,10 @@
 """Check for redundant **kwargs forwarding to parent __init__ methods.
 
-TRI003: Detects when a class forwards **kwargs to a parent __init__ that
+TR3: Detects when a class forwards **kwargs to a parent __init__ that
 accepts no arguments. This is a logic error that creates misleading inheritance
 patterns.
 
-Inline ignore: # pytriage: ignore=TRI003, placed on the __init__ definition line.
+Inline ignore: # pytriage: TR3, placed on the __init__ definition line.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("redundant_super_init")
 
-IGNORE_PATTERN = ignore_pattern_for("TRI003")
+IGNORE_PATTERN = ignore_pattern_for("TR3")
 
 
 class SuperInitChecker(ast.NodeVisitor):
@@ -68,7 +68,7 @@ class SuperInitChecker(ast.NodeVisitor):
                                 (
                                     f"Redundant **kwargs forwarded to {base.id}.__init__() "
                                     "which accepts no arguments. Or add "
-                                    "'# pytriage: ignore=TRI003' to suppress."
+                                    "'# pytriage: TR3' to suppress."
                                 ),
                             )
                         )
@@ -132,7 +132,7 @@ class RedundantSuperInitCheck(BaseCheck):
 
     @property
     def error_code(self) -> str:
-        return "TRI003"
+        return "TR3"
 
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["super().__init__"]

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -1,4 +1,4 @@
-"""TRI006: redundant builtin type-conversion calls. See
+"""TR6: redundant builtin type-conversion calls. See
 `docs/rules/redundant-type-conversion.md` and ADR-0035.
 """
 
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
     import ast
     from pathlib import Path
 
-# Format: # pytriage: ignore=TRI006
-IGNORE_PATTERN = ignore_pattern_for("TRI006")
+# Format: # pytriage: TR6
+IGNORE_PATTERN = ignore_pattern_for("TR6")
 
 # See docs/rules/redundant-type-conversion.md's Suppression section.
 THIRD_PARTY_IGNORE_PATTERN = re.compile(r"#\s*(?:type|pyright|ty)\s*:\s*ignore\b", re.IGNORECASE)
 
-ERROR_CODE = "TRI006"
+ERROR_CODE = "TR6"
 CHECK_ID = "redundant-type-conversion"
 
 
@@ -34,7 +34,7 @@ def _format_message(item: RedundantConversion) -> str:
     if is_exact_match(item.argument_type, constructor):
         return (
             f"Redundant `{constructor}(...)` conversion: the argument is already `{item.argument_type}`, so "
-            f"wrapping it in `{constructor}()` has no effect. Or add '# pytriage: ignore={ERROR_CODE}' to suppress."
+            f"wrapping it in `{constructor}()` has no effect. Or add '# pytriage: {ERROR_CODE}' to suppress."
         )
     # Not a real type match -- `ty` just didn't distinguish the two here
     # (e.g. either side of a weakly-typed `==`), see ADR-0035's permissive
@@ -43,7 +43,7 @@ def _format_message(item: RedundantConversion) -> str:
     return (
         f"Redundant `{constructor}(...)` conversion: `ty` sees no difference with or without this wrap here, "
         f"though the argument's own type is `{item.argument_type}`, not `{constructor}` -- verify before removing. "
-        f"Or add '# pytriage: ignore={ERROR_CODE}' to suppress."
+        f"Or add '# pytriage: {ERROR_CODE}' to suppress."
     )
 
 
@@ -76,7 +76,7 @@ class RedundantTypeConversionCheck(BaseCheck):
             choices=["conservative", "permissive"],
             default="conservative",
             help=(
-                "How eagerly redundant-type-conversion (TRI006) reports a violation. 'conservative' (default) "
+                "How eagerly redundant-type-conversion (TR6) reports a violation. 'conservative' (default) "
                 "flags str/int/float/bool/bytes/frozenset/tuple conversions, only when the wrapped value already "
                 "matches that type exactly. 'permissive' also flags copy-producing conversions "
                 "(list/dict/set/bytearray) and a looser match, e.g. an already-list[str] value passed somewhere "

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/analysis.py
@@ -1,6 +1,6 @@
 """Ties AST candidate detection (`candidates.py`), confidence tiering
 (`confidence.py`), and `ty`'s own redundancy decision (`session.py`)
-together for TRI006.
+together for TR6.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from .confidence import ConfidenceLevel
 
 _SESSION_LOST_HINT = (
-    "redundant-type-conversion (TRI006) lost its connection to `ty` mid-run (the `ty server` process likely "
+    "redundant-type-conversion (TR6) lost its connection to `ty` mid-run (the `ty server` process likely "
     "crashed or exited). Re-run to start a fresh session; if this keeps happening, try a different installed "
     "`ty` version. See docs/rules/redundant-type-conversion.md."
 )
@@ -135,6 +135,6 @@ def _build_modified_text(source_lines: list[str], candidate: Candidate) -> str:
         + line_bytes[candidate.arg_start_col : candidate.arg_end_col]
         + line_bytes[candidate.call_end_col :]
     )
-    new_lines = list(source_lines)  # pytriage: ignore=TRI006 -- copy, not redundant: avoids aliasing the caller's list
+    new_lines = list(source_lines)  # pytriage: TR6 -- copy, not redundant: avoids aliasing the caller's list
     new_lines[candidate.line - 1] = new_line_bytes.decode("utf-8")
     return "".join(new_lines)

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/candidates.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/candidates.py
@@ -1,4 +1,4 @@
-"""AST-level candidate detection for TRI006, before any `ty` session is involved. See ADR-0035."""
+"""AST-level candidate detection for TR6, before any `ty` session is involved. See ADR-0035."""
 
 from __future__ import annotations
 

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/confidence.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/confidence.py
@@ -1,4 +1,4 @@
-"""Confidence tiering for TRI006 — see ADR-0035 and `docs/rules/redundant-type-conversion.md`."""
+"""Confidence tiering for TR6 — see ADR-0035 and `docs/rules/redundant-type-conversion.md`."""
 
 from __future__ import annotations
 

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
@@ -236,7 +236,7 @@ _session: TySession | None = None
 _session_lock = threading.Lock()
 
 
-def get_session() -> TySession:  # pytriage: ignore=TRI004,TR4 -- fixed by ADR-0037, pending a released pin bump
+def get_session() -> TySession:
     """Process-wide `TySession` singleton, created lazily. See ADR-0035's "Invocation"/"Failure handling"."""
     global _session  # noqa: PLW0603 -- the documented, deliberate one-session-per-process singleton this whole module exists for
     with _session_lock:

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/session.py
@@ -1,4 +1,4 @@
-"""Drives one long-lived `ty server` LSP session for TRI006 — see
+"""Drives one long-lived `ty server` LSP session for TR6 — see
 docs/audits/type-checker-selection-for-redundant-type-conversion.md for why
 `ty`, driven over LSP, was chosen, and ADR-0035 for the self-test/session
 design this module implements.
@@ -32,14 +32,14 @@ _HOVER_DOC_SEPARATOR = re.compile(r"\n-{3,}\n")
 _MIN_TY_VERSION = "0.0.64"
 
 _INSTALL_HINT = (
-    "redundant-type-conversion (TRI006) requires Astral's `ty` type checker on PATH. Install it with "
+    "redundant-type-conversion (TR6) requires Astral's `ty` type checker on PATH. Install it with "
     "`uv tool install ty`, or add `ty` as a dev dependency of your own project and commit with that virtual "
     "environment active, or opt out with `--ignore=redundant-type-conversion`. "
     "See https://github.com/astral-sh/ty."
 )
 
 _SELF_TEST_FAILED_HINT = (
-    "redundant-type-conversion (TRI006) found `ty` on PATH, but it failed this check's own compatibility "
+    "redundant-type-conversion (TR6) found `ty` on PATH, but it failed this check's own compatibility "
     "self-test: a known redundant/necessary type-conversion pair didn't produce the diagnostics this check "
     f"expects. `ty` is pre-1.0 and its diagnostics can change between versions in either direction. This "
     f"release of ruff-extra-rules was validated against ty>={_MIN_TY_VERSION} -- if your `ty` predates that, "
@@ -158,7 +158,7 @@ class TySession:
                 timeout=10.0,
             )
         except LSPError:
-            logger.debug("TRI006 hover failed for %s", filepath, exc_info=True)
+            logger.debug("TR6 hover failed for %s", filepath, exc_info=True)
             return None
         if not response:
             return None
@@ -178,7 +178,7 @@ class TySession:
             try:
                 self._client.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
             except LSPError:
-                logger.debug("TRI006 close_file failed for %s", filepath, exc_info=True)
+                logger.debug("TR6 close_file failed for %s", filepath, exc_info=True)
             del self._open_versions[uri]
 
     def close(self) -> None:
@@ -236,7 +236,7 @@ _session: TySession | None = None
 _session_lock = threading.Lock()
 
 
-def get_session() -> TySession:  # pytriage: ignore=TRI004 -- fixed by ADR-0037, pending a released pin bump
+def get_session() -> TySession:  # pytriage: ignore=TRI004,TR4 -- fixed by ADR-0037, pending a released pin bump
     """Process-wide `TySession` singleton, created lazily. See ADR-0035's "Invocation"/"Failure handling"."""
     global _session  # noqa: PLW0603 -- the documented, deliberate one-session-per-process singleton this whole module exists for
     with _session_lock:

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -1,6 +1,6 @@
 """validate_function_name - Detect get_* functions and suggest better names.
 
-TRI004: Functions with get_ prefix should use more descriptive names based on
+TR4: Functions with get_ prefix should use more descriptive names based on
 their behavior (e.g., load_, fetch_, calculate_, is_, iter_).
 
 This hook detects functions prefixed with `get_` and suggests more specific
@@ -23,10 +23,10 @@ This check runs as part of the grouped `ruff-extra-rules` hook:
     python -m pre_commit_hooks.ast_checks [--fix] <files>
 
 Suppression:
-    Add inline comment to suppress: # pytriage: ignore=TRI004
+    Add inline comment to suppress: # pytriage: TR4
 
 Example:
-    def get_users() -> list[User]:  # pytriage: ignore=TRI004
+    def get_users() -> list[User]:  # pytriage: TR4
         return User.objects.all()
 """
 
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import ast
     from pathlib import Path
 
-ERROR_CODE = "TRI004"
+ERROR_CODE = "TR4"
 
 logger_check = logging.getLogger("validate_function_name_check")
 

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("validate_function_name")
 
-# Format: # pytriage: ignore=TRI004
-IGNORE_PATTERN = ignore_pattern_for("TRI004")
+# Format: # pytriage: TR4
+IGNORE_PATTERN = ignore_pattern_for("TR4")
 GET_PREFIX = "get_"
 
 

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
@@ -352,7 +352,7 @@ def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
     # Positions come from real ast.Name/Attribute nodes resolved against
     # this same tree/source, so line/col are always in range and the text
     # at each position always equals old_name.
-    for line_num, col in sorted(set(positions), reverse=True):  # pytriage: ignore=TRI006 -- dedupes, not redundant
+    for line_num, col in sorted(set(positions), reverse=True):  # pytriage: TR6 -- dedupes, not redundant
         line_idx = line_num - 1
         line = lines[line_idx]
         lines[line_idx] = line[:col] + new_name + line[col + old_len :]

--- a/tests/fixtures/excessive_blank_lines/ignore/double_blank_after_comment.py
+++ b/tests/fixtures/excessive_blank_lines/ignore/double_blank_after_comment.py
@@ -1,7 +1,7 @@
 # This is a module comment
 
 
-import os  # pytriage: ignore=TRI002
+import os  # pytriage: TR2
 
 
 def example():

--- a/tests/fixtures/excessive_blank_lines/ignore/triple_blank_after_docstring.py
+++ b/tests/fixtures/excessive_blank_lines/ignore/triple_blank_after_docstring.py
@@ -2,6 +2,6 @@
 
 
 
-def example():  # pytriage: ignore=TRI002
+def example():  # pytriage: TR2
     """Example function."""
     return None

--- a/tests/fixtures/redundant_super_init/ignore/redundant_kwargs_forwarding.py
+++ b/tests/fixtures/redundant_super_init/ignore/redundant_kwargs_forwarding.py
@@ -12,7 +12,7 @@ class Base:
 class Child(Base):
     """Child class that redundantly forwards kwargs."""
 
-    def __init__(self, value, **kwargs):  # pytriage: ignore=TRI003
+    def __init__(self, value, **kwargs):  # pytriage: TR3
         """Initialize child."""
         self.value = value
         super().__init__(**kwargs)  # VIOLATION suppressed by inline ignore above

--- a/tests/fixtures/redundant_type_conversion/ignore/suppressed.py
+++ b/tests/fixtures/redundant_type_conversion/ignore/suppressed.py
@@ -1,5 +1,5 @@
 def echo_pytriage_ignored(value: str) -> str:
-    return str(value)  # pytriage: ignore=TRI006
+    return str(value)  # pytriage: TR6
 
 
 def echo_type_ignored(value: str) -> str:

--- a/tests/fixtures/validate_function_name/ignore/inline_ignore.py
+++ b/tests/fixtures/validate_function_name/ignore/inline_ignore.py
@@ -1,12 +1,12 @@
 """Test fixture: Inline ignore comments."""
 
 
-def get_users() -> list:  # pytriage: ignore=TRI004
+def get_users() -> list:  # pytriage: TR4
     """Suppressed with inline comment."""
     with open("users.json") as f:
         return f.read()
 
 
-def get_data():  # pytriage: ignore=TRI004
+def get_data():  # pytriage: TR4
     """Also suppressed."""
     return []

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -390,7 +390,7 @@ def func():
         (
             # An augmented-assignment target (`x += 1`) can't be inlined —
             # the result (`5 += 1`) is invalid syntax — and isn't the
-            # read-then-forward pattern TRI005 targets anyway.
+            # read-then-forward pattern TR5 targets anyway.
             """
 def func():
     x = 5

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -129,9 +129,7 @@ def test_autofix_skips_violation_without_fix_data(tmp_path: Path) -> None:
     filepath = tmp_path / "source.py"
     filepath.write_text(source)
 
-    violation = ViolationFactory.build(
-        check_id="redundant-assignment", error_code="TRI005", fixable=True, fix_data=None
-    )
+    violation = ViolationFactory.build(check_id="redundant-assignment", error_code="TR5", fixable=True, fix_data=None)
 
     check = RedundantAssignmentCheck()
     assert check.fix(filepath, [violation], source, ast.parse(source)) is False
@@ -144,7 +142,7 @@ def test_autofix_skips_violation_with_invalid_fix_data(tmp_path: Path) -> None:
 
     # fix_data is missing 'use_line'.
     violation = ViolationFactory.build(
-        check_id="redundant-assignment", error_code="TRI005", fixable=True, fix_data={"other_key": "value"}
+        check_id="redundant-assignment", error_code="TR5", fixable=True, fix_data={"other_key": "value"}
     )
 
     check = RedundantAssignmentCheck()
@@ -176,7 +174,7 @@ def test_autofix_with_invalid_assignment_line(tmp_path: Path) -> None:
 
     violation = ViolationFactory.build(
         check_id="redundant-assignment",
-        error_code="TRI005",
+        error_code="TR5",
         fixable=True,
         fix_data={
             "pattern": "IMMEDIATE_SINGLE_USE",
@@ -199,7 +197,7 @@ def test_autofix_with_invalid_usage_line(tmp_path: Path) -> None:
 
     violation = ViolationFactory.build(
         check_id="redundant-assignment",
-        error_code="TRI005",
+        error_code="TR5",
         fixable=True,
         fix_data={
             "pattern": "IMMEDIATE_SINGLE_USE",
@@ -224,7 +222,7 @@ def test_autofix_with_multiple_uses(tmp_path: Path) -> None:
     # whenever a lifecycle doesn't have exactly one use.
     violation = ViolationFactory.build(
         check_id="redundant-assignment",
-        error_code="TRI005",
+        error_code="TR5",
         fixable=True,
         fix_data={
             "pattern": "SINGLE_USE",
@@ -248,7 +246,7 @@ def test_autofix_with_unsafe_inlining(tmp_path: Path) -> None:
 
     violation = ViolationFactory.build(
         check_id="redundant-assignment",
-        error_code="TRI005",
+        error_code="TR5",
         fixable=True,
         fix_data={
             "pattern": "IMMEDIATE_SINGLE_USE",
@@ -269,9 +267,7 @@ def test_fix_method_with_no_fixable_violations() -> None:
 x = "foo"
 func(x=x)
 """
-    violation = ViolationFactory.build(
-        check_id="redundant-assignment", error_code="TRI005", fixable=False, fix_data=None
-    )
+    violation = ViolationFactory.build(check_id="redundant-assignment", error_code="TR5", fixable=False, fix_data=None)
     assert apply_fixes(Path("test.py"), [violation], source) is False
 
 

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -66,7 +66,7 @@ x = "foo"  # pytriage: TR5
 func(x=x)
 """,
         """
-x = "foo"  # PYTRIAGE: IGNORE=TR5
+x = "foo"  # PYTRIAGE: TR5
 func(x=x)
 """,
         """

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 def test_check_id_and_error_code() -> None:
     check = RedundantAssignmentCheck()
     assert check.check_id == "redundant-assignment"
-    assert check.error_code == "TRI005"
+    assert check.error_code == "TR5"
 
 
 def test_prefilter_pattern() -> None:
@@ -62,11 +62,11 @@ def example():
     return formatted_timestamp
 """,
         """
-x = "foo"  # pytriage: ignore=TRI005
+x = "foo"  # pytriage: TR5
 func(x=x)
 """,
         """
-x = "foo"  # PYTRIAGE: IGNORE=TRI005
+x = "foo"  # PYTRIAGE: IGNORE=TR5
 func(x=x)
 """,
         """
@@ -334,7 +334,7 @@ def find_place_document(place_id):
 """,
         """
 def func(depot_data, depots):
-    depot_iso_country = depot_data.iso_country  # pytriage: ignore=TRI005
+    depot_iso_country = depot_data.iso_country  # pytriage: TR5
     return [x for x in depots if x.country == depot_iso_country]
 """,
     ],
@@ -995,7 +995,7 @@ def test_check_never_flags_variable(source: str, path: str, excluded: str) -> No
 # ---------------------------------------------------------------------------
 # check(): issue #76 calibration cases — the conservative (default) level
 # must not flag these, even though each scores low enough to have qualified
-# under TRI005's old single reporting threshold.
+# under TR5's old single reporting threshold.
 # ---------------------------------------------------------------------------
 
 
@@ -1073,7 +1073,7 @@ def test_conservative_level_calibration_cases_not_flagged(source: str, excluded:
 def test_screaming_snake_case_string_constant_still_flagged_at_permissive_level() -> None:
     # Rule 12 (see should_report_violation) is conservative-only, matching
     # Rule 11's precedent — permissive still reports every single-use
-    # string assignment TRI005 always used to, name shape included.
+    # string assignment TR5 always used to, name shape included.
     source = """
 _GREY = "rgb(201, 203, 207)"
 config = {"colors": [_GREY]}
@@ -1202,16 +1202,16 @@ def test_untracked_rebinding_not_flagged_as_redundant(source: str, excluded_name
 
 
 def test_ignore_marker_inside_string_literal_does_not_suppress_violation() -> None:
-    # A string literal that merely contains the ignore-marker text is not
-    # a real suppression comment and must not hide a violation on that
+    # A string literal that merely contains the suppression-marker text is
+    # not a real suppression comment and must not hide a violation on that
     # line. Regression: line-based ignore detection used a plain text
     # search over raw source lines, so a string literal containing '#
-    # pytriage: ignore=...' text was indistinguishable from an actual
-    # comment. Ignore detection must be tokenize-based so it only matches
-    # genuine COMMENT tokens.
+    # pytriage: TR5' text was indistinguishable from an actual comment.
+    # Ignore detection must be tokenize-based so it only matches genuine
+    # COMMENT tokens.
     source = """
 def call_it():
-    x = "foo"; note = "# pytriage: ignore=TRI005"
+    x = "foo"; note = "# pytriage: TR5"
     func(x=x)
 """
     violations = _check(source)
@@ -1330,7 +1330,7 @@ def func_scope():
 
     assert len(violations) >= 1
     violation = violations[0]
-    assert violation.error_code == "TRI005"
+    assert violation.error_code == "TR5"
     assert "x" in violation.message
 
 
@@ -1479,4 +1479,4 @@ def test_orchestrator_skips_file_with_invalid_syntax(tmp_path: Path) -> None:
     orchestrator = CheckOrchestrator(checks=[RedundantAssignmentCheck()])
     violations = orchestrator.process_files([str(filepath)])
 
-    assert violations.get(str(filepath), []) == []  # pytriage: ignore=TRI006
+    assert violations.get(str(filepath), []) == []  # pytriage: TR6

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -22,7 +22,7 @@ def _fail_if_called() -> NoReturn:
 def test_check_id_and_error_code() -> None:
     check = RedundantTypeConversionCheck()
     assert check.check_id == "redundant-type-conversion"
-    assert check.error_code == "TRI006"
+    assert check.error_code == "TR6"
 
 
 def test_is_not_cacheable() -> None:
@@ -62,10 +62,10 @@ def test_is_not_cacheable() -> None:
 def test_prefilter_pattern_matches_the_configured_levels_eligible_constructors(
     level: ConfidenceLevel, expected: set[str]
 ) -> None:
-    # Narrowed to eligible_constructors(level), not every constructor TRI006 knows about.
+    # Narrowed to eligible_constructors(level), not every constructor TR6 knows about.
     pattern = RedundantTypeConversionCheck(level=level).get_prefilter_pattern()
     assert pattern is not None
-    assert set(pattern) == expected  # pytriage: ignore=TRI006
+    assert set(pattern) == expected  # pytriage: TR6
 
 
 def test_fix_never_applies_a_fix() -> None:
@@ -88,7 +88,7 @@ def test_check_never_calls_get_session_when_the_file_has_no_real_candidate(monke
 
 
 def test_check_never_calls_get_session_when_every_candidate_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
-    source = "y = str(x)  # pytriage: ignore=TRI006\n"
+    source = "y = str(x)  # pytriage: TR6\n"
     monkeypatch.setattr(tri006_module, "get_session", _fail_if_called)
 
     violations = RedundantTypeConversionCheck().check(Path("test.py"), ast.parse(source), source)
@@ -133,11 +133,11 @@ def test_check_flags_a_redundant_conservative_case(monkeypatch: pytest.MonkeyPat
 
     assert len(violations) == 1
     assert violations[0].check_id == "redundant-type-conversion"
-    assert violations[0].error_code == "TRI006"
+    assert violations[0].error_code == "TR6"
     assert violations[0].line == 1
     assert violations[0].fixable is False
     assert "str" in violations[0].message
-    assert "pytriage: ignore=TRI006" in violations[0].message
+    assert "pytriage: TR6" in violations[0].message
 
 
 def test_check_hedges_the_message_for_a_non_exact_permissive_match(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -158,11 +158,11 @@ def test_check_hedges_the_message_for_a_non_exact_permissive_match(monkeypatch: 
     assert "already `str`" not in message
     assert "dict[str, list[int]]" in message
     assert "not `str`" in message
-    assert "pytriage: ignore=TRI006" in message
+    assert "pytriage: TR6" in message
 
 
 def test_check_honors_pytriage_inline_ignore(monkeypatch: pytest.MonkeyPatch) -> None:
-    source = "y = str(x)  # pytriage: ignore=TRI006\n"
+    source = "y = str(x)  # pytriage: TR6\n"
     session = FakeSession(diagnostics_by_content={}, hover_by_position={})
     _patch_session(monkeypatch, session)
 
@@ -224,4 +224,4 @@ def test_end_to_end_through_main_reports_a_violation(
     exit_code = main([str(filepath), "--select=redundant-type-conversion"])
 
     assert exit_code == 1
-    assert "TRI006" in capsys.readouterr().err
+    assert "TR6" in capsys.readouterr().err

--- a/tests/redundant_type_conversion/test_session.py
+++ b/tests/redundant_type_conversion/test_session.py
@@ -149,7 +149,7 @@ def test_spawn_raises_check_unavailable_error_when_ty_exists_but_is_not_executab
     not_executable = tmp_path / "not-really-ty"
     not_executable.write_text("#!/bin/sh\necho fake ty\n")
     not_executable.chmod(0o644)
-    monkeypatch.setattr(session_module, "_TY_COMMAND", (str(not_executable),))  # pytriage: ignore=TRI006
+    monkeypatch.setattr(session_module, "_TY_COMMAND", (str(not_executable),))  # pytriage: TR6
     with pytest.raises(CheckUnavailableError, match="requires Astral's `ty`"):
         _spawn(tmp_path)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -179,8 +179,39 @@ def test_classify_comment_lines_on_cr_only_source() -> None:
 
 
 def test_find_ignored_lines_on_cr_only_source() -> None:
-    source = "x = 1\rdata = 2  # pytriage: ignore=TRI001\r"
-    assert find_ignored_lines(source, ignore_pattern_for("TRI001")) == {2}
+    source = "x = 1\rdata = 2  # pytriage: TR1\r"
+    assert find_ignored_lines(source, ignore_pattern_for("TR1")) == {2}
+
+
+@pytest.mark.parametrize(
+    ("comment", "code", "expected"),
+    [
+        ("# pytriage: TR1", "TR1", True),
+        ("# pytriage: tr1", "TR1", True),
+        ("# pytriage: TR1,TR5", "TR1", True),
+        ("# pytriage: TR1,TR5", "TR5", True),
+        ("# pytriage: TR7,TR1,TR12", "TR1", True),
+        ("# pytriage: TR1, TR5", "TR5", True),
+        ("# pytriage: TR10", "TR1", False),
+        ("# pytriage: TR10", "TR10", True),
+        ("# pytriage: TR10,TR5", "TR1", False),
+        ("# some unrelated comment mentioning TR1", "TR1", False),
+    ],
+    ids=[
+        "single-code",
+        "case-insensitive",
+        "list-first-entry",
+        "list-second-entry",
+        "list-middle-entry",
+        "list-space-after-comma",
+        "no-false-match-on-longer-code",
+        "exact-match-on-longer-code",
+        "no-false-match-with-list-prefix",
+        "no-match-without-pytriage-prefix",
+    ],
+)
+def test_ignore_pattern_for_comma_separated_codes(comment: str, code: str, expected: bool) -> None:
+    assert bool(find_ignored_lines(f"x = 1  {comment}\n", ignore_pattern_for(code))) is expected
 
 
 def _setup_plain(tmp_path: Path) -> Path:

--- a/tests/test_excessive_blank_lines.py
+++ b/tests/test_excessive_blank_lines.py
@@ -60,7 +60,7 @@ def test_ignore_fixtures_are_not_flagged(fixture_path: Path) -> None:
         ("", False),
         # The blank run's own line is blank, so the ignore comment goes on
         # the first code line after it instead.
-        ('"""Docstring."""\n\n\n\ndef foo():  # pytriage: ignore=TRI002\n    pass\n', False),
+        ('"""Docstring."""\n\n\n\ndef foo():  # pytriage: TR2\n    pass\n', False),
     ],
     ids=["raw-prefixed-docstring", "comment-only-file", "empty-file", "inline-ignore"],
 )
@@ -75,7 +75,7 @@ def test_leading_blank_lines_before_first_code_with_no_header() -> None:
     assert _check("\n\n\nimport os\n") == [
         (
             "Excessive blank lines (3) should be collapsed to 1. Add "
-            "'# pytriage: ignore=TRI002' to the line following the blank run "
+            "'# pytriage: TR2' to the line following the blank run "
             "to suppress."
         )
     ]
@@ -84,7 +84,7 @@ def test_leading_blank_lines_before_first_code_with_no_header() -> None:
 @pytest.mark.parametrize(
     "source",
     [
-        '"""Docstring."""\n\n\n\ndef foo():  # pytriage: ignore=TRI002\n    pass\n',
+        '"""Docstring."""\n\n\n\ndef foo():  # pytriage: TR2\n    pass\n',
         '"""Docstring."""\n\ndef foo():\n    pass\n',
     ],
     ids=["ignore-comment-respected", "no-current-violation"],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -233,6 +233,6 @@ def test_verbose_flag_does_not_change_violations_or_exit_code(tmp_path: Path) ->
 
     assert quiet.returncode == verbose.returncode == 1
     assert quiet.stdout == verbose.stdout == ""
-    violation_line = f"{filepath}:1:1: TRI001:"
+    violation_line = f"{filepath}:1:1: TR1:"
     assert any(line.startswith(violation_line) for line in quiet.stderr.splitlines())
     assert any(line.startswith(violation_line) for line in verbose.stderr.splitlines())

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -79,17 +79,24 @@ def create_model():
 """,
         """
 def process():
-    data = {}  # pytriage: ignore=TRI001
+    data = {}  # pytriage: TR1
     return data
 """,
         """
 def process():
-    data = {}  # pytriage: ignore=TRI001
-    result = None  # pytriage: ignore=TRI001
+    data = {}  # pytriage: TR1
+    result = None  # pytriage: TR1
     return data, result
 """,
         """def process():
-    data = 1  # pytriage: ignore=TRI001
+    data = 1  # pytriage: TR1
+""",
+        # A comma-separated suppression list also suppresses this check's
+        # own code, wherever it falls in the list.
+        """
+def process():
+    data = {}  # pytriage: TR5,TR1
+    return data
 """,
         # An annotated assignment whose target is an attribute (e.g.
         # ``self.data: int = 5``), not a plain name, is skipped entirely —
@@ -143,6 +150,7 @@ def feed_data(
         "inline-ignore-comment",
         "all-suppressed",
         "single-suppressed",
+        "multi-code-suppression-list",
         "annotated-attribute-assignment",
         "async-model-validator-decorator",
         "multiple-assignment-targets",
@@ -525,7 +533,7 @@ def test_check_ids() -> None:
     check = MeaninglessVarsCheck()
 
     assert check.check_id == "meaningless-vars"
-    assert check.error_code == "TRI001"
+    assert check.error_code == "TR1"
 
 
 def test_prefilter_pattern() -> None:
@@ -1643,7 +1651,7 @@ def f(x: data) -> result:
 
     assert len(violations) == 2
     assert all(
-        violation.message.endswith("Use a more descriptive name. Or add '# pytriage: ignore=TRI001' to suppress.")
+        violation.message.endswith("Use a more descriptive name. Or add '# pytriage: TR1' to suppress.")
         for violation in violations
     )
     assert all(violation.fixable is False for violation in violations)

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -14,7 +14,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "misplaced_comments"
 def test_check_id_and_error_code() -> None:
     check = MisplacedCommentCheck()
     assert check.check_id == "misplaced-comment"
-    assert check.error_code == "STYLE-001"
+    assert check.error_code == "TR7"
 
 
 def test_prefilter_pattern_is_hash() -> None:
@@ -34,7 +34,7 @@ def test_check_detects_trailing_comment(source: str, line: int, *, fixable: bool
     violations = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
 
     assert len(violations) == 1
-    assert violations[0].error_code == "STYLE-001"
+    assert violations[0].error_code == "TR7"
     assert violations[0].line == line
     assert violations[0].fixable is fixable
 
@@ -43,7 +43,7 @@ def test_check_detects_trailing_comment(source: str, line: int, *, fixable: bool
     "source",
     [
         "result = func(\n    arg  # Comment inline on expression\n)\n",
-        "result = func(\n    arg\n)  # Comment  # pytriage: ignore=STYLE-001\n",
+        "result = func(\n    arg\n)  # Comment  # pytriage: TR7\n",
         # `[1, 2][0]  # c`: tokens between the first `]` and the comment aren't COMMENT.
         "items = [1, 2][0]  # not a bracket-only line\n",
     ],
@@ -97,7 +97,7 @@ def test_fix_moves_trailing_comment(source: str, fixed_source: str, tmp_path: Pa
         # with anything to do here — but fix() must independently honor the
         # ignore comment too, since it re-scans the source rather than
         # trusting its input.
-        "result = func(\n    arg\n)  # Comment  # pytriage: ignore=STYLE-001\n",
+        "result = func(\n    arg\n)  # Comment  # pytriage: TR7\n",
     ],
     ids=["nothing-to-fix", "ignore-comment-respected"],
 )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -58,7 +58,7 @@ def test_expand_directories_leaves_plain_files_untouched(tmp_path: Path) -> None
     filepath.write_text("x = 1\n")
 
     assert expand_directories([str(filepath), "also/does/not/exist.py"]) == [
-        str(filepath),  # pytriage: ignore=TRI006
+        str(filepath),  # pytriage: TR6
         "also/does/not/exist.py",
     ]
 
@@ -488,7 +488,7 @@ def test_main_directory_argument_checks_files_inside_it(tmp_path: Path, capsys: 
         exit_code = main([str(tmp_path), "--select", "meaningless-vars", "--meaningless-vars-level", "permissive"])
 
         assert exit_code == 1
-        assert "TRI001" in capsys.readouterr().err
+        assert "TR1" in capsys.readouterr().err
     finally:
         os.chdir(original_dir)
 
@@ -512,10 +512,10 @@ def test_main_directory_argument_matches_explicit_file_argument_for_untracked_fi
         untracked.write_text("result = 2\n")
 
         assert main([str(untracked), "--select", "meaningless-vars", "--meaningless-vars-level", "permissive"]) == 1
-        assert "TRI001" in capsys.readouterr().err
+        assert "TR1" in capsys.readouterr().err
 
         assert main([str(tmp_path), "--select", "meaningless-vars", "--meaningless-vars-level", "permissive"]) == 1
-        assert "TRI001" in capsys.readouterr().err
+        assert "TR1" in capsys.readouterr().err
     finally:
         os.chdir(original_dir)
 
@@ -557,7 +557,7 @@ def test_process_files_handles_utf8_bom(tmp_path: Path) -> None:
     violations = orchestrator.process_files([str(filepath)])
 
     assert len(violations[str(filepath)]) == 1
-    assert violations[str(filepath)][0].error_code == "TRI001"
+    assert violations[str(filepath)][0].error_code == "TR1"
 
 
 def test_apply_fixes_handles_utf8_bom(tmp_path: Path) -> None:
@@ -785,7 +785,7 @@ def test_refresh_stale_positions_records_rule_failure_when_check_raises(
 
     orchestrator._refresh_stale_positions(filepath, violations)
 
-    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: ignore=TRI006
+    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: TR6
     # Left exactly as it was -- the check crashed before it could report
     # anything current to replace it with.
     assert violations == [stale_violation]
@@ -838,7 +838,7 @@ def test_process_files_no_prefilter_pattern_checks_all_files(tmp_path: Path) -> 
     orchestrator = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck()])
     violations = orchestrator.process_files([str(filepath)])
 
-    assert violations[str(filepath)][0].error_code == "TRI002"
+    assert violations[str(filepath)][0].error_code == "TR2"
 
 
 def test_process_files_no_candidates_after_prefilter_returns_empty(
@@ -872,7 +872,7 @@ def test_process_files_none_pattern_check_still_sees_a_file_other_checks_pattern
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck(), ExcessiveBlankLinesCheck()])
     violations = orchestrator.process_files([str(filepath)])
 
-    assert violations[str(filepath)][0].error_code == "TRI002"
+    assert violations[str(filepath)][0].error_code == "TR2"
 
 
 def test_process_files_applies_each_checks_prefilter_independently(
@@ -897,7 +897,7 @@ def test_process_files_applies_each_checks_prefilter_independently(
     violations = orchestrator.process_files([str(filepath)])
 
     spy_check.assert_not_called()
-    assert violations[str(filepath)][0].error_code == "TRI001"
+    assert violations[str(filepath)][0].error_code == "TR1"
 
 
 @pytest.mark.parametrize(
@@ -934,7 +934,7 @@ def test_process_files_records_unprocessable_file(tmp_path: Path) -> None:
     violations = orchestrator.process_files([str(filepath)])
 
     assert violations == {}
-    assert orchestrator.unprocessable_files == [str(filepath)]  # pytriage: ignore=TRI006
+    assert orchestrator.unprocessable_files == [str(filepath)]  # pytriage: TR6
 
 
 def test_process_files_resets_unprocessable_files_between_calls(tmp_path: Path) -> None:
@@ -947,7 +947,7 @@ def test_process_files_resets_unprocessable_files_between_calls(tmp_path: Path) 
 
     orchestrator = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck()])
     orchestrator.process_files([str(bad_filepath)])
-    assert orchestrator.unprocessable_files == [str(bad_filepath)]  # pytriage: ignore=TRI006
+    assert orchestrator.unprocessable_files == [str(bad_filepath)]  # pytriage: TR6
 
     orchestrator.process_files([str(good_filepath)])
     assert orchestrator.unprocessable_files == []
@@ -959,14 +959,14 @@ def test_process_files_second_call_uses_cache(tmp_path: Path, monkeypatch: pytes
 
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)])
     first = orchestrator.process_files([str(filepath)])
-    assert first[str(filepath)][0].error_code == "TRI001"
+    assert first[str(filepath)][0].error_code == "TR1"
 
     def boom(*_args: object, **_kws: object) -> None:
         raise AssertionError("_check_file should not run on a cache hit")
 
     monkeypatch.setattr(CheckOrchestrator, "_check_file", boom)
     second = orchestrator.process_files([str(filepath)])
-    assert second[str(filepath)][0].error_code == "TRI001"
+    assert second[str(filepath)][0].error_code == "TR1"
 
 
 def test_cache_hit_and_cache_miss_report_equivalent_violations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -984,7 +984,7 @@ def test_cache_hit_and_cache_miss_report_equivalent_violations(tmp_path: Path, m
 
     cache_miss_orchestrator = CheckOrchestrator(checks=checks)
     cache_miss = cache_miss_orchestrator.process_files([str(filepath)])[str(filepath)]
-    assert {v.error_code for v in cache_miss} == {"TRI001", "TRI002"}
+    assert {v.error_code for v in cache_miss} == {"TR1", "TR2"}
 
     def boom(*_args: object, **_kws: object) -> None:
         raise AssertionError("_check_file should not run on a cache hit")
@@ -1014,7 +1014,7 @@ def test_process_files_different_check_set_forces_recheck(tmp_path: Path) -> Non
     violations = both_checks.process_files([str(filepath)])
 
     error_codes = {v.error_code for v in violations[str(filepath)]}
-    assert error_codes == {"TRI001", "TRI002"}
+    assert error_codes == {"TR1", "TR2"}
 
 
 def test_generate_cache_key_changes_when_source_tree_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1081,7 +1081,7 @@ def test_cache_violations_serialization_error_is_caught(tmp_path: Path, monkeypa
 
     # Must not raise, just skip caching for this file.
     violations = orchestrator.process_files([str(filepath)])
-    assert violations[str(filepath)][0].error_code == "TRI001"
+    assert violations[str(filepath)][0].error_code == "TR1"
 
 
 def test_process_files_check_exception_is_logged_and_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1099,7 +1099,7 @@ def test_process_files_check_exception_is_logged_and_skipped(tmp_path: Path, mon
     violations = orchestrator.process_files([str(filepath)])
 
     error_codes = {v.error_code for v in violations[str(filepath)]}
-    assert error_codes == {"TRI002"}
+    assert error_codes == {"TR2"}
 
 
 def test_process_files_check_exception_records_rule_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1119,7 +1119,7 @@ def test_process_files_check_exception_records_rule_failure(tmp_path: Path, monk
     violations = orchestrator.process_files([str(filepath)])
 
     assert violations == {}
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: ignore=TRI006
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
 
 
 def test_process_files_rule_failure_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1145,10 +1145,10 @@ def test_process_files_rule_failure_is_not_cached(tmp_path: Path, monkeypatch: p
     orchestrator = CheckOrchestrator(checks=[meaningless_vars])
     first = orchestrator.process_files([str(filepath)])
     assert first == {}
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: ignore=TRI006
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
 
     second = orchestrator.process_files([str(filepath)])
-    assert second[str(filepath)][0].error_code == "TRI001"
+    assert second[str(filepath)][0].error_code == "TR1"
 
 
 def test_process_files_unavailable_checks_result_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1177,7 +1177,7 @@ def test_process_files_unavailable_checks_result_is_not_cached(tmp_path: Path, m
     assert orchestrator.unavailable_checks == [("meaningless-vars", "some prerequisite is missing")]
 
     second = orchestrator.process_files([str(filepath)])
-    assert second[str(filepath)][0].error_code == "TRI001"
+    assert second[str(filepath)][0].error_code == "TR1"
 
 
 class _AlwaysRerunProbeCheck:
@@ -1261,8 +1261,8 @@ def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a
         checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE), _CrashingAlwaysRerunCheck()]
     )
     first = orchestrator.process_files([str(filepath)])
-    assert {v.error_code for v in first[str(filepath)]} == {"TRI001"}
-    assert orchestrator.rule_failures == [(str(filepath), "crashing-always-rerun-probe")]  # pytriage: ignore=TRI006
+    assert {v.error_code for v in first[str(filepath)]} == {"TR1"}
+    assert orchestrator.rule_failures == [(str(filepath), "crashing-always-rerun-probe")]  # pytriage: TR6
 
     def boom(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("meaningless-vars must have been cached despite the always-rerun check's own crash")
@@ -1273,7 +1273,7 @@ def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a
         checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE), _CrashingAlwaysRerunCheck()]
     )
     second = second_orchestrator.process_files([str(filepath)])
-    assert {v.error_code for v in second[str(filepath)]} == {"TRI001"}
+    assert {v.error_code for v in second[str(filepath)]} == {"TR1"}
 
 
 def test_process_files_non_cacheable_check_never_serves_a_stale_result(tmp_path: Path) -> None:
@@ -1329,7 +1329,7 @@ def test_process_files_non_cacheable_check_does_not_disturb_a_cacheable_checks_o
     violations = combined.process_files([str(filepath)])
 
     error_codes = {v.error_code for v in violations[str(filepath)]}
-    assert error_codes == {"TRI001", "ZZZ001"}
+    assert error_codes == {"TR1", "ZZZ001"}
     assert probe.call_count == 1
 
 
@@ -1363,7 +1363,7 @@ def test_process_single_file_reports_unprocessable_when_always_rerun_group_fails
     violations = combined.process_files([str(filepath)])
 
     assert violations == {}
-    assert combined.unprocessable_files == [str(filepath)]  # pytriage: ignore=TRI006
+    assert combined.unprocessable_files == [str(filepath)]  # pytriage: TR6
 
 
 def test_process_files_enabling_a_non_cacheable_check_does_not_change_cache_key(
@@ -1745,7 +1745,7 @@ def test_apply_fixes_records_rule_failure_when_fix_raises_after_resolving_everyt
     assert violation.fix_data is not None
     assert violation.fix_data.get("fixed") is True
     assert not is_fix_errored(violation)
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: ignore=TRI006
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
     )
@@ -2063,7 +2063,7 @@ def test_main_list_checks(capsys: pytest.CaptureFixture[str]) -> None:
 
     out = capsys.readouterr().out
     assert "Available checks:" in out
-    assert "meaningless-vars: TRI001" in out
+    assert "meaningless-vars: TR1" in out
 
 
 def test_main_no_filenames_returns_zero() -> None:
@@ -2189,7 +2189,7 @@ def test_main_reports_non_fixable_violation(tmp_path: Path, capsys: pytest.Captu
     assert exit_code == 1
 
     err = capsys.readouterr().err
-    assert "TRI003" in err
+    assert "TR3" in err
     assert "[FIXABLE]" not in err
     assert "[FIXED]" not in err
     assert "Run with --fix" not in err
@@ -2208,7 +2208,7 @@ def test_main_reports_column_alongside_line(tmp_path: Path, capsys: pytest.Captu
     exit_code = main([str(filepath), "--select", "meaningless-vars", "--meaningless-vars-level", "permissive"])
     assert exit_code == 1
 
-    assert f"{filepath}:2:5: TRI001:" in capsys.readouterr().err
+    assert f"{filepath}:2:5: TR1:" in capsys.readouterr().err
 
 
 def test_main_reports_fixable_violation_without_fix_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -2401,7 +2401,7 @@ def test_main_reports_rule_failure_when_reread_fails_mid_fix_loop(
     orchestrator = CheckOrchestrator(checks=checks, fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
 
-    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: ignore=TRI006
+    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: TR6
     meaningless_vars_violation = next(v for v in violations[str(filepath)] if v.check_id == "meaningless-vars")
     super_init_violation = next(v for v in violations[str(filepath)] if v.check_id == "redundant-super-init")
     assert is_fix_errored(meaningless_vars_violation)
@@ -2529,7 +2529,7 @@ def test_main_check_specific_cli_arg_round_trip(
     # redundant-assignment's own --redundant-assignment-level flag (see
     # test_main_redundant_assignment_level_flag below) already exercises
     # this wiring against a shipped check; this synthetic one keeps that
-    # coverage independent of TRI005's own reporting rules.
+    # coverage independent of TR5's own reporting rules.
     # Exercises main()'s add_cli_arguments -> parse_args ->
     # cli_kwargs_from_args -> check_args wiring end-to-end against a
     # synthetic check.
@@ -2696,7 +2696,7 @@ def test_main_trailing_comma_does_not_report_blank_unknown_check(
     # Regression: a trailing comma left an empty string in the parsed set,
     # reported as a confusing blank "Unknown checks: " instead of being
     # tolerated like --exclude's own comma list already is. Asserting on the
-    # TRI001 violation itself (not just the exit code) is what actually
+    # TR1 violation itself (not just the exit code) is what actually
     # proves meaningless-vars was recognized: both the fixed and the reverted
     # behavior exit 1 for --select (a real violation vs. the old bogus
     # "Unknown checks" error), so the exit code alone can't tell them apart.
@@ -2707,7 +2707,7 @@ def test_main_trailing_comma_does_not_report_blank_unknown_check(
     err = capsys.readouterr().err
 
     assert "Unknown checks" not in err
-    assert ("TRI001" in err) is meaningless_vars_runs
+    assert ("TR1" in err) is meaningless_vars_runs
     assert exit_code == (1 if meaningless_vars_runs else 0)
 
 
@@ -2743,7 +2743,7 @@ def test_main_select_and_ignore_compose(tmp_path: Path, capsys: pytest.CaptureFi
     )
     assert exit_code == 0
 
-    assert "TRI001" not in capsys.readouterr().err
+    assert "TR1" not in capsys.readouterr().err
 
 
 def test_main_malformed_cli_argument_exits_via_argparse(capsys: pytest.CaptureFixture[str]) -> None:
@@ -2851,7 +2851,7 @@ def test_main_handles_path_containing_spaces_and_unicode(
     # a command that dropped the pathspec (searching the whole repo instead
     # of this one file) would still find the sole match and pass every
     # assertion above, silently losing path scoping without this check.
-    assert all(str(filepath) in command for command in grep_commands)  # pytriage: ignore=TRI006
+    assert all(str(filepath) in command for command in grep_commands)  # pytriage: TR6
 
     assert exit_code == 1
     assert "[FIXED]" in capsys.readouterr().err

--- a/tests/test_redundant_super_init.py
+++ b/tests/test_redundant_super_init.py
@@ -45,7 +45,7 @@ def test_ignore_fixtures_are_not_flagged(fixture_path: Path) -> None:
 def test_check_id_and_error_code() -> None:
     check = RedundantSuperInitCheck()
     assert check.check_id == "redundant-super-init"
-    assert check.error_code == "TRI003"
+    assert check.error_code == "TR3"
 
 
 def test_get_prefilter_pattern() -> None:
@@ -90,7 +90,7 @@ class Child(Base):
 
 
 class Child(Base):
-    def __init__(self, **kwargs):  # pytriage: ignore=TRI003
+    def __init__(self, **kwargs):  # pytriage: TR3
         super().__init__(**kwargs)
 """,
             False,

--- a/tests/test_redundant_type_conversion_integration.py
+++ b/tests/test_redundant_type_conversion_integration.py
@@ -1,4 +1,4 @@
-"""Integration layer for TRI006: runs the real `ty` binary (pinned as a dev
+"""Integration layer for TR6: runs the real `ty` binary (pinned as a dev
 dependency, see pyproject.toml), sharing one warm `ty server` session
 across this whole module -- mirroring the check's own production design
 (one session per hook invocation, not one per file/query).
@@ -55,7 +55,7 @@ def test_same_scope_scalar_conversion_is_flagged() -> None:
 
     assert len(violations) == 1
     assert violations[0].line == 2
-    assert violations[0].error_code == "TRI006"
+    assert violations[0].error_code == "TR6"
 
 
 def test_cross_file_call_site_conversion_is_flagged_at_permissive() -> None:
@@ -66,7 +66,7 @@ def test_cross_file_call_site_conversion_is_flagged_at_permissive() -> None:
     violations = _check(BAD_ROOT / "cross_file_call_site.py", level=ConfidenceLevel.PERMISSIVE)
 
     assert {v.line for v in violations} == {5, 6}
-    assert {v.error_code for v in violations} == {"TRI006"}
+    assert {v.error_code for v in violations} == {"TR6"}
 
 
 def test_cross_file_call_site_conversion_is_not_flagged_at_conservative() -> None:

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -57,7 +57,7 @@ def test_fix_skips_violation_missing_suggestion(fix_data: dict[str, int] | None,
     filepath = tmp_path / "mod.py"
     filepath.write_text("def get_data() -> bool:\n    return True\n")
 
-    violation = ViolationFactory.build(check_id="validate-function-name", error_code="TRI004", fix_data=fix_data)
+    violation = ViolationFactory.build(check_id="validate-function-name", error_code="TR4", fix_data=fix_data)
 
     check = ValidateFunctionNameCheck()
     assert check.fix(filepath, [violation], "x = 1\n", ast.parse("x = 1\n")) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for shorter diagnostic identifiers (`TR1`–`TR7`) and for suppressing multiple checks via `# pytriage: TRx,TRy`.

* **Documentation**
  * Updated all published check docs and “inline suppression” guidance to use `# pytriage: <code>` (instead of the legacy `ignore=<code>` format) and the new `TR` codes.

* **Bug Fixes**
  * Improved suppression matching to recognize the new syntax reliably and avoid false matches with longer codes.

* **Chores**
  * Refreshed lint/CI formatting configuration.
  
* **Tests**
  * Updated fixtures and assertions for the new identifiers and suppression format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->