### PR TITLE
fix: name context managers as noun phrases

### DIFF
--- a/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
@@ -73,6 +73,19 @@ def is_decorator_override_or_abstract(
     return False
 
 
+def _is_context_manager(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return any(
+        decorator_name(decorator)
+        in {
+            "contextmanager",
+            "asynccontextmanager",
+            "contextlib.contextmanager",
+            "contextlib.asynccontextmanager",
+        }
+        for decorator in func_node.decorator_list
+    )
+
+
 class FunctionBehavior(TypedDict):
     """Detected behavior flags used by `suggest_name_for` to pick a naming pattern. See ADR-0037."""
 
@@ -726,6 +739,9 @@ def suggest_name_for(func_node: ast.FunctionDef | ast.AsyncFunctionDef, analysis
         suggested = entity or old
         reason = "@property: prefer noun name rather than verb"
         return suggested, reason
+
+    if _is_context_manager(func_node):
+        return entity or old, "context manager; prefer noun phrase"
 
     # A generator's calling contract (must be iterated, can't be used as a
     # plain return value) is a stronger, unambiguous signal than any verb

--- a/tests/validate_function_name/test_analysis.py
+++ b/tests/validate_function_name/test_analysis.py
@@ -1164,6 +1164,36 @@ def test_extract_first_verb(docstring_line: str, verb: str | None) -> None:
             "iter_lines",
             "generator/iterator",
         ),
+        (
+            ("from contextlib import contextmanager\n\n@contextmanager\ndef get_transaction():\n    yield object()\n"),
+            "get_transaction",
+            "transaction",
+            "context manager; prefer noun phrase",
+        ),
+        (
+            (
+                "from contextlib import asynccontextmanager\n"
+                "\n"
+                "@asynccontextmanager\n"
+                "async def get_tempfile_session():\n"
+                "    yield object()\n"
+            ),
+            "get_tempfile_session",
+            "tempfile_session",
+            "context manager; prefer noun phrase",
+        ),
+        (
+            ("import contextlib\n\n@contextlib.contextmanager\ndef get_connection():\n    yield object()\n"),
+            "get_connection",
+            "connection",
+            "context manager; prefer noun phrase",
+        ),
+        (
+            ("import contextlib\n\n@contextlib.asynccontextmanager\nasync def get_lock():\n    yield object()\n"),
+            "get_lock",
+            "lock",
+            "context manager; prefer noun phrase",
+        ),
     ],
     ids=[
         "test-prefixed-untouched",
@@ -1173,6 +1203,10 @@ def test_extract_first_verb(docstring_line: str, verb: str | None) -> None:
         "validates-only-suggests-validate",
         "transforms-only-suggests-transform",
         "generator-outranks-disk-read",
+        "context-manager-uses-noun-phrase",
+        "async-context-manager-uses-noun-phrase",
+        "qualified-context-manager-uses-noun-phrase",
+        "qualified-async-context-manager-uses-noun-phrase",
     ],
 )
 def test_suggest_name_for(source: str, func_name: str, suggested_name: str, reason: str) -> None:

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -82,6 +82,32 @@ def test_fix_applies_safe_suggestion(tmp_path: Path) -> None:
     assert "def is_data() -> bool:" in filepath.read_text()
 
 
+def test_fix_applies_context_manager_rename(tmp_path: Path) -> None:
+    filepath = tmp_path / "mod.py"
+    source = (
+        "from contextlib import asynccontextmanager\n"
+        "\n"
+        "@asynccontextmanager\n"
+        "async def get_tempfile_session():\n"
+        "    yield object()\n"
+        "\n"
+        "async def use_session():\n"
+        "    async with get_tempfile_session() as session:\n"
+        "        return session\n"
+    )
+    filepath.write_text(source)
+    tree = ast.parse(source)
+
+    check = ValidateFunctionNameCheck()
+    violations = check.check(filepath, tree, source)
+
+    assert len(violations) == 1
+    assert violations[0].fixable is True
+    assert check.fix(filepath, violations, source, tree) is True
+    assert "async def tempfile_session()" in filepath.read_text()
+    assert "async with tempfile_session() as session:" in filepath.read_text()
+
+
 def test_fix_skips_unsafe_suggestion(tmp_path: Path) -> None:
     # A suggestion should_autofix rejects (e.g. a method) isn't applied.
     filepath = tmp_path / "mod.py"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function-name validation for synchronous and asynchronous context managers.
  * Context-manager functions now receive noun-based naming suggestions.
  * Autofixes correctly rename context-manager definitions and their usage sites.

* **Tests**
  * Added coverage for qualified and unqualified context-manager decorators.
  * Added verification for asynchronous context-manager renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->