### PR TITLE
fix(tr5): preserve assignments in try blocks

### DIFF
--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -415,19 +415,28 @@ class VariableTracker(ast.NodeVisitor):
             self.nonlocal_vars.add((scope_id, name))
         self.generic_visit(node)
 
+    def _visit_defaults(self, arguments: ast.arguments) -> None:
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
     def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         """Decorators are evaluated in the outer (enclosing) scope before the
         function body, so they must be visited before entering the new scope.
         """
         for decorator in node.decorator_list:
             self.visit(decorator)
+        self._visit_defaults(node.args)
 
         self._enter_scope()
+        try_depth = self.try_depth
+        self.try_depth = 0
 
         for stmt in node.body:
             self.visit(stmt)
             self._increment_stmt_index()
 
+        self.try_depth = try_depth
         self._exit_scope()
 
     visit_AsyncFunctionDef = visit_FunctionDef  # noqa: N815
@@ -482,11 +491,22 @@ class VariableTracker(ast.NodeVisitor):
         self.parent_stack.pop()
 
     def visit_Try(self, node: ast.Try | ast.TryStar) -> None:
+        self.parent_stack.append(node)
         self.control_flow_depth += 1
         self.try_depth += 1
-        self.generic_visit(node)
+        for stmt in node.body:
+            self.visit(stmt)
         self.try_depth -= 1
+
+        for handler in node.handlers:
+            self.visit(handler)
+        for stmt in node.orelse:
+            self.visit(stmt)
+        for stmt in node.finalbody:
+            self.visit(stmt)
+
         self.control_flow_depth -= 1
+        self.parent_stack.pop()
 
     visit_TryStar = visit_Try  # noqa: N815
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -481,12 +481,14 @@ class VariableTracker(ast.NodeVisitor):
         self.control_flow_depth -= 1
         self.parent_stack.pop()
 
-    def visit_Try(self, node: ast.Try) -> None:
+    def visit_Try(self, node: ast.Try | ast.TryStar) -> None:
         self.control_flow_depth += 1
         self.try_depth += 1
         self.generic_visit(node)
         self.try_depth -= 1
         self.control_flow_depth -= 1
+
+    visit_TryStar = visit_Try  # noqa: N815
 
     def visit_With(self, node: ast.With | ast.AsyncWith) -> None:
         # Each item's optional_vars (`as target`) rebinds on entry, same

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -34,6 +34,7 @@ class AssignmentInfo:
     has_type_annotation: bool = False
     in_loop: bool = False
     in_control_flow: bool = False
+    in_try: bool = False
     in_global_scope: bool = False
     has_comment_above: bool = False
     has_inline_comment: bool = False
@@ -334,6 +335,8 @@ class VariableTracker(ast.NodeVisitor):
         # if/try/with/match — excludes loops, tracked separately above.
         self.control_flow_depth = 0
 
+        self.try_depth = 0
+
         self.comprehension_depth = 0
 
         # A use inside a lambda body executes later (and possibly
@@ -480,7 +483,9 @@ class VariableTracker(ast.NodeVisitor):
 
     def visit_Try(self, node: ast.Try) -> None:
         self.control_flow_depth += 1
+        self.try_depth += 1
         self.generic_visit(node)
+        self.try_depth -= 1
         self.control_flow_depth -= 1
 
     def visit_With(self, node: ast.With | ast.AsyncWith) -> None:
@@ -613,6 +618,7 @@ class VariableTracker(ast.NodeVisitor):
                     has_type_annotation=False,
                     in_loop=self.loop_depth > 0,
                     in_control_flow=self.control_flow_depth > 0,
+                    in_try=self.try_depth > 0,
                     in_global_scope=(scope_id == 0),
                     has_comment_above=(node.lineno - 1) in self._comment_only_lines,
                     has_inline_comment=node.lineno in self._trailing_comment_lines,
@@ -725,6 +731,7 @@ class VariableTracker(ast.NodeVisitor):
                 has_type_annotation=True,
                 in_loop=self.loop_depth > 0,
                 in_control_flow=self.control_flow_depth > 0,
+                in_try=self.try_depth > 0,
                 in_global_scope=(scope_id == 0),
                 has_comment_above=(node.lineno - 1) in self._comment_only_lines,
                 has_inline_comment=node.lineno in self._trailing_comment_lines,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -551,6 +551,9 @@ def should_report_violation(
     if assignment.in_loop:
         return False
 
+    if assignment.in_try:
+        return False
+
     # Skip if there's a comment right above the assignment (any scope)
     # Comments above variables indicate documentation/explanation intent
     if assignment.has_comment_above:

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -224,6 +224,7 @@ def test_function_defaults_are_visited_in_the_enclosing_try_context() -> None:
 def outer():
     try:
         value = source()
+        @decorate(value)
         def inner(*, required, argument=value):
             return argument
     except ValueError:
@@ -231,7 +232,7 @@ def outer():
 """
     lifecycle = _lifecycle_for(source, "value")
 
-    assert len(lifecycle.uses) == 1
+    assert len(lifecycle.uses) == 2
 
 
 def test_named_expr_rebinding_skipped_for_global_variable() -> None:

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -224,7 +224,7 @@ def test_function_defaults_are_visited_in_the_enclosing_try_context() -> None:
 def outer():
     try:
         value = source()
-        def inner(argument=value):
+        def inner(*, required, argument=value):
             return argument
     except ValueError:
         pass

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -126,6 +126,26 @@ def example():
     assert len(lifecycle.uses) == 2
 
 
+def test_try_star_assignment_is_protected_from_redundancy_reporting() -> None:
+    source = """
+def f():
+    try:
+        value = load()
+    except* ValueError:
+        pass
+
+    try:
+        use(value)
+    except ValueError:
+        pass
+"""
+    lifecycle = _lifecycle_for(source, "value")
+
+    assert lifecycle.assignment.in_try is True
+    assert lifecycle.assignment.in_control_flow is True
+    assert _check(source, level=AggressivenessLevel.PERMISSIVE) == []
+
+
 def test_named_expr_rebinding_skipped_for_global_variable() -> None:
     # Branch coverage: a walrus target declared `global` in this scope
     # must not be tracked as a rebinding use here — matching

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -146,6 +146,94 @@ def f():
     assert _check(source, level=AggressivenessLevel.PERMISSIVE) == []
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+def f():
+    try:
+        pass
+    except ValueError:
+        value = load()
+        return value
+""",
+        """
+def f():
+    try:
+        pass
+    except ValueError:
+        pass
+    else:
+        value = load()
+        return value
+""",
+        """
+def f():
+    try:
+        pass
+    except ValueError:
+        pass
+    finally:
+        value = load()
+        return value
+""",
+    ],
+)
+def test_try_depth_does_not_include_non_body_clauses(source: str) -> None:
+    lifecycle = _lifecycle_for(source, "value")
+
+    assert lifecycle.assignment.in_try is False
+    assert lifecycle.assignment.in_control_flow is True
+    assert len(_check(source, level=AggressivenessLevel.PERMISSIVE)) == 1
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+def outer():
+    try:
+        def inner():
+            value = load()
+            return value
+    except ValueError:
+        pass
+""",
+        """
+def outer():
+    try:
+        class Inner:
+            def method(self):
+                value = load()
+                return value
+    except ValueError:
+        pass
+""",
+    ],
+)
+def test_try_depth_does_not_include_deferred_function_bodies(source: str) -> None:
+    lifecycle = _lifecycle_for(source, "value")
+
+    assert lifecycle.assignment.in_try is False
+    assert lifecycle.assignment.in_control_flow is True
+    assert len(_check(source, level=AggressivenessLevel.PERMISSIVE)) == 1
+
+
+def test_function_defaults_are_visited_in_the_enclosing_try_context() -> None:
+    source = """
+def outer():
+    try:
+        value = source()
+        def inner(argument=value):
+            return argument
+    except ValueError:
+        pass
+"""
+    lifecycle = _lifecycle_for(source, "value")
+
+    assert len(lifecycle.uses) == 1
+
+
 def test_named_expr_rebinding_skipped_for_global_variable() -> None:
     # Branch coverage: a walrus target declared `global` in this scope
     # must not be tracked as a rebinding use here — matching

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -42,6 +42,39 @@ def test_check_reports_character_offset_not_byte_offset_before_multibyte_text() 
     assert violations[0].col == 10
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+def is_directory_change(command):
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+
+    try:
+        target = tokens[1]
+    except IndexError:
+        return False
+
+    return target.startswith("/")
+""",
+        """
+def start_daemon():
+    try:
+        ty_version = _ty_version()
+    except OSError as error:
+        print(f"FAILED: {error}", flush=True)
+        return
+
+    return ty_version
+""",
+    ],
+)
+def test_check_does_not_report_assignments_protected_by_try_handlers(source: str) -> None:
+    assert _check(source, level=AggressivenessLevel.PERMISSIVE) == []
+
+
 # ---------------------------------------------------------------------------
 # check(): reports no violations at all
 # ---------------------------------------------------------------------------

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -67,7 +67,19 @@ def start_daemon():
         print(f"FAILED: {error}", flush=True)
         return
 
-    return ty_version
+        return ty_version
+""",
+        """
+def load_config():
+    try:
+        config: dict[str, str] = read_config()
+    except OSError:
+        return None
+
+    try:
+        return config["name"]
+    except KeyError:
+        return None
 """,
     ],
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redundant-assignment checks no longer report assignments protected by `try`/`except` or `try`/`except*` handlers.
  * This behavior applies to failures involving malformed command parsing, version detection, and configuration lookup.
  * Assignment analysis now correctly handles nested error-handling blocks and function defaults evaluated within them.

* **Tests**
  * Added coverage for protected assignments, nested exception handling, deferred function and class bodies, and usage tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->