### PR TITLE
refactor: delete meaningless "regression" filler word

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -5,7 +5,7 @@ regex-style-search=true
 [title-must-not-contain-word]
 # AI writes meaningless "apply reviewer feedback" (a.k.a. "I did something")
 # messages instead of writing what was changed and why.
-words=resolve thread,resolve threads,resolve remark,resolve remarks,wip,implement review comments,reviewer changes,reviewer feedback,address code review feedback,address reviewer,apply reviewer,address review feedback,address feedback,review findings
+words=resolve thread,resolve threads,resolve remark,resolve remarks,wip,implement review comments,reviewer changes,reviewer feedback,address code review feedback,address reviewer,apply reviewer,address review feedback,address feedback,review findings,flagged in review
 
 [body-max-line-length]
 line-length=100

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -538,11 +538,11 @@ def func(x):
             None,
         ),
         (
-            # Regression: `old`'s assignment, the `self._server_session =
+            # `old`'s assignment, the `self._server_session =
             # ...` reassignment, and `old`'s own use are all nested inside
             # the same top-level `if`, so they share one coarse
             # stmt_index. Bisecting the hazard scan on stmt_index (instead
-            # of line) skipped straight past the reassignment, silently
+            # of line) would skip straight past the reassignment, silently
             # missing this snapshot-before-reassignment hazard.
             """
 def func(self):
@@ -556,10 +556,10 @@ def func(self):
             None,
         ),
         (
-            # Regression: two semicolon-separated statements on one
+            # Two semicolon-separated statements on one
             # physical line have the same `line` but distinct
             # `stmt_index`. Bisecting the hazard scan on line alone (the
-            # fix for the coarse-stmt_index case above) skipped straight
+            # fix for the coarse-stmt_index case above) would skip straight
             # past this same-line reassignment.
             """
 def func(x):
@@ -687,10 +687,10 @@ async def func(obj, cond):
         ),
         (
             # Same hazard as the two cases above, but semicolon-separated
-            # onto one physical line — assignment, await, and use now tie
-            # on *both* line and stmt_index, which used to make the bisect
-            # boundary skip the await point entirely (it looked identical
-            # to the assignment's own position).
+            # onto one physical line — assignment, await, and use tie on
+            # *both* line and stmt_index, so the bisect boundary must not
+            # skip the await point just because it looks identical to the
+            # assignment's own position.
             """
 async def func(obj, cond):
     if cond:
@@ -909,11 +909,11 @@ def test_evaluation_order_children_assign_yields_value_before_targets() -> None:
     ("source", "var_name", "expected"),
     [
         (
-            # Regression (2nd P1 in issue #22's fix): the evaluation-order
-            # check must be AST-based, not line/column-text-based — a
-            # text heuristic sees an empty same-line prefix for `x` here
-            # and wrongly calls it safe, even though side_effect() (on the
-            # previous physical line, same statement) already ran first.
+            # The evaluation-order check must be AST-based, not
+            # line/column-text-based — a text heuristic sees an empty
+            # same-line prefix for `x` here and wrongly calls it safe, even
+            # though side_effect() (on the previous physical line, same
+            # statement) already ran first.
             """
 def f():
     x = make()
@@ -1111,18 +1111,18 @@ def test_is_preceded_by_call_defaults_to_true_for_unknown_container() -> None:
         ('x = "test#test"  # real comment', True),  # String with `#` followed by a real comment.
         ('x = "test # not a comment"', False),  # Only a string containing `#`.
         ('x = ""  # comment', True),  # Empty string then comment.
-        # Regression: a single-quote inside a double-quoted string (e.g.
+        # A single-quote inside a double-quoted string (e.g.
         # "it's") must not be mistaken for a comment delimiter.
         ('x = "it\'s fine"', False),
         ('x = "it\'s fine"  # comment', True),
-        # Regression: a naive single-char-lookback escape check used to
-        # treat this closing quote as itself escaped (only the immediately
-        # preceding backslash was checked, not the full run), leaving the
-        # scanner stuck "inside" the string through the rest of the line —
-        # silently hiding a real trailing comment, which --fix would then
-        # have deleted along with the assignment it decorated.
+        # A naive single-char-lookback escape check would treat this
+        # closing quote as itself escaped (only the immediately preceding
+        # backslash checked, not the full run), leaving the scanner stuck
+        # "inside" the string through the rest of the line — silently
+        # hiding a real trailing comment, which --fix would then delete
+        # along with the assignment it decorated.
         ('x = "\\\\"  # comment', True),
-        # Regression: an embedded, unescaped quote inside a triple-quoted
+        # An embedded, unescaped quote inside a triple-quoted
         # string desyncs a single-quote-at-a-time toggle from the real
         # triple-quote delimiter, again hiding a real trailing comment.
         ('x = """a"b"""  # comment', True),

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -830,13 +830,14 @@ def test_autofix_declines_fstring_splice_with_unpaired_surrogate(tmp_path: Path)
 def test_autofix_declines_fstring_splice_when_value_unencodable_in_declared_encoding(
     tmp_path: Path,
 ) -> None:
-    # a PEP 263 file can declare a narrower encoding (e.g.
-    # ASCII) than UTF-8. "\xe9" ('é') is a perfectly safe splice target
-    # under UTF-8 (should_autofix's check()-time guess, which never learns
-    # the real declared encoding), but writing it back into an
-    # ASCII-declared file would raise UnicodeEncodeError — apply_fixes must
-    # re-check against the *real* encoding it was actually given and
-    # decline rather than crash.
+    # A file's own declared encoding (detected upstream via a PEP 263
+    # coding line, and passed in here as encoding="ascii" to isolate this
+    # check from that detection step) can be narrower than UTF-8. "\xe9"
+    # ('é') is a perfectly safe splice target under UTF-8 (should_autofix's
+    # check()-time guess, which never learns the real declared encoding),
+    # but writing it back into an ASCII-declared file would raise
+    # UnicodeEncodeError — apply_fixes must re-check against the *real*
+    # encoding it was actually given and decline rather than crash.
     source = 'def f():\n    label = "\\xe9"\n    return f"<{label}>"\n'
     filepath = tmp_path / "source.py"
     filepath.write_bytes(source.encode("ascii"))

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -15,7 +15,7 @@ from pre_commit_hooks.ast_checks.redundant_assignment.autofix import (
 from tests.factories import ViolationFactory
 
 # ---------------------------------------------------------------------------
-# fix() / apply_fixes(): file-mutation regression tests
+# fix() / apply_fixes(): file-mutation tests
 # ---------------------------------------------------------------------------
 
 
@@ -44,7 +44,7 @@ def test_fix_method_with_fixable_violations(tmp_path: Path) -> None:
 
 
 def test_fix_two_assignments_used_on_the_same_line(tmp_path: Path) -> None:
-    # Regression: two independently-fixable assignments whose single uses
+    # Two independently-fixable assignments whose single uses
     # land on the same line must both be inlined, even when the
     # replacement text is a different length than the variable it
     # replaces (which shifts the column of whichever use is processed
@@ -72,9 +72,9 @@ def test_fix_two_assignments_used_on_the_same_line(tmp_path: Path) -> None:
 def test_fix_chained_assignment_where_use_line_is_another_assign_line(
     tmp_path: Path,
 ) -> None:
-    # Regression: x's only use is on the same line as y's assignment (`y
-    # = x`). Applying y's fix first blanks that whole line, so x's own fix
-    # must skip cleanly instead of crashing when its use is gone.
+    # `x`'s only use is on the same line as `y`'s assignment (`y
+    # = x`). Applying `y`'s fix first blanks that whole line, so `x`'s own
+    # fix must skip cleanly instead of crashing when its use is gone.
     source = """def f():
     x = 1
     y = x
@@ -95,9 +95,9 @@ def test_fix_chained_assignment_where_use_line_is_another_assign_line(
 
 
 def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # Regression: apply_fixes() used to let atomic_write_text()'s OSError
-    # propagate uncaught instead of returning False like every other check's
-    # fix().
+    # apply_fixes() must catch atomic_write_text()'s OSError and return
+    # False, like every other check's fix(), instead of letting it
+    # propagate uncaught.
     source = """def func_scope():
     x = "foo"
     func(x=x)
@@ -112,7 +112,7 @@ def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptu
 
     with caplog.at_level("DEBUG"):
         assert check.fix(filepath, violations, source, tree) is False
-    # Regression: the write failure must be attributed to the violations it
+    # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.
@@ -384,11 +384,11 @@ def func():
 
 
 def test_zero_arg_call_immediate_single_use_is_fixable(tmp_path: Path) -> None:
-    # Regression test (issue #22): IMMEDIATE_SINGLE_USE never allowed a
-    # Call RHS, even trivial zero-arg ones, so idiomatic test code like
-    # `check = MeaninglessVarsCheck(); check.check(...)` was never auto-fixed.
     # A zero-arg call has no operands whose evaluation order inlining
-    # could disturb, so it's safe to allow as a narrow carve-out.
+    # could disturb, so IMMEDIATE_SINGLE_USE allows it as a narrow
+    # carve-out even though it's a Call RHS -- idiomatic test code like
+    # `check = MeaninglessVarsCheck(); check.check(...)` must be
+    # auto-fixable.
     source = """def test_something():
     check = MeaninglessVarsCheck()
     violations = check.check(Path("test.py"), tree, source)
@@ -414,9 +414,9 @@ def test_zero_arg_call_immediate_single_use_is_fixable(tmp_path: Path) -> None:
 def test_augmented_assignment_use_not_flagged_for_zero_arg_call(
     tmp_path: Path,
 ) -> None:
-    # Regression test: the issue #22 zero-arg-call carve-out for
-    # IMMEDIATE_SINGLE_USE must not make `x = Box(); x += 1` fixable —
-    # inlining would produce invalid syntax (`Box() += 1`).
+    # The zero-arg-call carve-out for IMMEDIATE_SINGLE_USE must not make
+    # `x = Box(); x += 1` fixable — inlining would produce invalid syntax
+    # (`Box() += 1`).
     source = """def f():
     x = Box()
     x += 1
@@ -570,8 +570,8 @@ def test_call_rhs_across_await_in_same_statement_not_reported(tmp_path: Path) ->
 
 
 def test_autofix_preserves_blank_lines_across_file(tmp_path: Path) -> None:
-    # Regression: autofix used to delete blank lines across the entire
-    # file, not just around the removed assignment.
+    # autofix must not delete blank lines across the entire
+    # file, only around the removed assignment.
     source = """class FirstClass:
     def method_one(self):
         pass
@@ -673,13 +673,14 @@ def test_cleanup_blank_lines_only_excess_above() -> None:
 
 
 def test_fix_preserves_trailing_comment_on_string_ending_in_escaped_backslash(tmp_path: Path) -> None:
-    # Regression: the old naive comment-detection heuristic missed the
+    # A naive comment-detection heuristic would miss the
     # trailing comment on a line like `sep = "\\"  # comment` (an escaped
     # backslash right before the closing quote), so should_report_violation
-    # never applied its "skip if there's an inline comment" rule and --fix
-    # silently deleted the comment along with the assignment it decorated
-    # (ch. 2: "MUST preserve comments unless the rule explicitly owns the
-    # relevant comment"; ch. 21: "MUST preserve comments where possible").
+    # must still apply its "skip if there's an inline comment" rule rather
+    # than letting --fix silently delete the comment along with the
+    # assignment it decorated (ch. 2: "MUST preserve comments unless the
+    # rule explicitly owns the relevant comment"; ch. 21: "MUST preserve
+    # comments where possible").
     source = 'def get_sep() -> str:\n    sep = "\\\\"  # Windows path separator\n    return sep\n'
     filepath = tmp_path / "source.py"
     filepath.write_text(source)
@@ -692,7 +693,7 @@ def test_fix_preserves_trailing_comment_on_string_ending_in_escaped_backslash(tm
 
 
 def test_check_reports_assignment_after_multiline_string_with_trailing_comment(tmp_path: Path) -> None:
-    # Regression: tokenize reports a multiline STRING token's line as only
+    # tokenize reports a multiline STRING token's line as only
     # its start line, not every line it spans, so a comment trailing the
     # closing `"""` on a later line was misclassified as comment-only —
     # wrongly making has_comment_above() true for the *next* line and
@@ -709,10 +710,10 @@ def test_check_reports_assignment_after_multiline_string_with_trailing_comment(t
 
 
 def test_autofix_splices_string_literal_into_fstring_field(tmp_path: Path) -> None:
-    # Regression (issue #72): inlining a string-literal variable into an
-    # f-string replacement field used to re-quote it inside the braces
-    # (`f"...{"requests-cache"}..."`) instead of splicing the literal's
-    # raw text directly into the surrounding string.
+    # Inlining a string-literal variable into an f-string replacement
+    # field must splice the literal's raw text directly into the
+    # surrounding string, not re-quote it inside the braces (which would
+    # produce `f"...{"requests-cache"}..."`).
     source = """def f():
     org = "requests-cache"
     return f"https://github.com/{org}/requests-cache"
@@ -759,7 +760,7 @@ def test_autofix_declines_fstring_splice_with_unsafe_characters(tmp_path: Path) 
 
 
 def test_autofix_declines_fstring_splice_with_control_character(tmp_path: Path) -> None:
-    # Regression: "\x1b[0m" (an ANSI reset code) is a valid, non-newline,
+    # "\x1b[0m" (an ANSI reset code) is a valid, non-newline,
     # non-NUL string literal, so it passed every prior unsafe-character
     # check. Splicing it as a raw byte is syntactically fine but renders
     # invisibly (the ESC[0m sequence produces no visible glyph), making a
@@ -784,7 +785,7 @@ def test_autofix_declines_fstring_splice_with_control_character(tmp_path: Path) 
 
 
 def test_autofix_declines_fstring_splice_with_nul_byte(tmp_path: Path) -> None:
-    # Regression: `"\x00"` is a perfectly valid string literal, but Python's
+    # `"\x00"` is a perfectly valid string literal, but Python's
     # tokenizer rejects any *source file* containing a raw NUL byte —
     # splicing it as literal text would turn a fixable file into an
     # unparsable one.
@@ -805,7 +806,7 @@ def test_autofix_declines_fstring_splice_with_nul_byte(tmp_path: Path) -> None:
 
 
 def test_autofix_declines_fstring_splice_with_unpaired_surrogate(tmp_path: Path) -> None:
-    # Regression: a str object can legally hold an unpaired surrogate (e.g.
+    # a str object can legally hold an unpaired surrogate (e.g.
     # from a "\ud800" escape) even though no real text encoding can
     # represent one — splicing it as raw source text would make
     # atomic_write_text's compile()/write() crash with an uncaught
@@ -829,7 +830,7 @@ def test_autofix_declines_fstring_splice_with_unpaired_surrogate(tmp_path: Path)
 def test_autofix_declines_fstring_splice_when_value_unencodable_in_declared_encoding(
     tmp_path: Path,
 ) -> None:
-    # Regression: a PEP 263 file can declare a narrower encoding (e.g.
+    # a PEP 263 file can declare a narrower encoding (e.g.
     # ASCII) than UTF-8. "\xe9" ('é') is a perfectly safe splice target
     # under UTF-8 (should_autofix's check()-time guess, which never learns
     # the real declared encoding), but writing it back into an
@@ -901,9 +902,9 @@ def test_autofix_declines_fstring_splice_for_nested_expression(tmp_path: Path) -
 
 
 def test_autofix_fstring_field_unaffected_for_non_string_rhs(tmp_path: Path) -> None:
-    # Regression guard: a non-string RHS (e.g. a number) was never buggy —
-    # `f"{5}"` is fine as-is, no quotes involved — so the new f-string
-    # handling must not change this existing, already-correct behavior.
+    # A non-string RHS (e.g. a number) needs no re-quoting — `f"{5}"` is
+    # fine as-is, no quotes involved — so the f-string splice handling
+    # must leave this path unaffected.
     source = """def f():
     n = 5
     return f"Total: {n}"
@@ -924,11 +925,11 @@ def test_autofix_fstring_field_unaffected_for_non_string_rhs(tmp_path: Path) -> 
 
 
 def test_autofix_fstring_field_unaffected_for_name_rhs(tmp_path: Path) -> None:
-    # Regression guard: a Name RHS used as a whole f-string field (e.g.
-    # `x = obj; f"{x}"`) was never buggy either — `rhs_source` isn't a
-    # string-literal expression at all here, so the new splice path must
-    # recognize that (via ast.literal_eval raising) and fall through to the
-    # ordinary inlining path unchanged.
+    # A Name RHS used as a whole f-string field (e.g. `x = obj; f"{x}"`)
+    # isn't a string-literal expression, so `rhs_source` isn't eligible
+    # for splicing — the splice path must recognize that (via
+    # ast.literal_eval raising) and fall through to the ordinary inlining
+    # path unchanged.
     source = """def f(obj):
     x = obj
     return f"value: {x}"
@@ -949,7 +950,7 @@ def test_autofix_fstring_field_unaffected_for_name_rhs(tmp_path: Path) -> None:
 
 
 def test_autofix_fstring_splice_declines_when_earlier_fix_lengthens_line(tmp_path: Path) -> None:
-    # Regression: same-line violations are applied rightmost-first, so a
+    # same-line violations are applied rightmost-first, so a
     # fix processed before this one can lengthen the line beyond what
     # should_autofix saw at check() time (see exceeds_line_length_when_inlined's
     # docstring on why both call sites must independently re-check the
@@ -983,7 +984,7 @@ def test_autofix_fstring_splice_declines_when_earlier_fix_lengthens_line(tmp_pat
 
 
 def test_fix_inlines_use_on_line_with_non_ascii_text(tmp_path: Path) -> None:
-    # Regression: ast.col_offset is a UTF-8 byte offset, not a character
+    # ast.col_offset is a UTF-8 byte offset, not a character
     # offset. A non-ASCII character earlier on the use's line must not
     # throw off the position used to locate the variable for inlining.
     # `data`'s use must stay on the very next statement (issue #76 requires

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -28,7 +28,7 @@ def test_prefilter_pattern() -> None:
 
 
 def test_check_reports_character_offset_not_byte_offset_before_multibyte_text() -> None:
-    # Regression: ast.col_offset is a UTF-8 *byte* offset, not a character
+    # ast.col_offset is a UTF-8 *byte* offset, not a character
     # offset -- storing it on Violation.col directly reports a column too
     # far right on any line with non-ASCII text before the violation
     # (ch. 7: "MUST report ... column information accurately"; ch. 20:
@@ -582,8 +582,8 @@ def get_cache_file(cache):
             "redirects_file",
         ),
         (
-            # Regression: the linter used to remove a variable that was
-            # modified via nonlocal in a nested function.
+            # A variable modified via `nonlocal` in a nested function must
+            # not be treated as a candidate for removal.
             """
 async def test_websocket():
     cancelled = False
@@ -1047,7 +1047,7 @@ def check_warning(conn):
             "'warning'",
         ),
         (
-            # Regression: a single "private" (underscore-prefixed),
+            # A single "private" (underscore-prefixed),
             # SCREAMING_SNAKE_CASE module-level string constant used only
             # once elsewhere in the file reads as a deliberate, reusable
             # declaration (Rule 12), even though it's genuinely single-use.
@@ -1111,10 +1111,10 @@ def func():
     ("source", "excluded_names"),
     [
         (
-            # Regression: a tuple-unpacking target (`user, passwd =
-            # parse_userinfo(...)`) wasn't tracked as a reassignment, so
-            # `--fix` blanked `user = None` and inlined `None` at the
-            # return statement, discarding the real value.
+            # A tuple-unpacking target (`user, passwd =
+            # parse_userinfo(...)`) must be tracked as a reassignment —
+            # otherwise `--fix` would blank `user = None` and inline `None`
+            # at the return statement, discarding the real value.
             """
 def parse(host_part):
     user = None
@@ -1204,11 +1204,10 @@ def test_untracked_rebinding_not_flagged_as_redundant(source: str, excluded_name
 def test_ignore_marker_inside_string_literal_does_not_suppress_violation() -> None:
     # A string literal that merely contains the suppression-marker text is
     # not a real suppression comment and must not hide a violation on that
-    # line. Regression: line-based ignore detection used a plain text
-    # search over raw source lines, so a string literal containing '#
-    # pytriage: TR5' text was indistinguishable from an actual comment.
-    # Ignore detection must be tokenize-based so it only matches genuine
-    # COMMENT tokens.
+    # line. Ignore detection must be tokenize-based, matching only genuine
+    # COMMENT tokens — a plain text search over raw source lines can't
+    # distinguish a string literal containing '# pytriage: TR5' text from
+    # an actual comment.
     source = """
 def call_it():
     x = "foo"; note = "# pytriage: TR5"
@@ -1414,8 +1413,6 @@ def f():
     ids=["multiline-rhs", "complex-call-args", "long-use-line"],
 )
 def test_check_does_not_mark_unfixable_violation_fixable(source: str, message_filter: str) -> None:
-    # Regression test: violations used to be marked [FIXABLE] even when
-    # --fix couldn't actually fix them.
     matching = [v for v in _check(source) if message_filter in v.message]
     assert matching
     assert all(not v.fixable for v in matching)

--- a/tests/redundant_assignment/test_semantic.py
+++ b/tests/redundant_assignment/test_semantic.py
@@ -183,13 +183,13 @@ def test_should_autofix_allows_simple_zero_arg_call() -> None:
 
 @pytest.mark.parametrize("rhs_source", ["get_value()", "obj.attr"], ids=["call", "attribute"])
 def test_should_autofix_rejects_non_immediate_attribute_or_call_use(rhs_source: str) -> None:
-    # Regression (code review of issue #76): Attribute/Call RHS can run
-    # arbitrary code when evaluated, so inlining one is only safe when the
-    # use is the very next statement — otherwise an intervening
-    # statement's own effects could end up reordered relative to it, e.g.
-    # `result = pop(queue); queue.clear(); return result` must not become
-    # `queue.clear(); return pop(queue)`, which pops after clearing
-    # instead of before. A Constant/Name RHS has no such hazard (see
+    # Attribute/Call RHS can run arbitrary code when evaluated, so inlining
+    # one is only safe when the use is the very next statement —
+    # otherwise an intervening statement's own effects could end up
+    # reordered relative to it, e.g. `result = pop(queue); queue.clear();
+    # return result` must not become `queue.clear(); return pop(queue)`,
+    # which pops after clearing instead of before. A Constant/Name RHS has
+    # no such hazard (see
     # test_should_autofix_returns_true_for_single_use_constant_rhs), so
     # this restriction is specific to Attribute/Call.
     lifecycle = _lifecycle_with_use_node(rhs_source, use_stmt_index=4)
@@ -209,11 +209,9 @@ def test_should_autofix_returns_false_for_multiline_rhs() -> None:
 
 
 def test_should_autofix_allows_long_var_name_when_line_length_is_fine() -> None:
-    # Issue #76: the old var-name-length > 10 guard was only ever a crude
-    # proxy for "inlining might push the line too long" — now superseded
-    # entirely by the real line-length check below (with the actual use
-    # line, or the RHS-length estimate as a fallback), so a long name on
-    # its own is no longer disqualifying.
+    # A long variable name on its own must not disqualify autofix — only
+    # the real line-length check (using the actual use line, or the
+    # RHS-length estimate as a fallback) may reject it.
     rhs_node = ast.parse("something1", mode="eval").body
     lifecycle = _make_single_use_lifecycle("something1", rhs_node, var_name="myvariablex")
     assert should_autofix(lifecycle) is True
@@ -244,8 +242,7 @@ def test_should_autofix_allows_zero_arg_call() -> None:
 
 
 def test_should_autofix_rejects_zero_arg_call_preceded_by_a_call() -> None:
-    # Regression test (P1 caught in review of issue #22's fix): a
-    # zero-arg call must not be inlined when a sibling expression
+    # A zero-arg call must not be inlined when a sibling expression
     # evaluates before it within the same statement, or inlining reverses
     # the original execution order. Example: `value = next_value();
     # sink(side_effect(), value)` must not become `sink(side_effect(),
@@ -257,11 +254,10 @@ def test_should_autofix_rejects_zero_arg_call_preceded_by_a_call() -> None:
 
 
 def test_should_autofix_allows_call_with_one_arg() -> None:
-    # Issue #76: autofix eligibility is no longer pattern-dependent — a
-    # call with a single simple argument used to be rejected whenever the
-    # pattern was IMMEDIATE_SINGLE_USE/LITERAL_IDENTITY (only a bare
-    # zero-arg carve-out was allowed there); the same ≤2-arg allowance
-    # SINGLE_USE already had now applies uniformly.
+    # Autofix eligibility for a call RHS must not depend on the violation
+    # pattern -- a call with a single simple argument must be allowed the
+    # same ≤2-arg allowance regardless of whether the pattern is
+    # IMMEDIATE_SINGLE_USE, LITERAL_IDENTITY, or SINGLE_USE.
     rhs_node = ast.parse("make_check(1)", mode="eval").body
     lifecycle = _make_single_use_lifecycle("make_check(1)", rhs_node, var_name="check")
     assert should_autofix(lifecycle) is True

--- a/tests/redundant_assignment/test_semantic.py
+++ b/tests/redundant_assignment/test_semantic.py
@@ -254,10 +254,8 @@ def test_should_autofix_rejects_zero_arg_call_preceded_by_a_call() -> None:
 
 
 def test_should_autofix_allows_call_with_one_arg() -> None:
-    # Autofix eligibility for a call RHS must not depend on the violation
-    # pattern -- a call with a single simple argument must be allowed the
-    # same ≤2-arg allowance regardless of whether the pattern is
-    # IMMEDIATE_SINGLE_USE, LITERAL_IDENTITY, or SINGLE_USE.
+    # A call with a single simple argument must be allowed the same
+    # ≤2-arg allowance as a zero-arg call.
     rhs_node = ast.parse("make_check(1)", mode="eval").body
     lifecycle = _make_single_use_lifecycle("make_check(1)", rhs_node, var_name="check")
     assert should_autofix(lifecycle) is True

--- a/tests/redundant_type_conversion/test_analysis.py
+++ b/tests/redundant_type_conversion/test_analysis.py
@@ -121,11 +121,11 @@ def test_decide_candidates_hovers_the_arguments_own_last_character() -> None:
 
 
 def test_decide_candidates_handles_a_multibyte_final_character_in_the_argument() -> None:
-    # Regression: the hover position used to be computed by subtracting 1
-    # directly in UTF-8 *byte* space from the argument's own end offset.
-    # That offset is only a valid boundary when the argument's own last
-    # character is single-byte in UTF-8 -- for a multi-byte final
-    # character (e.g. 'é', 2 bytes), it landed mid-character and raised
+    # The hover position must not be computed by subtracting 1 directly in
+    # UTF-8 *byte* space from the argument's own end offset -- that offset
+    # is only a valid boundary when the argument's own last character is
+    # single-byte in UTF-8. For a multi-byte final character (e.g. 'é', 2
+    # bytes), subtracting a raw byte would land mid-character and raise
     # UnicodeDecodeError on otherwise ordinary, valid Python source.
     source = "y = str(é)\n"
     redundant, session = _decide(
@@ -151,13 +151,13 @@ def test_decide_candidates_conservative_excludes_mutable_constructors() -> None:
 
 
 def test_decide_candidates_restores_pristine_source_before_each_candidates_hover() -> None:
-    # Regression: hover used to run against whatever the *previous*
-    # candidate's own synthetic rewrite left the in-memory document as,
-    # rather than the file's real, unmodified content -- with two
-    # candidates, the second one's hover would see the first candidate's
-    # rewrite still in place instead of the original source. The recorded
-    # open_or_update() sequence is the direct evidence: `source` must be
-    # reopened before candidate 2's own hover, not left at `modified_1`.
+    # Hover must run against the file's real, unmodified content, not
+    # whatever the *previous* candidate's own synthetic rewrite left the
+    # in-memory document as -- with two candidates, the second one's hover
+    # would otherwise see the first candidate's rewrite still in place
+    # instead of the original source. The recorded open_or_update()
+    # sequence is the direct evidence: `source` must be reopened before
+    # candidate 2's own hover, not left at `modified_1`.
     source = "a = str(x)\nb = int(y)\n"
     modified_1 = "a = x\nb = int(y)\n"
     modified_2 = "a = str(x)\nb = y\n"

--- a/tests/redundant_type_conversion/test_candidates.py
+++ b/tests/redundant_type_conversion/test_candidates.py
@@ -129,11 +129,10 @@ def test_ignores_a_call_missing_its_own_end_position(null_out: Callable[[ast.Cal
     ],
 )
 def test_ignores_a_call_whose_constructor_name_is_shadowed(shadowing_statement: str) -> None:
-    # Regression: a bare `str(x)` call was previously always treated as
-    # the builtin constructor, even when `str` itself was rebound
-    # somewhere in the module -- removing the "conversion" in that case
-    # calls a *different*, user-defined callable, which can change
-    # behavior rather than being a safe no-op.
+    # A bare `str(x)` call must not be treated as the builtin constructor
+    # when `str` itself is rebound somewhere in the module -- removing the
+    # "conversion" in that case calls a *different*, user-defined callable,
+    # which can change behavior rather than being a safe no-op.
     source = f"{shadowing_statement}func(str(x))\n"
     assert find_candidates(ast.parse(source), ALL_CONSTRUCTORS) == []
 
@@ -163,7 +162,7 @@ def test_shadowing_one_constructor_does_not_affect_an_unrelated_one() -> None:
     ids=["before-the-candidate", "after-the-candidate", "nested-in-an-unrelated-function"],
 )
 def test_ignores_every_candidate_when_a_wildcard_import_is_present(source: str) -> None:
-    # Regression: `from module import *` can bind any name at all,
+    # `from module import *` can bind any name at all,
     # including a builtin constructor's own name (e.g. a compatibility
     # shim exporting its own `str`), without _scan()'s shadowed-name
     # tracking ever seeing that specific binding -- a wildcard import
@@ -365,7 +364,7 @@ def test_shadowing_an_unrelated_name_does_not_disable_the_equality_marker() -> N
     ids=["single-import", "multiple-purepath-imports"],
 )
 def test_importing_path_from_pathlib_itself_does_not_disable_the_equality_marker(import_statement: str) -> None:
-    # Regression: an ordinary, correct `from pathlib import Path` must not
+    # An ordinary, correct `from pathlib import Path` must not
     # be treated as shadowing pathlib's own class -- that's the overwhelmingly
     # common case this whole exclusion exists for.
     source = f"{import_statement}y = matches == [str(x)]\n"

--- a/tests/redundant_type_conversion/test_confidence.py
+++ b/tests/redundant_type_conversion/test_confidence.py
@@ -126,7 +126,7 @@ def test_conservative_accepts_a_flow_narrowed_literal_of_the_same_scalar(hover_t
     ],
 )
 def test_conservative_rejects_a_literal_of_a_different_scalar(hover_text: str, constructor: str) -> None:
-    # Regression guard: bool is an int subclass at runtime, so a naive
+    # Bool is an int subclass at runtime, so a naive
     # "Literal[...] always matches" rule would let int(some_bool) through
     # as if it were a no-op, even though it genuinely changes the runtime
     # type from bool to plain int.
@@ -161,7 +161,7 @@ def test_permissive_rejects_a_union_with_a_non_matching_member(hover_text: str, 
     ids=["union-in-generic-arg", "union-in-mapping-value", "union-in-callable-arg"],
 )
 def test_permissive_does_not_split_a_union_nested_inside_brackets(hover_text: str) -> None:
-    # Regression: a " | " nested inside a generic's own brackets isn't a top-level union.
+    # A " | " nested inside a generic's own brackets isn't a top-level union.
     assert hover_passes_gate(hover_text, ConfidenceLevel.PERMISSIVE, "list") is True
 
 

--- a/tests/redundant_type_conversion/test_session.py
+++ b/tests/redundant_type_conversion/test_session.py
@@ -53,7 +53,7 @@ def test_diagnostic_key_tolerates_a_missing_range() -> None:
 
 
 def test_diagnostic_key_ignores_a_character_column_shift() -> None:
-    # Regression: a same-line synthetic rewrite shifts every *other*
+    # A same-line synthetic rewrite shifts every *other*
     # diagnostic's own column positions on that line without changing the
     # diagnostic itself -- confirmed empirically against real ty (an
     # untouched invalid-argument-type diagnostic's range shifted left by
@@ -141,11 +141,11 @@ def test_spawn_raises_check_unavailable_error_when_ty_is_not_on_path(
 def test_spawn_raises_check_unavailable_error_when_ty_exists_but_is_not_executable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: _spawn only caught FileNotFoundError, so `ty` resolving
+    # _spawn must catch more than just FileNotFoundError -- `ty` resolving
     # on PATH but failing to actually launch (missing execute permission
-    # here; a corrupt/wrong-format binary raises the same way) surfaced as
-    # an uncaught PermissionError instead of this check's own actionable
-    # CheckUnavailableError.
+    # here; a corrupt/wrong-format binary raises the same way) must raise
+    # this check's own actionable CheckUnavailableError, not an uncaught
+    # PermissionError.
     not_executable = tmp_path / "not-really-ty"
     not_executable.write_text("#!/bin/sh\necho fake ty\n")
     not_executable.chmod(0o644)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -140,11 +140,11 @@ def test_classify_comment_lines(source: str, comment_only: set[int], trailing: s
 
 
 def test_classify_comment_lines_multiline_string_closing_line_is_code() -> None:
-    # Regression: tokenize reports a multiline STRING token's line as only
+    # tokenize reports a multiline STRING token's line as only
     # its *start* line, not every line it spans — so a comment trailing the
-    # closing `"""` (on a later line) used to be misclassified as
-    # comment-only instead of trailing, since that later line was never
-    # recorded as containing code at all.
+    # closing `"""` (on a later line) must not be misclassified as
+    # comment-only instead of trailing, even though that later line is
+    # never recorded as containing code at all.
     source = 'x = """\nmulti\nline\n"""  # trailing comment\ny = 5\n'
     comment_only, trailing = classify_comment_lines(source)
     assert trailing == {4}
@@ -166,13 +166,12 @@ def test_normalize_for_tokenize(source: str, expected: str) -> None:
 
 
 def test_classify_comment_lines_on_cr_only_source() -> None:
-    # Regression: io.StringIO.readline() (unlike ast.parse(), which treats
+    # io.StringIO.readline() (unlike ast.parse(), which treats
     # a bare \r as a line boundary the same as \n/\r\n) doesn't split on a
-    # lone \r at all, so tokenize used to see an old-Mac-style CR-only file
-    # as one giant physical line and never emit a COMMENT token on the
-    # line that actually has one — silently hiding a real trailing comment
-    # the same way the pre-tokenize naive heuristic did, just for files
-    # using a different newline convention.
+    # lone \r at all, so tokenize must not see an old-Mac-style CR-only
+    # file as one giant physical line and skip emitting a COMMENT token on
+    # the line that actually has one — that would silently hide a real
+    # trailing comment on any file using this newline convention.
     source = 'x = 1\rsep = "\\\\"  # trailing comment\rprint(x, sep)\r'
     _comment_only, trailing = classify_comment_lines(source)
     assert trailing == {2}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -114,12 +114,12 @@ def test_cache_version_mismatch(temp_cache_dir: Path, sample_file: Path) -> None
 
 def test_cache_version_mismatch_recovers_on_rewrite(temp_cache_dir: Path, sample_file: Path) -> None:
     # A version bump must not pin a file to permanent cache misses.
-    # set_cached_result() used to load the on-disk blob (still tagged with
-    # the old version) and only patch individual keys, leaving the stale
-    # version tag in place forever — so every later run would keep missing
-    # and rewriting under the same never-updated old tag. Writing a fresh
-    # result under the new version must actually persist that version, so
-    # the immediately following read is a hit.
+    # set_cached_result() must not load the on-disk blob (still tagged
+    # with the old version) and only patch individual keys, leaving the
+    # stale version tag in place forever — every later run would then keep
+    # missing and rewriting under the same never-updated old tag. Writing
+    # a fresh result under the new version must actually persist that
+    # version, so the immediately following read is a hit.
     cache_v1 = CacheManager(cache_dir=temp_cache_dir, cache_version="1.0.0")
     cache_v1.set_cached_result(sample_file, "test-hook", {"violations": ["old"]})
 
@@ -189,11 +189,11 @@ def test_cache_write_errors_do_not_crash(cache_manager: CacheManager, sample_fil
 
 
 def test_construction_does_not_crash_when_cache_dir_is_unavailable(tmp_path: Path, sample_file: Path) -> None:
-    # Regression: CacheManager.__init__ used to let mkdir()'s PermissionError
+    # CacheManager.__init__ must not let mkdir()'s PermissionError
     # (or any other OSError creating/tagging the cache dir) propagate
-    # uncaught, crashing the whole hook instead of degrading to uncached
-    # execution. A read-only parent directory means the cache dir itself can
-    # never be created.
+    # uncaught and crash the whole hook -- it must degrade to uncached
+    # execution instead. A read-only parent directory means the cache dir
+    # itself can never be created.
     readonly_parent = tmp_path / "readonly_parent"
     readonly_parent.mkdir()
 
@@ -206,11 +206,11 @@ def test_construction_does_not_crash_when_cache_dir_is_unavailable(tmp_path: Pat
 
 
 def test_construction_detects_pre_existing_read_only_cache_dir(tmp_path: Path) -> None:
-    # Regression: a cache dir that already exists (from a prior run) with
+    # A cache dir that already exists (from a prior run) with
     # its CACHEDIR.TAG already written makes both mkdir(exist_ok=True) and
     # the "if not tag_file.exists()" write-skip succeed without ever
     # attempting a write, so a directory later chmodded read-only (or
-    # mounted read-only) looked exactly like an available one -- the
+    # mounted read-only) looks exactly like an available one -- the
     # os.access(W_OK) check exists specifically to catch this case, which
     # neither a raised OSError nor a first write attempt would.
     existing_cache_dir = tmp_path / "cache"
@@ -224,11 +224,11 @@ def test_construction_detects_pre_existing_read_only_cache_dir(tmp_path: Path) -
 def test_unavailable_cache_dir_short_circuits_without_touching_filesystem(
     temp_cache_dir: Path, sample_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: once the cache directory is known unavailable, later calls
+    # Once the cache directory is known unavailable, later calls
     # must not repeat the doomed mkdir() attempt (and its warning) per file
-    # -- set_cached_result() used to hash the file's full content before
-    # even reaching the failing mkdir(), wasted work on every processed file
-    # for the rest of the run.
+    # -- set_cached_result() must not hash the file's full content before
+    # even reaching the (failing) mkdir() check, which would waste work on
+    # every processed file for the rest of the run.
     cache = CacheManager(cache_dir=temp_cache_dir, hook_name="test-hook", cache_version="1")
     cache._cache_dir_unavailable = True
 
@@ -260,14 +260,14 @@ def test_write_cache_cleans_up_temp_file_on_write_error(
 def test_write_cache_does_not_follow_a_symlink_planted_at_the_old_predictable_temp_name(
     cache_manager: CacheManager, tmp_path: Path
 ) -> None:
-    # Regression: _write_cache() used to write through a fixed
-    # `<hash>.tmp` sibling (`cache_file.with_suffix(".tmp")`), predictable
-    # from the cache file's own name alone. Anyone able to write to
-    # cache_dir could pre-plant a symlink at that exact path pointing at a
-    # file the running user can write but doesn't intend to touch; a plain
+    # _write_cache() must not write through a fixed `<hash>.tmp` sibling
+    # (`cache_file.with_suffix(".tmp")`), predictable from the cache
+    # file's own name alone. Anyone able to write to cache_dir could
+    # pre-plant a symlink at that exact path pointing at a file the
+    # running user can write but doesn't intend to touch; a plain
     # `open(..., "w")` follows a symlink, so the write would land on the
-    # symlink's target instead of a fresh file. Now that the temp file
-    # comes from `tempfile.mkstemp()`, a pre-planted symlink at the old
+    # symlink's target instead of a fresh file. Sourcing the temp file
+    # from `tempfile.mkstemp()` instead means a pre-planted symlink at a
     # fixed name is simply never used.
     cache_file = cache_manager.cache_dir / "some_hash.json"
     victim = tmp_path / "victim.txt"
@@ -351,7 +351,7 @@ def test_construction_warns_and_continues_when_fcntl_unavailable(
     temp_cache_dir: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     # Windows has no fcntl module at all. `import fcntl` at module import
-    # time used to make the whole package fail to import there before any
+    # time must not make the whole package fail to import there before any
     # warning could even be printed (ch. 14: "MUST NOT hard-crash merely
     # because an optional platform feature is unavailable"). Simulated here
     # by monkeypatching the already-imported module-level name, the same
@@ -391,9 +391,9 @@ def test_concurrent_writers_do_not_lose_updates(cache_manager: CacheManager, sam
     # Concurrent set_cached_result calls for different hook names on the
     # same file must not clobber each other's entries.
     #
-    # Regression: the read-modify-write of the shared per-file cache blob
-    # was unsynchronized, so under prek's parallel hook execution one
-    # writer's update could silently overwrite another's (lost update).
+    # The read-modify-write of the shared per-file cache blob must be
+    # synchronized, or under prek's parallel hook execution one writer's
+    # update could silently overwrite another's (lost update).
     hook_names = [f"hook-{i}" for i in range(20)]
 
     with ThreadPoolExecutor(max_workers=len(hook_names)) as executor:

--- a/tests/test_excessive_blank_lines.py
+++ b/tests/test_excessive_blank_lines.py
@@ -50,7 +50,7 @@ def test_ignore_fixtures_are_not_flagged(fixture_path: Path) -> None:
 @pytest.mark.parametrize(
     ("source", "flagged"),
     [
-        # Regression: raw/byte-prefixed docstrings must be detected via the
+        # Raw/byte-prefixed docstrings must be detected via the
         # AST — a raw-text quote-prefix scan misses the r/b prefix entirely
         # and would treat the whole file as one giant docstring.
         ('r"""Raw docstring."""\n\n\n\nimport os\n', True),
@@ -143,7 +143,7 @@ def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptu
     violations = check.check(test_file, tree, bad_source)
     with caplog.at_level("DEBUG"):
         assert check.fix(test_file, violations, bad_source, tree) is False
-    # Regression: the write failure must be attributed to the violations it
+    # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -132,18 +132,10 @@ def test_real_sigterm_mid_run_stops_gracefully_without_leftover_temp_files(
 
 
 def test_real_invocation_does_not_leak_a_traceback_onto_stderr(tmp_path: Path) -> None:
-    """Regression: pytest's own logging-capture plugin attaches a handler to
-    the root logger for the whole test session, so every other test in this
-    suite calling main()/run() in-process never observes what an actual
-    end user does. Nothing in this codebase configures logging itself, so
-    outside of pytest, Python's own `logging.lastResort` handler prints any
-    WARNING+ record straight to stderr with no handler of its own -- several
-    internal `logger.exception()` calls used to leak a full raw traceback
-    onto the user's terminal this way, duplicating and cluttering the clean,
-    documented diagnostic line the hook already prints for the exact same
-    failure (ch. 7: "MUST NOT emit uncontrolled human-oriented text into a
-    machine-readable output stream"; ch. 34: "MUST make errors actionable").
-    Only a real subprocess -- not an in-process call -- can observe this.
+    """Only a real subprocess -- not an in-process call -- can observe this:
+    pytest's own logging-capture plugin hides what an actual end user's
+    terminal would show (ch. 7: "MUST NOT emit uncontrolled human-oriented
+    text into a machine-readable output stream").
     """
     filepath = tmp_path / "unreadable.py"
     filepath.write_text("data = requests.get(url)\n")

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -610,8 +610,8 @@ def test_autofix_no_fixable_violations() -> None:
 
 
 def test_autofix_follows_closure_reference_into_nested_function() -> None:
-    # Regression: renaming only the assignment while leaving a nested
-    # function's free-variable reference untouched used to leave the
+    # Renaming only the assignment while leaving a nested
+    # function's free-variable reference untouched would leave the
     # closure reading a name that no longer exists in its enclosing scope
     # (NameError at call time) — ch. 2: "MUST NOT perform an auto-fix that
     # can change runtime behavior"; "MUST ensure that a fix does not change
@@ -690,7 +690,7 @@ def test_autofix_follows_closure_reference_into_comprehension() -> None:
 
 
 def test_walrus_rebinding_suppresses_suggestion() -> None:
-    # Regression: PEP 572 binds a `:=` target inside a comprehension to the
+    # PEP 572 binds a `:=` target inside a comprehension to the
     # nearest *enclosing* non-comprehension scope, not the comprehension
     # itself — so a walrus target sharing the outer variable's name is the
     # *same* binding, not a shadow of it, and must be renamed along with
@@ -721,7 +721,7 @@ def test_walrus_rebinding_suppresses_suggestion() -> None:
     ("source", "expected_snippet"),
     [
         (
-            # Regression: a comprehension's *first* `for` clause's iterable
+            # a comprehension's *first* `for` clause's iterable
             # is evaluated in the enclosing scope, before the
             # comprehension's own for-target ("data" here) starts shadowing
             # anything — must still be renamed even though the
@@ -755,7 +755,7 @@ def test_walrus_rebinding_suppresses_suggestion() -> None:
             "{x: payload for x in xs}",
         ),
         (
-            # Regression: a parameter default and a parameter/return
+            # a parameter default and a parameter/return
             # annotation are both evaluated at def-time in the enclosing
             # scope (not the function's own body scope) — must be renamed
             # even though the parameter itself ("data") also shadows the
@@ -922,7 +922,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             "[data for data in range(3)]",
         ),
         (
-            # Regression: `except E as data:` binds `data` as a plain string
+            # `except E as data:` binds `data` as a plain string
             # (ast.ExceptHandler.name), not an ast.Name node, so it was
             # invisible to the shadow check — `return data` inside the
             # handler was wrongly renamed to `return payload`, silently
@@ -943,7 +943,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             "except RuntimeError as data:\n            return data",
         ),
         (
-            # Regression: a match `case data:` capture binds via
+            # a match `case data:` capture binds via
             # ast.MatchAs.name, also a plain string, not an ast.Name.
             """def outer(response):
     data: Payload = response.json()
@@ -958,7 +958,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             "case data:\n                return data",
         ),
         (
-            # Regression: a match `case {**rest}:` mapping-rest capture
+            # a match `case {**rest}:` mapping-rest capture
             # binds via ast.MatchMapping.rest, also a plain string.
             """def outer(response):
     data: Payload = response.json()
@@ -973,7 +973,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             "case {**data}:\n                return data",
         ),
         (
-            # Regression: a PEP 695 type parameter (`def f[data]():`) binds
+            # a PEP 695 type parameter (`def f[data]():`) binds
             # via ast.TypeVar.name, also a plain string — and, unlike a
             # regular parameter, type params are accessible at runtime
             # inside the function body too.
@@ -988,7 +988,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             "def inner[data]() -> data:\n        return data",
         ),
         (
-            # Regression: `del data` makes `data` local to the *whole*
+            # `del data` makes `data` local to the *whole*
             # enclosing function (Python's rule for any binding operation,
             # not just assignment) — `del`'s target has ctx=ast.Del, not
             # ast.Store, so the original Store-only check missed it and
@@ -1007,7 +1007,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
             'del data\n        data = "local value"\n        return data',
         ),
         (
-            # Regression: a dotted `import data.models` (no `as`) binds
+            # a dotted `import data.models` (no `as`) binds
             # only the first component, "data", in the local namespace —
             # ast.alias.name is the full dotted path "data.models", which
             # never equals a bare "data", so the original check missed the
@@ -1120,7 +1120,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 @pytest.mark.parametrize(
     "source",
     [
-        # Regression: `def data(): ...` rebinds the *same* local slot as the
+        # `def data(): ...` rebinds the *same* local slot as the
         # earlier `data: Payload = response.json()` — Python resolves a closure (or
         # any same-scope reference) to whichever binding is current at call
         # time, not definition time. Confirmed against CPython: calling
@@ -1140,7 +1140,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader, data
 """,
-        # Regression: same failure class via `class data: ...` instead of
+        # same failure class via `class data: ...` instead of
         # `def` — ast.ClassDef.name is also a plain string.
         """def outer(response):
     data: Payload = response.json()
@@ -1153,7 +1153,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader, data
 """,
-        # Regression: an `except ... as data:` in the *same* scope as the
+        # an `except ... as data:` in the *same* scope as the
         # assignment (not a nested one) also rebinds the same slot — its
         # name is only bound for the duration of the handler, but Python
         # still treats the whole scope as governed by it for compile-time
@@ -1172,7 +1172,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader
 """,
-        # Regression: a match `case data:` capture in the same scope, also
+        # a match `case data:` capture in the same scope, also
         # a plain-string ast.MatchAs.name.
         """def outer(response, command):
     data: Payload = response.json()
@@ -1186,7 +1186,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader
 """,
-        # Regression: a match `case {**data}:` mapping-rest capture in the
+        # a match `case {**data}:` mapping-rest capture in the
         # same scope, also a plain-string ast.MatchMapping.rest.
         """def outer(response, command):
     data: Payload = response.json()
@@ -1200,7 +1200,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader
 """,
-        # Regression: a dotted `import data.models` in the same scope binds
+        # a dotted `import data.models` in the same scope binds
         # the bare name "data" (ast.alias.name is the full dotted path,
         # never equal to a bare name — this exercises the split-on-dot path).
         """def outer(response):
@@ -1213,7 +1213,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
 
     return reader
 """,
-        # Regression: a non-dotted `from x import data` in the same scope,
+        # a non-dotted `from x import data` in the same scope,
         # distinct branch from the dotted import above.
         """def outer(response):
     data: Payload = response.json()
@@ -1256,16 +1256,16 @@ def test_autofix_never_offered_when_same_scope_rebinds_via_non_name_construct(so
 
 
 def test_autofix_never_offered_for_module_global_read_in_function() -> None:
-    # Regression: a module-level `data` read via `global data` inside a
+    # A module-level `data` read via `global data` inside a
     # function isn't a *new* binding at all — it's the same variable being
-    # renamed. `_binds_name_in_nested_scope` used to treat `global data` as
-    # shadowing (a blanket, conservative rule that was right for the
-    # nonlocal-mutation case but wrong here), so the function's own body
-    # was skipped entirely and `return data` was left referencing a name
-    # that no longer existed after the module-level rename — a NameError
-    # the moment the function is called. Rather than trying to safely
-    # follow the reference (impossible: `global data`'s own "data" is a
-    # plain string, not a rewritable ast.Name), check() now simply never
+    # renamed. `_binds_name_in_nested_scope` must not treat `global data`
+    # as shadowing (that blanket, conservative rule is right for the
+    # nonlocal-mutation case but wrong here) -- doing so would skip the
+    # function's own body entirely and leave `return data` referencing a
+    # name that no longer exists after the module-level rename — a
+    # NameError the moment the function is called. Rather than trying to
+    # safely follow the reference (impossible: `global data`'s own "data"
+    # is a plain string, not a rewritable ast.Name), check() simply never
     # offers a fix for a name mentioned in any `global`/`nonlocal`
     # anywhere in scope (ch. 2: "MUST NOT perform an auto-fix that can
     # change runtime behavior").
@@ -1298,11 +1298,11 @@ def reader():
 
 
 def test_autofix_avoids_cross_scope_suggestion_collision() -> None:
-    # Regression: two *independent* violations in different (but nested,
+    # Two *independent* violations in different (but nested,
     # non-shadowing) scopes that happen to generate the same suggested
-    # name used to both become that name, colliding once the outer one's
-    # rename is followed into the inner scope via closure-following. Here
-    # both `data` and the inner `result` match the same `.json()` autofix
+    # name must not both become that name, once the outer one's rename is
+    # followed into the inner scope via closure-following. Here both
+    # `data` and the inner `result` match the same `.json()` autofix
     # pattern ("payload") — `return data, result` must not become `return
     # payload, payload`, silently making both returned values identical.
     source = """def outer(response):
@@ -1329,10 +1329,10 @@ def test_autofix_avoids_cross_scope_suggestion_collision() -> None:
 
 
 def test_autofix_avoids_suggestion_colliding_with_existing_nested_name() -> None:
-    # Branch coverage / regression: _get_scope_names() now walks the
-    # *entire* subtree (not just the immediate scope) so a suggestion also
-    # avoids an already-existing identifier that lives in a nested scope,
-    # not just a colliding future suggestion.
+    # _get_scope_names() walks the *entire* subtree (not just the
+    # immediate scope) so a suggestion also avoids an already-existing
+    # identifier that lives in a nested scope, not just a colliding future
+    # suggestion.
     source = """def outer(response):
     data: Payload = response.json()
 
@@ -1357,7 +1357,7 @@ def test_autofix_avoids_suggestion_colliding_with_existing_nested_name() -> None
 
 
 def test_autofix_avoids_suggestion_colliding_with_nested_parameter_name() -> None:
-    # Regression: _get_scope_names() must also see *parameter* names (never
+    # _get_scope_names() must also see *parameter* names (never
     # `ast.Name` nodes), not just already-bound locals, or a suggestion can
     # collide with a nested function's own parameter and silently rebind a
     # closure read to that parameter instead of the renamed outer variable.
@@ -1384,12 +1384,13 @@ def test_autofix_avoids_suggestion_colliding_with_nested_parameter_name() -> Non
 
 
 def test_autofix_avoids_suggestion_colliding_with_nested_global_declaration() -> None:
-    # Regression: a name declared `global`/`nonlocal` in a nested scope is
+    # A name declared `global`/`nonlocal` in a nested scope is
     # stored as a plain string (`ast.Global.names`), never an `ast.Name`
-    # node, so `_get_scope_names()` didn't see it as reserved. A suggestion
-    # equal to such a name turned what used to be a closure read into a
-    # lookup of the unrelated global/nonlocal binding instead, once the
-    # closure-following rename reached that nested scope.
+    # node, so `_get_scope_names()` must still see it as reserved. A
+    # suggestion equal to such a name would otherwise turn what was a
+    # closure read into a lookup of the unrelated global/nonlocal binding
+    # instead, once the closure-following rename reached that nested
+    # scope.
     source = """payload = "module-level unrelated value"
 
 def outer(response):
@@ -1416,11 +1417,11 @@ def outer(response):
 
 
 def test_autofix_renames_walrus_target_inside_default_evaluated_in_enclosing_scope() -> None:
-    # Regression: `_binds_name_in_nested_scope()` must scan only the nested
+    # `_binds_name_in_nested_scope()` must scan only the nested
     # function's *own* scope, not its `_outer_scope_children()` (decorators,
     # defaults, annotations without type params) — those run in the
-    # *enclosing* scope. A walrus target inside a default value used to be
-    # wrongly treated as a body-level shadow, so the default got renamed
+    # *enclosing* scope. A walrus target inside a default value must not
+    # be treated as a body-level shadow, or the default would get renamed
     # while the body's closure read was left stale, splitting one variable
     # into two and breaking the fixed code at runtime.
     source = """def outer(response):
@@ -1454,13 +1455,14 @@ def test_autofix_renames_walrus_target_inside_default_evaluated_in_enclosing_sco
 
 
 def test_autofix_follows_closure_through_scope_that_itself_contains_a_shadowing_nested_scope() -> None:
-    # Regression: `_binds_name_in_nested_scope()` must not descend into a
+    # `_binds_name_in_nested_scope()` must not descend into a
     # *further*-nested function/lambda/comprehension when checking whether
     # the scope it was actually asked about binds the name. `middle` itself
     # doesn't shadow `data`, but `middle`'s own body contains `deeper`,
-    # which does — `_iter_own_scope_descendants()` used to walk straight
-    # into `deeper`'s body too, wrongly concluding `middle` itself shadows
-    # `data`, and skipping `middle`'s own legitimate closure reference.
+    # which does — `_iter_own_scope_descendants()` must not walk straight
+    # into `deeper`'s body too, or it would wrongly conclude `middle`
+    # itself shadows `data`, and skip `middle`'s own legitimate closure
+    # reference.
     source = """def outer(response):
     data: Payload = response.json()
 
@@ -1496,12 +1498,12 @@ def test_autofix_follows_closure_through_scope_that_itself_contains_a_shadowing_
 
 
 def test_autofix_avoids_suggestion_collision_when_nested_closure_precedes_captured_assignment() -> None:
-    # Regression: suggestions used to be assigned in AST visit (textual)
-    # order, so a nested closure defined *before* the outer variable it
+    # Suggestions must not be assigned in AST visit (textual)
+    # order, or a nested closure defined *before* the outer variable it
     # will eventually capture (valid Python — closures resolve names at
-    # call time) got its own, unrelated violation's suggestion chosen
-    # first, unaware of what the outer scope would later pick for the same
-    # RHS pattern. assign_suggestions() now processes violations in
+    # call time) could get its own, unrelated violation's suggestion
+    # chosen first, unaware of what the outer scope would later pick for
+    # the same RHS pattern. assign_suggestions() processes violations in
     # ascending scope-depth order instead, so the outer scope's own
     # violation is always assigned first regardless of source order.
     source = """def outer(response, response2):
@@ -1527,14 +1529,14 @@ def test_autofix_avoids_suggestion_collision_when_nested_closure_precedes_captur
 
 
 def test_autofix_does_not_rename_annotation_under_deferred_annotations() -> None:
-    # Regression: with `from __future__ import annotations` (PEP 563)
+    # With `from __future__ import annotations` (PEP 563)
     # active, every annotation is stored as a string and resolved later
     # against the function's *module* globals, never the enclosing
     # function's locals — unlike a default value, it is never a true
     # closure reference. Renaming an annotation that happens to share a
-    # name with an outer local used to follow it anyway, pointing the
-    # (module-global-resolved) annotation at a name that only exists as a
-    # local, breaking `typing.get_type_hints()` at runtime.
+    # name with an outer local must not follow it anyway — that would
+    # point the (module-global-resolved) annotation at a name that only
+    # exists as a local, breaking `typing.get_type_hints()` at runtime.
     source = """from __future__ import annotations
 
 data = int
@@ -1619,7 +1621,7 @@ def test_autofix_still_follows_annotation_closure_without_deferred_annotations()
 
 
 def test_autofix_never_offered_for_module_scope_name_referenced_in_annotation() -> None:
-    # Regression: under PEP 563, every annotation resolves only against the
+    # under PEP 563, every annotation resolves only against the
     # annotated function's own *module* globals, ignoring any local
     # shadowing along the way — so unlike a nested-local rename (previous
     # two tests), a module-scope rename genuinely *should* propagate into
@@ -1658,7 +1660,7 @@ def f(x: data) -> result:
 
 
 def test_autofix_follows_closure_into_type_parameter_bound_and_default() -> None:
-    # Regression: a PEP 695 type parameter's own `bound`/`default_value`
+    # a PEP 695 type parameter's own `bound`/`default_value`
     # expression is evaluated lazily, but through a real closure over the
     # scope enclosing the `def` — confirmed against CPython to respect
     # ordinary shadowing rules, unlike a deferred annotation (previous
@@ -1708,7 +1710,7 @@ def test_autofix_follows_closure_into_type_parameter_bound_and_default() -> None
 
 
 def test_autofix_does_not_rename_type_parameter_bound_referencing_a_peer_type_parameter() -> None:
-    # Regression: within one `type_params` list, a *later* type parameter's
+    # within one `type_params` list, a *later* type parameter's
     # own bound/default expression can reference an *earlier* type
     # parameter by name — confirmed against CPython that this resolves to
     # the peer type parameter, not to whatever the enclosing scope happens
@@ -1749,7 +1751,7 @@ def test_autofix_does_not_rename_type_parameter_bound_referencing_a_peer_type_pa
 
 
 def test_autofix_does_not_reuse_a_nested_functions_own_mapping_for_its_default() -> None:
-    # Regression: a parameter default is evaluated in the *enclosing* scope,
+    # a parameter default is evaluated in the *enclosing* scope,
     # not the function it belongs to — `_collect_scope_replacements()` (the
     # entry point used when a violation's own enclosing scope is the nested
     # function itself, here `inner`'s body-local `data`) walked every one of
@@ -1794,12 +1796,12 @@ def test_autofix_does_not_reuse_a_nested_functions_own_mapping_for_its_default()
 
 
 def test_autofix_does_not_rename_a_nested_functions_own_type_parameter_bound_via_its_own_scope() -> None:
-    # Regression: same root cause as the test above, but reached through
+    # Same root cause as the test above, but reached through
     # `inner`'s own type parameter bound instead of a default — the
     # violation here is `data`'s reassignment inside `inner`'s own body, so
-    # `_collect_scope_replacements()` is entered directly on `inner`, and its
-    # old unfiltered child walk reached into `inner.type_params` too,
-    # renaming `T`'s bound (which references the peer type parameter `data`,
+    # `_collect_scope_replacements()` is entered directly on `inner`. Its
+    # child walk must not reach into `inner.type_params` too, or it would
+    # rename `T`'s bound (which references the peer type parameter `data`,
     # unaffected by the body-local reassignment) to a name nothing else
     # binds.
     source = """def outer(response):
@@ -1824,13 +1826,13 @@ def test_autofix_does_not_rename_a_nested_functions_own_type_parameter_bound_via
 
 
 def test_autofix_does_not_rename_type_alias_bound_referencing_a_peer_type_parameter() -> None:
-    # Regression: a PEP 695 `type` alias statement (`ast.TypeAlias`) has its
+    # a PEP 695 `type` alias statement (`ast.TypeAlias`) has its
     # own implicit type-parameter scope, exactly like a generic function —
     # confirmed against CPython that a later type parameter's own bound can
     # reference an earlier peer by name, resolving to that peer object, not
     # to the enclosing scope. `ast.TypeAlias` isn't in `_CROSSABLE_SCOPE_NODES`
-    # at all, so before this fix it fell through to the generic recursive
-    # case in `_collect_replacements`, which walked into the alias's
+    # at all, so it must not fall through to the generic recursive case in
+    # `_collect_replacements`, which would walk into the alias's
     # `type_params`/`value` with no peer-name filtering whatsoever.
     source = """def outer(response):
     data: Payload = response.json()
@@ -1909,7 +1911,7 @@ def test_autofix_follows_closure_into_type_alias_value() -> None:
 
 
 def test_autofix_follows_closure_into_generic_functions_own_annotation_despite_body_shadowing() -> None:
-    # Regression: a PEP 695 generic function's parameter/return annotations
+    # a PEP 695 generic function's parameter/return annotations
     # run in the type parameters' own implicit scope, not the function's own
     # body/parameter scope — confirmed against CPython that a body-local
     # reassignment of the annotated name has no effect on what the
@@ -2182,7 +2184,7 @@ def test_repeated_binding_leaves_the_file_unchanged() -> None:
 
 
 def test_autofix_replaces_name_on_line_with_non_ascii_text() -> None:
-    # Regression: ast.col_offset is a UTF-8 byte offset, not a character
+    # ast.col_offset is a UTF-8 byte offset, not a character
     # offset. Non-ASCII text earlier on the same line as the meaningless
     # name must not throw off the position used to locate and replace it.
     source = """import requests
@@ -2211,7 +2213,7 @@ def process():
 
 
 def test_check_reports_character_offset_not_byte_offset_before_multibyte_text() -> None:
-    # Regression: ast.col_offset is a UTF-8 *byte* offset, not a character
+    # ast.col_offset is a UTF-8 *byte* offset, not a character
     # offset -- storing it on Violation.col directly reports a column too
     # far right on any line with non-ASCII text before the violation
     # (ch. 7: "MUST report ... column information accurately"; ch. 20:
@@ -2253,7 +2255,7 @@ def other():
 
     with caplog.at_level("DEBUG"):
         assert check.fix(filepath, violations, source, tree) is False
-    # Regression: the write failure must be attributed to the violations it
+    # the write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again. A

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -1420,10 +1420,11 @@ def test_autofix_renames_walrus_target_inside_default_evaluated_in_enclosing_sco
     # `_binds_name_in_nested_scope()` must scan only the nested
     # function's *own* scope, not its `_outer_scope_children()` (decorators,
     # defaults, annotations without type params) — those run in the
-    # *enclosing* scope. A walrus target inside a default value must not
-    # be treated as a body-level shadow, or the default would get renamed
-    # while the body's closure read was left stale, splitting one variable
-    # into two and breaking the fixed code at runtime.
+    # *enclosing* scope (see ADR 0023 for this rename-safety scope model).
+    # A walrus target inside a default value must not be treated as a
+    # body-level shadow, or the default would get renamed while the
+    # body's closure read was left stale, splitting one variable into two
+    # and breaking the fixed code at runtime.
     source = """def outer(response):
     data: Payload = response.json()
 
@@ -1796,14 +1797,12 @@ def test_autofix_does_not_reuse_a_nested_functions_own_mapping_for_its_default()
 
 
 def test_autofix_does_not_rename_a_nested_functions_own_type_parameter_bound_via_its_own_scope() -> None:
-    # Same root cause as the test above, but reached through
-    # `inner`'s own type parameter bound instead of a default — the
-    # violation here is `data`'s reassignment inside `inner`'s own body, so
-    # `_collect_scope_replacements()` is entered directly on `inner`. Its
-    # child walk must not reach into `inner.type_params` too, or it would
-    # rename `T`'s bound (which references the peer type parameter `data`,
-    # unaffected by the body-local reassignment) to a name nothing else
-    # binds.
+    # `data`'s reassignment inside `inner`'s own body causes
+    # `_collect_scope_replacements()` to be entered directly on `inner`.
+    # Its child walk must not reach into `inner.type_params` too, or it
+    # would rename `T`'s bound (which references the peer type parameter
+    # `data`, unaffected by the body-local reassignment) to a name nothing
+    # else binds.
     source = """def outer(response):
     def inner[data, T: data](response2):
         data = response2.json()

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -135,10 +135,11 @@ def test_fix_is_noop_when_nothing_to_fix(source: str, tmp_path: Path) -> None:
     ids=["inline-placement", "preceding-placement"],
 )
 def test_fix_preserves_crlf_on_touched_lines(source: str, fixed_source: str, tmp_path: Path) -> None:
-    # Regression: fix() used to hardcode "\n" when rewriting the expression
-    # and bracket lines, silently converting a CRLF file's touched lines to
-    # LF (ch. 3: "MUST preserve the intended newline convention"; ch. 21:
-    # "MUST NOT unexpectedly reformat unrelated code").
+    # fix() must not hardcode "\n" when rewriting the expression
+    # and bracket lines -- that would silently convert a CRLF file's
+    # touched lines to LF (ch. 3: "MUST preserve the intended newline
+    # convention"; ch. 21: "MUST NOT unexpectedly reformat unrelated
+    # code").
     test_file = tmp_path / "test.py"
     test_file.write_bytes(source.encode())
     tree = ast.parse(source)
@@ -150,11 +151,12 @@ def test_fix_preserves_crlf_on_touched_lines(source: str, fixed_source: str, tmp
 
 
 def test_check_and_fix_detect_comment_on_cr_only_source(tmp_path: Path) -> None:
-    # Regression: tokenize couldn't see a COMMENT token at all on an
-    # old-Mac-style CR-only file (io.StringIO.readline() doesn't split on a
-    # lone \r), so the violation went completely undetected — not just
-    # misplaced, invisible. Also confirms the fix preserves the CR-only
-    # convention on the lines it touches, same as the CRLF case above.
+    # tokenize can't see a COMMENT token at all on an old-Mac-style
+    # CR-only file (io.StringIO.readline() doesn't split on a lone \r), so
+    # the violation must still be detected here rather than going
+    # completely undetected — not just misplaced, invisible. Also confirms
+    # the fix preserves the CR-only convention on the lines it touches,
+    # same as the CRLF case above.
     source = "foo(\r    bar,\r)  # comment\r"
     test_file = tmp_path / "test.py"
     test_file.write_bytes(source.encode())
@@ -168,8 +170,9 @@ def test_check_and_fix_detect_comment_on_cr_only_source(tmp_path: Path) -> None:
 
 
 def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # Regression: fix() used to let atomic_write_text()'s OSError propagate
-    # uncaught instead of returning False like every other check's fix().
+    # fix() must catch atomic_write_text()'s OSError and return False,
+    # like every other check's fix(), instead of letting it propagate
+    # uncaught.
     source = "result = func(\n    arg\n)  # Comment here\n"
 
     # Point at a path inside a directory that doesn't exist so the
@@ -182,7 +185,7 @@ def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptu
 
     with caplog.at_level("DEBUG"):
         assert check.fix(filepath, violations, source, tree) is False
-    # Regression: the write failure must be attributed to the violations it
+    # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -77,15 +77,15 @@ def test_expand_directories_globs_python_files_outside_a_git_repo(tmp_path: Path
 
 
 def test_expand_directories_uses_git_ls_files_inside_a_git_repo(tmp_path: Path) -> None:
-    # Regression: a directory argument (e.g. `ruff-extra-rules src/`, the
-    # form this project's own dev docs use — see AGENTS.md) used to reach
-    # CheckOrchestrator.process_files() as a single unexpanded path. Inside
-    # a git repo, git grep's own directory pathspec support made it recurse
-    # and match files *inside* that directory, but those resolved paths
-    # never matched the literal directory path in git_grep_filter's own
-    # input map, so every result was silently discarded as unresolvable —
-    # the run reported zero violations, exit code 0, having checked
-    # nothing.
+    # A directory argument (e.g. `ruff-extra-rules src/`, the
+    # form this project's own dev docs use — see AGENTS.md) must not reach
+    # CheckOrchestrator.process_files() as a single unexpanded path.
+    # Inside a git repo, git grep's own directory pathspec support makes
+    # it recurse and match files *inside* that directory, but those
+    # resolved paths never match the literal directory path in
+    # git_grep_filter's own input map, so every result would be silently
+    # discarded as unresolvable — the run would report zero violations,
+    # exit code 0, having checked nothing.
     git = shutil.which("git")
     assert git is not None
 
@@ -100,10 +100,10 @@ def test_expand_directories_uses_git_ls_files_inside_a_git_repo(tmp_path: Path) 
 
 
 def test_expand_directories_includes_untracked_file_inside_a_git_repo(tmp_path: Path) -> None:
-    # Regression (#67): a brand-new file that hasn't been `git add`ed yet
-    # used to be silently dropped from a directory-argument expansion, even
-    # though git_grep_filter already always searches that same file when
-    # it's named explicitly on the CLI instead (ADR 0024's
+    # A brand-new file that hasn't been `git add`ed yet must not be
+    # silently dropped from a directory-argument expansion, even though
+    # git_grep_filter already always searches that same file when it's
+    # named explicitly on the CLI instead (ADR 0024's
     # `--untracked --no-exclude-standard`) — naming the containing
     # directory must not produce a different, false-clean result for the
     # identical file.
@@ -175,11 +175,11 @@ def test_expand_directories_warns_about_an_ignored_directory_with_an_unrecognize
 def test_expand_directories_does_not_warn_about_known_non_source_directories(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression (ADR 0029): __pycache__/, *.egg-info/, and .cache/ get
-    # created by this project's own routine `pytest`/`build`/`uv sync`
-    # commands, so warning about them unconditionally fired on essentially
-    # every directory-argument run -- none of them is ever used for
-    # hand-written source, so all are excluded from this warning.
+    # __pycache__/, *.egg-info/, and .cache/ get created by this
+    # project's own routine `pytest`/`build`/`uv sync` commands (see ADR
+    # 0029), so warning about them unconditionally would fire on
+    # essentially every directory-argument run -- none of them is ever
+    # used for hand-written source, so all are excluded from this warning.
     git = shutil.which("git")
     assert git is not None
 
@@ -210,7 +210,7 @@ def test_expand_directories_does_not_warn_about_known_non_source_directories(
 def test_expand_directories_does_not_warn_about_ruff_cache_even_though_its_own_gitignore_is_nested(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression (ADR 0029): unlike __pycache__/.cache/etc., `.ruff_cache`
+    # Unlike __pycache__/.cache/etc. (see ADR 0029), `.ruff_cache`
     # isn't named in a top-level .gitignore at all -- ruff writes its own
     # nested `.ruff_cache/.gitignore` containing `*`, which is what makes
     # `git status --ignored` collapse the directory to a single ignored-
@@ -238,7 +238,7 @@ def test_expand_directories_does_not_warn_about_ruff_cache_even_though_its_own_g
 def test_expand_directories_warns_about_ignored_file_regardless_of_status_showuntrackedfiles_config(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression: `git status`'s own `--ignored` reporting is otherwise
+    # `git status`'s own `--ignored` reporting is otherwise
     # governed by the ambient `status.showUntrackedFiles` config -- "no"
     # suppresses every `!!` record, silently defeating this warning's whole
     # purpose for a user who's set that (a real, documented git setting),
@@ -264,7 +264,7 @@ def test_expand_directories_warns_about_ignored_file_regardless_of_status_showun
 def test_expand_directories_caps_gitignore_warning_at_a_bounded_number_of_paths(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression: a directory that isn't *entirely* ignored (e.g. a
+    # A directory that isn't *entirely* ignored (e.g. a
     # generated/ subtree with one tracked file alongside many individually
     # -ignored `.py` outputs) can't collapse to a single git-status line --
     # each ignored path is reported separately. The warning must stay
@@ -340,7 +340,7 @@ def test_expand_directories_skips_gitignore_warning_when_git_status_probe_is_unr
 
 
 def test_expand_directories_skips_tracked_file_deleted_from_working_tree(tmp_path: Path) -> None:
-    # Regression: `git ls-files` reports the *index*, not the working tree
+    # `git ls-files` reports the *index*, not the working tree
     # -- a tracked file removed from disk with a plain `rm` (not `git rm`)
     # still shows up in its output even though it no longer exists. A
     # directory scan isn't asking about that specific file by name, so a
@@ -375,8 +375,8 @@ def test_expand_directories_falls_back_when_git_ls_files_fails(
         matches = expand_directories([str(tmp_path)])
 
     assert matches == [str(py_file.resolve())]
-    # Regression: this is self-healing (falls back to an equivalent glob
-    # scan), so an ERROR-level .exception() call here used to leak a raw
+    # This is self-healing (falls back to an equivalent glob
+    # scan), so an ERROR-level .exception() call here would leak a raw
     # traceback onto the user's stderr by default (nothing in this codebase
     # configures logging, so Python's own lastResort handler prints
     # WARNING+ straight to stderr) for a condition nothing actually failed
@@ -385,7 +385,7 @@ def test_expand_directories_falls_back_when_git_ls_files_fails(
 
 
 def test_expand_directories_includes_a_file_with_a_non_utf8_name(tmp_path: Path) -> None:
-    # Regression: `git ls-files -z`'s stdout is decoded via `text=True`. A
+    # `git ls-files -z`'s stdout is decoded via `text=True`. A
     # filename that's a valid path on Linux (paths are just bytes, never
     # required to be valid UTF-8) but isn't decodable as UTF-8 must not
     # crash a directory scan that contains it -- `errors="surrogateescape"`
@@ -433,10 +433,9 @@ def test_main_directory_argument_checks_files_inside_it(tmp_path: Path, capsys: 
 def test_main_directory_argument_matches_explicit_file_argument_for_untracked_file(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Regression (#67): reproduces the issue's own repro exactly — an
-    # untracked file's violation must be reported the same way whether it's
-    # named explicitly or reached by expanding its containing directory.
-    # Before the fix, only the explicit-file run below caught it.
+    # An untracked file's violation must be reported the same way whether
+    # it's named explicitly or reached by expanding its containing
+    # directory.
     git = shutil.which("git")
     assert git is not None
 
@@ -454,7 +453,7 @@ def test_main_directory_argument_matches_explicit_file_argument_for_untracked_fi
 
 
 def test_main_directory_scan_does_not_crash_on_a_file_with_a_non_utf8_name(tmp_path: Path) -> None:
-    # Regression: expand_directories() safely includes a file whose name
+    # expand_directories() safely includes a file whose name
     # isn't valid UTF-8 (see test_expand_directories_includes_a_file_with_a_
     # non_utf8_name), but that file still has to survive _prefilter.py's own
     # git_grep_filter() call once meaningless-vars' prefilter pattern runs against
@@ -540,7 +539,7 @@ def test_apply_fixes_recomputes_stale_positions(tmp_path: Path) -> None:
 
 
 def test_apply_fixes_refreshes_non_fixable_checks_position_too(tmp_path: Path) -> None:
-    # Regression: only checks that themselves had a fixable violation this
+    # only checks that themselves had a fixable violation this
     # run got their positions recomputed against the file's post-fix state.
     # redundant-super-init is never fixable (RedundantSuperInitCheck.fix()
     # always returns False), so it never participated in that loop -- its
@@ -579,7 +578,7 @@ def test_apply_fixes_refreshes_non_fixable_checks_position_too(tmp_path: Path) -
 
 
 def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tmp_path: Path) -> None:
-    # Regression: a check that *did* participate in the fix loop (it had
+    # a check that *did* participate in the fix loop (it had
     # some fixable violation this run) only had its own positions
     # recomputed once, immediately before its own fix() call -- a violation
     # it left open that call (e.g. validate-function-name's should_autofix
@@ -630,7 +629,7 @@ def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tm
 def test_refresh_stale_positions_never_drops_an_unrelated_open_violation_sharing_a_check_id_with_a_terminal_one(
     tmp_path: Path,
 ) -> None:
-    # Regression: a check_id with a rejected/errored/failed entry must be
+    # a check_id with a rejected/errored/failed entry must be
     # skipped entirely by the reconciliation pass, not just have that one
     # terminal entry protected -- a fresh check() call has no reliable way
     # to distinguish "this is the same still-present violation as the
@@ -781,16 +780,16 @@ def test_process_files_no_candidates_after_prefilter_returns_empty(
 
 
 def test_process_files_none_pattern_check_still_sees_a_file_other_checks_patterns_miss(tmp_path: Path) -> None:
-    # Regression (#46): combining every enabled check's own prefilter
-    # pattern into one OR'd filter before running any check dropped a file
-    # for every check whenever it failed to match ANY enabled check's
-    # pattern -- including excessive-blank-lines, whose own
-    # get_prefilter_pattern() returns None (see
-    # test_process_files_no_prefilter_pattern_checks_all_files) precisely so
-    # it sees every file regardless of what else is enabled. This file has a
-    # real excessive-blank-lines violation but contains none of meaningless-vars'
-    # own patterns ("data"/"result"), so the old combined filter dropped it
-    # before it was ever parsed.
+    # Each enabled check's own prefilter pattern must gate that check
+    # individually -- combining them into one OR'd filter before running
+    # any check would drop a file for every check whenever it failed to
+    # match ANY enabled check's pattern, including excessive-blank-lines,
+    # whose own get_prefilter_pattern() returns None (see
+    # test_process_files_no_prefilter_pattern_checks_all_files) precisely
+    # so it sees every file regardless of what else is enabled. This file
+    # has a real excessive-blank-lines violation but contains none of
+    # meaningless-vars' own patterns ("data"/"result"), so a combined
+    # filter would drop it before it was ever parsed.
     filepath = tmp_path / "module.py"
     filepath.write_text('"""Doc."""\n\n\n\nclass Foo:\n    pass\n')
 
@@ -803,7 +802,7 @@ def test_process_files_none_pattern_check_still_sees_a_file_other_checks_pattern
 def test_process_files_applies_each_checks_prefilter_independently(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression (#46): a file must only run through a check whose own
+    # A file must only run through a check whose own
     # prefilter pattern it actually matches -- not through every enabled
     # check merely because some *other* check's pattern matched. This file
     # contains meaningless-vars' own pattern ("data") but not
@@ -847,11 +846,11 @@ def test_process_files_unreadable_file_is_skipped(tmp_path: Path, write_file: Ca
 
 
 def test_process_files_records_unprocessable_file(tmp_path: Path) -> None:
-    # Regression: a file _check_file() can't parse used to vanish from the
-    # result with no trace at all — indistinguishable from a clean file with
-    # zero violations. ExcessiveBlankLinesCheck has no prefilter pattern (see
-    # its get_prefilter_pattern()), so the file reaches _check_file()
-    # regardless of its content.
+    # A file _check_file() can't parse must not vanish from the
+    # result with no trace at all — that would be indistinguishable from a
+    # clean file with zero violations. ExcessiveBlankLinesCheck has no
+    # prefilter pattern (see its get_prefilter_pattern()), so the file
+    # reaches _check_file() regardless of its content.
     filepath = tmp_path / "module.py"
     filepath.write_text("def foo(:\n")
 
@@ -941,10 +940,9 @@ def test_process_files_different_check_set_forces_recheck(tmp_path: Path) -> Non
 
 
 def test_generate_cache_key_changes_when_source_tree_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Regression: replaces the hand-bumped CACHE_VERSION that a developer
-    # had to remember to update whenever a check's own code changed
-    # (commit 0e3efba). The cache key must change on its own when the
-    # hashed source tree changes, without anyone bumping anything.
+    # The cache key must change on its own when the hashed source tree
+    # changes, without a developer having to remember to hand-bump
+    # CACHE_VERSION whenever a check's own code changes.
     fake_root = tmp_path / "pre_commit_hooks"
     fake_root.mkdir()
     (fake_root / "module.py").write_text("x = 1\n")
@@ -1020,10 +1018,11 @@ def test_process_files_check_exception_is_logged_and_skipped(tmp_path: Path, mon
 
 
 def test_process_files_check_exception_records_rule_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Regression: a check whose check() raises used to leave no trace at all
-    # outside a debug log line — indistinguishable from that check having
-    # run cleanly and found nothing. If it's the only check enabled, this
-    # used to make the whole file (and the whole run) look completely clean.
+    # A check whose check() raises must not leave no trace at all outside
+    # a debug log line — that would be indistinguishable from that check
+    # having run cleanly and found nothing. If it's the only check
+    # enabled, that would make the whole file (and the whole run) look
+    # completely clean.
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -1163,9 +1162,9 @@ class _CrashingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
 def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a_cacheable_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: a combined had_rule_failure flag used to gate caching on
-    # whether *any* check in this call crashed, cacheable or not -- so an
-    # always-rerun check's own crash silently disabled caching for an
+    # A combined had_rule_failure flag must not gate caching on whether
+    # *any* check in this call crashed, cacheable or not -- that would let
+    # an always-rerun check's own crash silently disable caching for an
     # unrelated, successfully-completed cacheable check sharing the same
     # file, forcing it to be needlessly recomputed on every future run.
     filepath = tmp_path / "module.py"
@@ -1430,13 +1429,13 @@ def test_apply_fixes_skips_check_with_no_fixable_violations(tmp_path: Path) -> N
 
 
 def test_apply_fixes_does_not_mark_fixed_a_violation_fix_left_untouched(tmp_path: Path) -> None:
-    # Regression: validate-function-name's fix() loops over violations and
+    # validate-function-name's fix() loops over violations and
     # can skip some (should_autofix refuses to rename methods) while fixing
-    # others in the same call. _apply_fixes used to mark every violation of
-    # a check as fixed whenever fix() returned True at all, regardless of
-    # whether that specific violation was actually touched — a rename that
-    # should_autofix skipped was reported [FIXED] even though the file
-    # still had the old name.
+    # others in the same call. _apply_fixes must not mark every violation
+    # of a check as fixed just because fix() returned True at all,
+    # regardless of whether that specific violation was actually touched —
+    # a rename that should_autofix skips must not be reported [FIXED]
+    # while the file still has the old name.
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import json\n\n\n"
@@ -1467,7 +1466,7 @@ def test_apply_fixes_does_not_mark_fixed_a_violation_fix_left_untouched(tmp_path
 
 
 def test_apply_fixes_distinguishes_violations_with_identical_messages(tmp_path: Path) -> None:
-    # Regression: a free function and an unrelated method can produce
+    # a free function and an unrelated method can produce
     # byte-identical violation messages (same func_name, same suggested
     # name, same reason). Marking "fixed" by message text alone would lose
     # their identity — after the free function is renamed, its own old
@@ -1575,7 +1574,7 @@ def test_apply_fixes_marks_violation_errored_when_fix_raises_unexpectedly(
 def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: a check that writes more than once per fix() call
+    # a check that writes more than once per fix() call
     # (looping over violations individually, like validate_function_name)
     # can commit some violations before a later write raises. Marking every
     # violation in the batch [FIX ERRORED] regardless would misreport an
@@ -1633,7 +1632,7 @@ def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
 def test_apply_fixes_records_rule_failure_when_fix_raises_after_resolving_everything(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: if fix() commits every requested edit successfully and
+    # if fix() commits every requested edit successfully and
     # then raises afterwards (e.g. during unrelated cleanup), every
     # violation ends up correctly marked [FIXED] and none are left to mark
     # [FIX ERRORED] — but the exception itself must still be recorded
@@ -1717,7 +1716,7 @@ def test_apply_fixes_marks_only_the_rejected_violation_of_a_multi_write_check(
 def test_apply_fixes_marks_errored_violation_of_a_multi_write_check_when_apply_fix_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: validate-function-name's own fix() already catches any
+    # validate-function-name's own fix() already catches any
     # exception apply_fix() raises other than FixValidationError internally
     # (logging it and moving on to the next violation), so it never
     # propagates to CheckOrchestrator._apply_fixes' own [FIX ERRORED]
@@ -1904,9 +1903,9 @@ def test_load_checks_ignore_set_skips_matching_check() -> None:
 
 
 def test_load_checks_ignore_composes_with_select() -> None:
-    # Regression: `select` used to make `ignore` a no-op entirely (an
-    # `elif` instead of two independent checks), so `--select`+`--ignore`
-    # couldn't be combined the way `ruff check --select`/`--ignore` can.
+    # `select` must not make `ignore` a no-op entirely (an
+    # `elif` instead of two independent checks) -- `--select`+`--ignore`
+    # must be composable, the way `ruff check --select`/`--ignore` can be.
     checks = load_checks(select={"meaningless-vars", "redundant-super-init"}, ignore={"meaningless-vars"})
     assert {c.check_id for c in checks} == {"redundant-super-init"}
 
@@ -2005,11 +2004,11 @@ def test_main_verbose_flag_does_not_change_a_clean_runs_exit_code(tmp_path: Path
 def test_main_unparseable_file_returns_one(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression: an unparseable file used to be silently dropped with exit
-    # code 0 — indistinguishable from a clean run with nothing to report.
-    # Content includes "data" so the file clears every check's prefilter
-    # pattern and actually reaches parsing rather than being dropped as a
-    # non-candidate beforehand.
+    # An unparseable file must not be silently dropped with exit
+    # code 0 — that would be indistinguishable from a clean run with
+    # nothing to report. Content includes "data" so the file clears every
+    # check's prefilter pattern and actually reaches parsing rather than
+    # being dropped as a non-candidate beforehand.
     filepath = tmp_path / "broken.py"
     filepath.write_text("data = foo(:\n")
 
@@ -2026,16 +2025,17 @@ def test_main_unparseable_file_returns_one(
 def test_main_permission_denied_file_returns_one_inside_git_repo(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Regression: inside a real git repo, the prefilter's `git grep`
+    # Inside a real git repo, the prefilter's `git grep`
     # subprocess (not the Python-only fallback the other tmp_path-based
-    # tests exercise, since they aren't git repos) used to report a
+    # tests exercise, since they aren't git repos) reports a
     # permission-denied file only via a "failed to stat" line on its own
     # stderr, without changing its exit code for the files it *could*
-    # read. main() never inspected that stderr, so the file was silently
-    # dropped before ever reaching _check_file — the whole run reported
-    # exit code 0, as if the file never existed. MeaninglessVarsCheck has a
-    # prefilter pattern ("data" is one of its meaningless names), so this
-    # only reproduces via the check that actually calls into git grep.
+    # read. main() must inspect that stderr — otherwise the file would be
+    # silently dropped before ever reaching _check_file, and the whole run
+    # would report exit code 0, as if the file never existed.
+    # MeaninglessVarsCheck has a prefilter pattern ("data" is one of its
+    # meaningless names), so this only exercises the check that actually
+    # calls into git grep.
     git = shutil.which("git")
     assert git is not None
 
@@ -2061,9 +2061,9 @@ def test_main_permission_denied_file_returns_one_inside_git_repo(
 def test_main_check_crash_returns_one_and_reports_check_and_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Regression: a check that crashes on every file it sees used to make
-    # the whole run look clean (exit code 0, nothing printed) whenever no
-    # other check reported a violation for the same files.
+    # A check that crashes on every file it sees must not make the whole
+    # run look clean (exit code 0, nothing printed) just because no other
+    # check reported a violation for the same files.
     monkeypatch.setattr(MeaninglessVarsCheck, "check", raises(ValueError, "simulated check failure"))
 
     filepath = tmp_path / "module.py"
@@ -2099,11 +2099,11 @@ def test_main_reports_non_fixable_violation(tmp_path: Path, capsys: pytest.Captu
 
 def test_main_reports_column_alongside_line(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     # Violation.col is computed accurately (meaningless-vars reports the assigned
-    # name's own ast.col_offset, converted to a character offset) but
-    # main()'s printed line used to drop it entirely, reporting only the
-    # line -- ch. 7: "MUST report line and column information accurately
-    # when available". "data" starts at the 0-indexed character offset 4;
-    # main() reports the conventional 1-based column, 5.
+    # name's own ast.col_offset, converted to a character offset), and
+    # main()'s printed line must include it, not just the line -- ch. 7:
+    # "MUST report line and column information accurately when available".
+    # "data" starts at the 0-indexed character offset 4; main() reports
+    # the conventional 1-based column, 5.
     filepath = tmp_path / "module.py"
     filepath.write_text("def process():\n    data = requests.get(url)\n    return data\n")
 
@@ -2262,12 +2262,12 @@ def test_main_fix_flag_reports_failed_fix(
 def test_main_reports_rule_failure_when_reread_fails_mid_fix_loop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Regression: _apply_fixes() re-reads the file before recomputing each
+    # _apply_fixes() re-reads the file before recomputing each
     # check's fresh violations (a previous check's fix in the same loop may
-    # have already modified it). If that re-read itself fails, the loop used
-    # to just `continue` with zero signal anywhere -- the stale violation
-    # was left unmarked and reported as an ordinary [FIXABLE], as if --fix
-    # had never even been attempted for it.
+    # have already modified it). If that re-read itself fails, the loop
+    # must not just `continue` with zero signal anywhere -- otherwise the
+    # stale violation would be left unmarked and reported as an ordinary
+    # [FIXABLE], as if --fix had never even been attempted for it.
     original_read_source = CheckOrchestrator._read_source
     calls = 0
 
@@ -2314,12 +2314,13 @@ def test_main_reports_rule_failure_when_recompute_raises_mid_fix_loop(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # Regression: _apply_fixes() recomputes fresh violations via check.check()
+    # _apply_fixes() recomputes fresh violations via check.check()
     # against the current file state before calling check.fix(). If that
-    # recompute itself raises, only the broad outer `except Exception` used
-    # to catch it -- logging the exception but never recording a
-    # rule_failure or marking any violation, so the run could look
-    # completely clean depending on what else was reported for the file.
+    # recompute itself raises, it must not be left to only the broad outer
+    # `except Exception` to catch -- that would log the exception but
+    # never record a rule_failure or mark any violation, so the run could
+    # look completely clean depending on what else was reported for the
+    # file.
     original_check = MeaninglessVarsCheck.check
     calls = 0
 
@@ -2373,7 +2374,7 @@ def test_main_reports_rule_failure_when_fix_raises_after_resolving_everything(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # Regression: fix() can commit every requested edit and then raise
+    # fix() can commit every requested edit and then raise
     # afterwards (e.g. during unrelated cleanup) — every violation ends up
     # correctly reported [FIXED], but the exception itself must still
     # surface in the run's own output, or a genuine internal failure would
@@ -2589,13 +2590,13 @@ def test_main_ignoring_all_checks_returns_one(tmp_path: Path, capsys: pytest.Cap
 def test_main_trailing_comma_does_not_report_blank_unknown_check(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], flag: str, meaningless_vars_runs: bool
 ) -> None:
-    # Regression: a trailing comma left an empty string in the parsed set,
+    # A trailing comma must not leave an empty string in the parsed set,
     # reported as a confusing blank "Unknown checks: " instead of being
-    # tolerated like --exclude's own comma list already is. Asserting on the
-    # TR1 violation itself (not just the exit code) is what actually
-    # proves meaningless-vars was recognized: both the fixed and the reverted
-    # behavior exit 1 for --select (a real violation vs. the old bogus
-    # "Unknown checks" error), so the exit code alone can't tell them apart.
+    # tolerated like --exclude's own comma list already is. Asserting on
+    # the TR1 violation itself (not just the exit code) is what actually
+    # proves meaningless-vars was recognized: a bogus "Unknown checks"
+    # error would also exit 1 for --select (masking a real violation), so
+    # the exit code alone can't tell the two apart.
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -2622,7 +2623,7 @@ def test_main_select_only_commas_reports_no_checks_enabled(tmp_path: Path, capsy
 
 
 def test_main_select_and_ignore_compose(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    # Regression: `--select`+`--ignore` together used to behave like
+    # `--select`+`--ignore` together must not behave like
     # `--select` alone, silently dropping `--ignore` (see
     # `test_load_checks_ignore_composes_with_select`).
     filepath = tmp_path / "module.py"
@@ -2669,10 +2670,7 @@ def test_fix_converges_after_one_pass_across_all_checks(fixture_path: Path, tmp_
     # to a stable result"; "MUST test fix idempotence explicitly". Runs
     # --fix (every check together, matching real pre-commit/prek usage)
     # twice over every existing bad/*.py fixture and asserts the second
-    # pass leaves the file exactly as the first pass did. Previously this
-    # was only ever verified once, ad hoc, by docs/audits/0002's own manual
-    # spot-check script -- never as a committed regression test that would
-    # actually catch a future fix-cycle regression.
+    # pass leaves the file exactly as the first pass did.
     target = tmp_path / fixture_path.name
     target.write_text(fixture_path.read_text(encoding="utf-8"), encoding="utf-8")
 
@@ -2696,12 +2694,11 @@ def test_main_handles_path_containing_spaces_and_unicode(
     # other test in this file uses it) makes `git grep` error out and
     # silently fall back to the Python-only path instead, which has no
     # subprocess argument-passing to prove safe in the first place, and would
-    # still produce the same passing result -- hiding exactly the regression
-    # this test exists to catch. Spies on the real subprocess.run (still
-    # executed for real, never mocked out) to confirm git grep itself
-    # actually received and matched this path rather than silently falling
-    # back. Only ever verified ad hoc before this (prose in
-    # docs/audits/0006), never as a committed regression test.
+    # still produce the same passing result -- silently masking exactly
+    # the bug this test exists to catch. Spies on the real subprocess.run
+    # (still executed for real, never mocked out) to confirm git grep
+    # itself actually received and matched this path rather than silently
+    # falling back.
     git = shutil.which("git")
     assert git is not None
 
@@ -2753,14 +2750,10 @@ def test_main_handles_path_containing_spaces_and_unicode(
 
 
 def test_process_files_handles_a_large_file(tmp_path: Path) -> None:
-    # ch. 31: "MUST test large files." The only prior evidence this pipeline
-    # behaves correctly on a large file was an ad hoc manual benchmark
-    # recorded as prose in docs/audits/0004 (a 2000-function/120KB file) --
-    # never committed as a regression test. This is a correctness check, not
-    # a performance benchmark (ch. 24/30's own concern, already covered by
-    # 0004's fix and its unit-level regression tests) -- it only proves every
-    # violation in a large file is still found and fixed correctly, with
-    # nothing dropped, corrupted, or left unprocessed.
+    # ch. 31: "MUST test large files." This is a correctness check, not a
+    # performance benchmark (ch. 24/30's own concern) -- it only proves
+    # every violation in a large file is still found and fixed correctly,
+    # with nothing dropped, corrupted, or left unprocessed.
     function_count = 300
     source = "import requests\n\n" + "\n\n".join(
         f"def func_{i}():\n    data = requests.get(url)\n    return data.status_code" for i in range(function_count)

--- a/tests/test_prefilter.py
+++ b/tests/test_prefilter.py
@@ -97,13 +97,13 @@ def test_git_grep_filter_real_success_and_no_match_paths(tmp_path: Path) -> None
 
 
 def test_git_grep_filter_includes_permission_denied_tracked_file(tmp_path: Path) -> None:
-    # Regression: `git grep` reports a permission-denied file only as an
+    # `git grep` reports a permission-denied file only as an
     # "error: failed to stat" line on stderr -- it still exits 0 (if
     # another requested file matched) or 1 (if none did), the same exit
-    # codes as an ordinary match/non-match. The old code only ever looked
-    # at stdout, so this file silently vanished from the candidate list:
-    # never checked, never reported, and the whole run could exit 0 as if
-    # it had never existed.
+    # codes as an ordinary match/non-match. Looking only at stdout would
+    # silently vanish this file from the candidate list: never checked,
+    # never reported, and the whole run could exit 0 as if it had never
+    # existed.
     git = shutil.which("git")
     assert git is not None
 
@@ -121,13 +121,14 @@ def test_git_grep_filter_includes_permission_denied_tracked_file(tmp_path: Path)
 
 
 def test_git_grep_filter_includes_file_deleted_since_discovery(tmp_path: Path) -> None:
-    # Regression: a file that's vanished between the caller's file list
+    # A file that's vanished between the caller's file list
     # being built and this call (e.g. deleted after pre-commit computed
     # the changed-file list but before this hook ran) produces *no*
     # signal from `git grep` at all -- exit code 1, empty stdout, empty
     # stderr, indistinguishable from "pattern genuinely absent from an
-    # existing file". The old code trusted that silence as proof of "no
-    # match" and dropped the file with no trace.
+    # existing file". That silence must not be trusted as proof of "no
+    # match" -- the file must still be kept as a candidate rather than
+    # dropped with no trace.
     git = shutil.which("git")
     assert git is not None
 
@@ -142,11 +143,11 @@ def test_git_grep_filter_includes_file_deleted_since_discovery(tmp_path: Path) -
 
 
 def test_git_grep_filter_includes_untracked_file(tmp_path: Path) -> None:
-    # Regression: a file that exists, is readable, and was passed
+    # A file that exists, is readable, and was passed
     # explicitly, but was never `git add`ed, is invisible to a plain `git
     # grep` -- it exits 1 with empty stdout *and* empty stderr, identical
-    # to "searched and found no match". The old code trusted that as proof
-    # of "no match" and silently dropped the file, so a brand-new file
+    # to "searched and found no match". That must not be trusted as proof
+    # of "no match" and silently dropped -- otherwise a brand-new file
     # linted directly via the CLI (before `git add`) could report zero
     # violations for content that was never actually examined.
     git = shutil.which("git")
@@ -165,7 +166,7 @@ def test_git_grep_filter_includes_untracked_file(tmp_path: Path) -> None:
 
 
 def test_git_grep_filter_includes_gitignored_file(tmp_path: Path) -> None:
-    # Regression: same root cause as the untracked case above, but for a
+    # The same root cause as the untracked case above, but for a
     # file matched by .gitignore -- explicitly naming a file on this hook's
     # own CLI must still check it, regardless of VCS ignore status.
     git = shutil.which("git")
@@ -184,8 +185,8 @@ def test_git_grep_filter_includes_gitignored_file(tmp_path: Path) -> None:
 
 
 def test_git_grep_filter_match_order_is_independent_of_hash_seed(tmp_path: Path) -> None:
-    # Regression: matches used to come from iterating an unordered `set` of
-    # git's own output paths, so the return order depended on
+    # Matches must not come from iterating an unordered `set` of
+    # git's own output paths -- that would make the return order depend on
     # PYTHONHASHSEED -- randomized per process by default -- rather than on
     # the input file order (ch. 9: "MUST NOT allow hash-table ... order to
     # affect the result"). Spawns real subprocesses with different explicit
@@ -291,11 +292,11 @@ def test_python_fallback_includes_unreadable_files(tmp_path: Path, caplog: pytes
         # Unreadable files are kept in; the hook itself surfaces the read error.
         assert str(file2) in matches
 
-    # Regression: both the git-unavailable fallback and this file's own
+    # Both the git-unavailable fallback and this file's own
     # unreadable-file fallback are self-healing (the caller already keeps
     # the file in as a candidate and the actual hook cleanly reports the
     # read failure downstream) -- logging them at ERROR/.exception() level
-    # used to leak a raw traceback onto the user's stderr by default
+    # would leak a raw traceback onto the user's stderr by default
     # (nothing in this codebase configures logging, so Python's own
     # lastResort handler prints WARNING+ straight to stderr), duplicating
     # and cluttering the clean diagnostic the hook already prints.

--- a/tests/test_redundant_type_conversion_integration.py
+++ b/tests/test_redundant_type_conversion_integration.py
@@ -77,13 +77,12 @@ def test_cross_file_call_site_conversion_is_not_flagged_at_conservative() -> Non
 
 
 def test_redundant_conversion_is_still_flagged_despite_an_unrelated_error_shifting_on_the_same_line() -> None:
-    # Regression: an unrelated, pre-existing diagnostic later on the same
+    # An unrelated, pre-existing diagnostic later on the same
     # line (here, a genuinely wrong second call argument) keeps its exact
     # code/message after the conversion is spliced out, but its own
     # column position shifts left by however many characters were
-    # removed. Treating that shift as "a new diagnostic" used to make
-    # this candidate's own genuinely redundant conversion look unsafe to
-    # flag.
+    # removed. Treating that shift as "a new diagnostic" would make this
+    # candidate's own genuinely redundant conversion look unsafe to flag.
     violations = _check(BAD_ROOT / "unrelated_diagnostic_shifts_on_same_line.py")
 
     assert len(violations) == 1

--- a/tests/validate_function_name/test_analysis.py
+++ b/tests/validate_function_name/test_analysis.py
@@ -58,8 +58,8 @@ def test_attach_parents_handles_deeply_nested_source_without_recursion_error() -
     ("source", "func_name", "flags"),
     [
         (
-            # Regression case from .cache/bug_report.md: get_or_create
-            # updating a module-level cache must not be flagged as mutation.
+            # get_or_create updating a module-level cache must not be
+            # flagged as mutation.
             """
 import structlog
 from structlog.typing import FilteringBoundLogger

--- a/tests/validate_function_name/test_autofix.py
+++ b/tests/validate_function_name/test_autofix.py
@@ -245,7 +245,7 @@ def test_apply_fix_does_not_rename_unrelated_class_method(tmp_path: Path) -> Non
 
 
 def test_apply_fix_renames_recursive_call(tmp_path: Path) -> None:
-    # Regression: a recursive call inside the renamed function must not be
+    # A recursive call inside the renamed function must not be
     # mistaken for a nested definition that shadows the outer function.
     # Builds the Suggestion directly: this recursive counter doesn't match
     # any of process_file's behavioral heuristics, but apply_fix's own
@@ -271,7 +271,7 @@ def test_apply_fix_renames_recursive_call(tmp_path: Path) -> None:
 
 
 def test_apply_fix_updates_call_site_of_nested_target_function(tmp_path: Path) -> None:
-    # Regression: renaming a *nested* function must update its own call
+    # Renaming a *nested* function must update its own call
     # site within the enclosing function. The enclosing scope legitimately
     # contains a def matching the target's own name (it IS the target),
     # which must not be mistaken for an unrelated shadowing definition
@@ -323,7 +323,7 @@ def test_apply_fix_updates_free_function_call_sites(tmp_path: Path) -> None:
 def test_apply_fix_renames_call_site_on_line_with_non_ascii_text(
     tmp_path: Path,
 ) -> None:
-    # Regression: ast.col_offset is a UTF-8 byte offset, not a character
+    # ast.col_offset is a UTF-8 byte offset, not a character
     # offset. Non-ASCII text earlier on a call site's line must not throw
     # off the position used to rename it.
     test_file = tmp_path / "module.py"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and reworded test comments/docstrings covering edge cases for tokenization, Unicode/offset handling, CR/CRLF behavior, caching scenarios, autofix safety rationale, name binding, diagnostics stability, and file-handling behaviors.
  * Improved wording for regression explanations across redundancy, type-conversion, validate-function-name, and orchestration/CLI-related tests.

* **Tests**
  * No executable test logic, assertions, inputs, or expected outcomes were changed.

* **Chores**
  * Updated lint configuration to allow additional reviewer-feedback-related terms in titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->