### PR TITLE
perf(redundant-assignment): tokenize source once per check() call

### DIFF
--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -480,6 +480,41 @@ def classify_comment_lines(source: str) -> tuple[set[int], set[int]]:
     return comment_lines - code_lines, comment_lines & code_lines
 
 
+def find_ignored_lines_and_classify_comments(
+    source: str, *patterns: re.Pattern[str]
+) -> tuple[set[int], set[int], set[int]]:
+    """Tokenize `source` exactly once, returning (ignored_lines,
+    comment_only_lines, trailing_comment_lines) — the same results
+    `find_ignored_lines`/`classify_comment_lines` would each compute from
+    their own separate tokenize pass, fused into one.
+
+    `RedundantAssignmentCheck.check()` needs both, and streams this single
+    combined pass over `tokenize_source`'s lazy `Iterator` (rather than
+    materializing the whole token stream once and feeding it to each
+    helper) so a large file's token count never inflates peak memory — only
+    the resulting line-number sets are retained, one token at a time.
+    """
+    ignored_lines: set[int] = set()
+    comment_lines: set[int] = set()
+    code_lines: set[int] = set()
+
+    try:
+        for tok_type, tok_string, start, end, _ in tokenize_source(source):
+            if tok_type == tokenize.COMMENT:
+                comment_lines.add(start[0])
+                if any(p.search(tok_string) for p in patterns):
+                    ignored_lines.add(start[0])
+            elif tok_type not in _NON_CODE_TOKEN_TYPES:
+                code_lines.update(range(start[0], end[0] + 1))
+    except tokenize.TokenError as token_error:  # pragma: no cover
+        # Defensive: source is already parsed by AST, so tokenizing it can't
+        # realistically fail. If it ever does, treat it as nothing found.
+        logger.debug(repr(token_error))
+        return set(), set(), set()
+
+    return ignored_lines, comment_lines - code_lines, comment_lines & code_lines
+
+
 def mark_fixed(violation: Violation) -> None:
     """The single place that writes the `fix_data["fixed"]` convention —
     previously three independent hand-written sites.

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import io
-import logging
 import os
 import re
 import stat
@@ -17,8 +16,6 @@ from typing import TYPE_CHECKING, Any, Protocol
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Iterable, Iterator
-
-logger = logging.getLogger("ast_checks")
 
 
 @dataclass(slots=True)
@@ -421,13 +418,7 @@ def find_ignored_lines(source: str, *patterns: re.Pattern[str]) -> set[int]:
     source (e.g. redundant-type-conversion's own pragma plus a third-party
     type-checker's `# type: ignore`) tokenizes it only once.
     """
-    try:
-        return ignored_lines_from_tokens(tokenize_source(source), *patterns)
-    except tokenize.TokenError as token_error:  # pragma: no cover
-        # Defensive: source is already parsed by AST, so tokenizing it can't
-        # realistically fail. If it ever does, treat it as no lines ignored.
-        logger.debug(repr(token_error))
-        return set()
+    return ignored_lines_from_tokens(tokenize_source(source), *patterns)
 
 
 _NON_CODE_TOKEN_TYPES = frozenset(
@@ -460,22 +451,16 @@ def classify_comment_lines(source: str) -> tuple[set[int], set[int]]:
     comment_lines: set[int] = set()
     code_lines: set[int] = set()
 
-    try:
-        for tok_type, _tok_string, start, end, _ in tokenize_source(source):
-            if tok_type == tokenize.COMMENT:
-                comment_lines.add(start[0])
-            elif tok_type not in _NON_CODE_TOKEN_TYPES:
-                # A multiline token (a triple-quoted string spanning
-                # several lines) reports only its *start* line in
-                # start[0] — every line up to and including end[0] (e.g.
-                # the closing line, which can carry its own trailing
-                # comment) is just as much "code" as the first.
-                code_lines.update(range(start[0], end[0] + 1))
-    except tokenize.TokenError as token_error:  # pragma: no cover
-        # Defensive: source is already parsed by AST, so tokenizing it can't
-        # realistically fail. If it ever does, treat it as no comments found.
-        logger.debug(repr(token_error))
-        return set(), set()
+    for tok_type, _tok_string, start, end, _ in tokenize_source(source):
+        if tok_type == tokenize.COMMENT:
+            comment_lines.add(start[0])
+        elif tok_type not in _NON_CODE_TOKEN_TYPES:
+            # A multiline token (a triple-quoted string spanning
+            # several lines) reports only its *start* line in
+            # start[0] — every line up to and including end[0] (e.g.
+            # the closing line, which can carry its own trailing
+            # comment) is just as much "code" as the first.
+            code_lines.update(range(start[0], end[0] + 1))
 
     return comment_lines - code_lines, comment_lines & code_lines
 
@@ -498,19 +483,13 @@ def find_ignored_lines_and_classify_comments(
     comment_lines: set[int] = set()
     code_lines: set[int] = set()
 
-    try:
-        for tok_type, tok_string, start, end, _ in tokenize_source(source):
-            if tok_type == tokenize.COMMENT:
-                comment_lines.add(start[0])
-                if any(p.search(tok_string) for p in patterns):
-                    ignored_lines.add(start[0])
-            elif tok_type not in _NON_CODE_TOKEN_TYPES:
-                code_lines.update(range(start[0], end[0] + 1))
-    except tokenize.TokenError as token_error:  # pragma: no cover
-        # Defensive: source is already parsed by AST, so tokenizing it can't
-        # realistically fail. If it ever does, treat it as nothing found.
-        logger.debug(repr(token_error))
-        return set(), set(), set()
+    for tok_type, tok_string, start, end, _ in tokenize_source(source):
+        if tok_type == tokenize.COMMENT:
+            comment_lines.add(start[0])
+            if any(p.search(tok_string) for p in patterns):
+                ignored_lines.add(start[0])
+        elif tok_type not in _NON_CODE_TOKEN_TYPES:
+            code_lines.update(range(start[0], end[0] + 1))
 
     return ignored_lines, comment_lines - code_lines, comment_lines & code_lines
 

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -152,14 +152,7 @@ class MisplacedCommentCheck(BaseCheck):
         return ["#"]
 
     def check(self, _filepath: Path, _tree: ast.Module, source: str) -> list[Violation]:
-        try:
-            tokens = tuple(tokenize.generate_tokens(StringIO(normalize_for_tokenize(source)).readline))
-        # Defensive: source is already parsed by AST, so tokenizing it can't
-        # realistically fail. If it ever does, treat it as no violations.
-        except tokenize.TokenError as token_error:  # pragma: no cover
-            logger.debug(repr(token_error))
-            return []
-
+        tokens = tuple(tokenize.generate_tokens(StringIO(normalize_for_tokenize(source)).readline))
         found = _scan_misplaced_comments(tokens)
         if not found:
             return []
@@ -190,14 +183,7 @@ class MisplacedCommentCheck(BaseCheck):
         _tree: ast.Module,
         encoding: str = "utf-8",
     ) -> bool:
-        try:
-            tokens = tuple(tokenize.generate_tokens(StringIO(normalize_for_tokenize(source)).readline))
-        # Defensive: source is already parsed by AST, so tokenizing it can't
-        # realistically fail. If it ever does, skip fixing rather than crash.
-        except tokenize.TokenError as token_error:  # pragma: no cover
-            logger.debug(repr(token_error))
-            return False
-
+        tokens = tuple(tokenize.generate_tokens(StringIO(normalize_for_tokenize(source)).readline))
         found = _scan_misplaced_comments(tokens)
         if not found:
             return False

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -36,7 +36,7 @@ from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
     Violation,
     byte_col_to_char_col,
-    find_ignored_lines,
+    find_ignored_lines_and_classify_comments,
     ignore_pattern_for,
 )
 
@@ -118,9 +118,14 @@ class RedundantAssignmentCheck(BaseCheck):
         return {"level": AggressivenessLevel[args.redundant_assignment_level.upper()]}
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
-        ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+        # Tokenized once and reused for both lookups below, rather than
+        # each independently tokenizing the whole file (see
+        # find_ignored_lines_and_classify_comments).
+        ignored_lines, comment_only_lines, trailing_comment_lines = find_ignored_lines_and_classify_comments(
+            source, IGNORE_PATTERN
+        )
 
-        tracker = VariableTracker(source)
+        tracker = VariableTracker(source, comment_only_lines, trailing_comment_lines)
         tracker.visit(tree)
         lifecycles = tracker.build_lifecycles()
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -395,15 +395,7 @@ class VariableTracker(ast.NodeVisitor):
         across the whole file, so the difference is O(source size) total
         instead of O(assignments x source size).
         """
-        try:
-            return fast_get_source_segment(self.source, self._ast_lines, node) or ""
-        # Defensive: fast_get_source_segment slices source by byte offset
-        # and decodes it, which could raise (ValueError/UnicodeDecodeError,
-        # or TypeError) if a node's position were ever inconsistent with
-        # this source — not expected for a node resolved against its own
-        # tree.
-        except ValueError, TypeError:  # pragma: no cover
-            return ""
+        return fast_get_source_segment(self.source, self._ast_lines, node) or ""
 
     def _is_simple_name_target(self, target: ast.expr) -> bool:
         return isinstance(target, ast.Name)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Literal
 
-from pre_commit_hooks.ast_checks._base import classify_comment_lines, fast_get_source_segment, split_lines_like_ast
+from pre_commit_hooks.ast_checks._base import fast_get_source_segment, split_lines_like_ast
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -298,18 +298,21 @@ def _suspension_precedes_use(use: UsageInfo) -> bool:
 class VariableTracker(ast.NodeVisitor):
     """Builds a map of variable lifecycles: where each variable is assigned and where it's used, across scopes."""
 
-    def __init__(self, source: str) -> None:
+    def __init__(self, source: str, comment_only_lines: set[int], trailing_comment_lines: set[int]) -> None:
         self.source = source
         self.source_lines = source.splitlines()
         # For _get_source_segment only: split on the same line boundaries
         # ast's own lineno/end_lineno use, unlike self.source_lines above
         # (see split_lines_like_ast).
         self._ast_lines = split_lines_like_ast(source)
-        # Computed once per file (not per assignment) since it tokenizes
-        # the whole source — see AssignmentInfo.has_comment_above/
-        # has_inline_comment for why a tokenize-based classification is
-        # needed instead of a naive text scan.
-        self._comment_only_lines, self._trailing_comment_lines = classify_comment_lines(source)
+        # Passed in by the caller rather than computed here — see
+        # AssignmentInfo.has_comment_above/has_inline_comment for why a
+        # tokenize-based classification is needed instead of a naive text
+        # scan, and RedundantAssignmentCheck.check() for why it's tokenized
+        # once there (shared with the ignored-lines lookup) instead of
+        # this constructor tokenizing `source` again on its own.
+        self._comment_only_lines = comment_only_lines
+        self._trailing_comment_lines = trailing_comment_lines
 
         self.current_scope_id = 0
         self.scope_stack: list[int] = [0]  # 0 = module scope

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -666,10 +666,8 @@ class VariableTracker(ast.NodeVisitor):
                 self._record_compound_target_rebindings(elt, stmt_index)
         elif isinstance(target, ast.Starred):
             self._record_compound_target_rebindings(target.value, stmt_index)
-        elif isinstance(target, ast.Attribute | ast.Subscript):  # pragma: no branch
-            # Python's grammar limits an assignment target to exactly these
-            # five shapes, so this dispatch is exhaustive — there's no
-            # "else" case to reach.
+        else:
+            assert isinstance(target, ast.Attribute | ast.Subscript)
             self._track_attribute_or_subscript_base_usage(target, stmt_index)
 
     def _track_attribute_or_subscript_base_usage(self, node: ast.Attribute | ast.Subscript, stmt_index: int) -> None:

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -19,14 +19,18 @@ from pre_commit_hooks.ast_checks.redundant_assignment.semantic import Aggressive
 from tests.redundant_assignment._helpers import _check
 
 
+def _tracker(source: str) -> VariableTracker:
+    return VariableTracker(source, *classify_comment_lines(source))
+
+
 def _lifecycle_for(source: str, var_name: str) -> VariableLifecycle:
-    tracker = VariableTracker(source)
+    tracker = _tracker(source)
     tracker.visit(ast.parse(source))
     return next(lc for lc in tracker.build_lifecycles() if lc.assignment.var_name == var_name)
 
 
 def _lifecycle_count(source: str, var_name: str) -> int:
-    tracker = VariableTracker(source)
+    tracker = _tracker(source)
     tracker.visit(ast.parse(source))
     return len([lc for lc in tracker.build_lifecycles() if lc.assignment.var_name == var_name])
 
@@ -133,7 +137,7 @@ def func():
     return (x := 1)
 """
     # Must not raise; global walrus targets are silently skipped.
-    VariableTracker(source).visit(ast.parse(source))
+    _tracker(source).visit(ast.parse(source))
 
 
 def test_tuple_unpacking_rebinding_skipped_for_global_variable() -> None:
@@ -146,7 +150,7 @@ def func():
     global x
     x, y = compute()
 """
-    VariableTracker(source).visit(ast.parse(source))
+    _tracker(source).visit(ast.parse(source))
 
 
 def test_starred_tuple_target_recorded_as_rebinding() -> None:
@@ -171,7 +175,7 @@ def func(obj):
     obj.attr, first = compute()
     return first
 """
-    tracker = VariableTracker(source)
+    tracker = _tracker(source)
     tracker.visit(ast.parse(source))
     obj_uses = tracker.uses[next(key for key in tracker.uses if key[1] == "obj")]
     assert any(use.context == "attribute_or_subscript_assignment" for use in obj_uses)
@@ -221,7 +225,7 @@ def outer():
     return 42
 """
     # Must not raise; call-result targets are silently skipped.
-    VariableTracker(source).visit(ast.parse(source))
+    _tracker(source).visit(ast.parse(source))
 
 
 def test_track_attribute_assignment_key_already_in_uses() -> None:
@@ -356,7 +360,7 @@ def outer():
 
 def test_get_source_segment_error_handling() -> None:
     node = ast.Constant(value=1, lineno=-1, col_offset=-1)
-    assert VariableTracker("x = 1")._get_source_segment(node) == ""
+    assert _tracker("x = 1")._get_source_segment(node) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -358,7 +358,7 @@ def outer():
     )
 
 
-def test_get_source_segment_error_handling() -> None:
+def test_get_source_segment_returns_empty_string_without_end_position() -> None:
     node = ast.Constant(value=1, lineno=-1, col_offset=-1)
     assert _tracker("x = 1")._get_source_segment(node) == ""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redundant-assignment detection around comment-only lines and trailing comments.
  * Inline suppression comments are now handled more consistently when evaluating redundant assignments.
  * Tokenization failures no longer silently suppress or skip misplaced-comment checks.
  * Preserved existing violation reporting and fixability behavior.
* **Performance**
  * Streamlined source analysis so redundant-assignment checks tokenize and classify comments in a single pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->