### PR TITLE
feat(meaningless-vars): add PyMongo document suggestions

### DIFF
--- a/docs/adr/0051-pymongo-document-rename-provenance.md
+++ b/docs/adr/0051-pymongo-document-rename-provenance.md
@@ -1,0 +1,19 @@
+# PyMongo document rename provenance
+
+## Context
+
+The generic producer rule derived `one` and `one_and_delete` from `find_one()` and related methods. Those words describe the method shape, not the returned value, so they were not useful variable names. PyMongo operations in this family return a single document, but treating every method with that spelling as PyMongo would misidentify unrelated APIs.
+
+## Decision
+
+ADR-0038's rejection of PyMongo-aware provenance tracking is superseded for the single-document collection methods. TR1 recognizes a PyMongo collection only from file-local evidence: supported static PyMongo imports, an annotated or constructed `MongoClient`, and collection construction through indexed client access or `get_database(...).get_collection(...)`. It follows those bindings through local names and instance attributes.
+
+For a proven collection, `find_one`, `find_one_and_delete`, `find_one_and_replace`, and `find_one_and_update` produce the auto-fixable name `document`. A concrete assignment annotation takes precedence, including a nullable annotation with one concrete type. Without either source of evidence, the generic producer rule must not suggest the uninformative method tails `one` or `one_and_*`.
+
+Existing bare DB-API method mappings remain suggestion-only because they do not establish the receiver type.
+
+## Consequences
+
+- PyMongo code receives a useful automatic rename without resolving installed type stubs or inspecting other files.
+- Unknown `find_one*` APIs remain silent instead of receiving a mechanically derived name.
+- The analysis stays deterministic, offline, and bounded to the parsed file.

--- a/docs/rules/meaningless-vars.md
+++ b/docs/rules/meaningless-vars.md
@@ -15,7 +15,7 @@ Meaningless variable names reduce code clarity and maintainability. See [Peter H
 ## Features
 
 - Detects meaningless names in assignments, function parameters, and async functions
-- **Autofixing**: derives names from file-local semantics such as concrete annotations, imported standard APIs, producers, and consumers (`--fix`). The rename is scope-aware — it replaces only the AST `Name` nodes for that specific binding within its scope, not every textual occurrence in the file. `--fix` applies only high-confidence local renames; weaker evidence is reported as a suggestion without changing the file.
+- **Autofixing**: derives names from file-local semantics such as concrete annotations, recognized imported APIs, producers, and consumers (`--fix`). The rename is scope-aware — it replaces only the AST `Name` nodes for that specific binding within its scope, not every textual occurrence in the file. `--fix` applies only high-confidence local renames; weaker evidence is reported as a suggestion without changing the file.
 - Inline suppression with `# pytriage: TR1`
 
 ## Reporting level

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -23,9 +23,9 @@ from ._base import (
     mark_fix_failed,
     split_lines_like_ast,
 )
-from ._meaningless_vars_suggestions import Confidence, plan_suggestions
 from ._options import EnumOption
 from ._scope import iter_within_scope_from
+from .meaningless_vars_suggestions import Confidence, plan_suggestions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/__init__.py
@@ -1,0 +1,3 @@
+from .analysis import Confidence, RenameProposal, plan_suggestions
+
+__all__ = ["Confidence", "RenameProposal", "plan_suggestions"]

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
@@ -354,7 +354,7 @@ def _scope_proposals(
 def _proposal_for(assignment: Assignment, meaningless_names: set[str]) -> RenameProposal | None:
     candidates: dict[str, set[str]] = defaultdict(set)
     constraints = _annotation_constraints(assignment.annotation)
-    annotation_name = _annotation_name(assignment.annotation)
+    annotation_name = _annotation_name(assignment.annotation, assignment.scope)
     if annotation_name is not None:
         candidates[annotation_name].add("annotation")
     else:
@@ -527,7 +527,7 @@ def _call_candidates(node: ast.Call, scope: ScopeInfo, target: ast.Name) -> dict
 
     if isinstance(node.func, ast.Name):
         return_annotation = _function_return_annotation(scope, node.func.id)
-        return_name = _annotation_name(return_annotation)
+        return_name = _annotation_name(return_annotation, scope)
         if return_name is not None:
             candidates.setdefault(return_name, set()).add("return_annotation")
     return candidates
@@ -726,24 +726,24 @@ def _verb_parameter_proposals(
         )
 
 
-def _annotation_name(annotation: ast.expr | None) -> str | None:
+def _annotation_name(annotation: ast.expr | None, scope: ScopeInfo | None = None) -> str | None:
     annotation = _unwrap_nullable_annotation(annotation)
     if annotation is None:
         return None
     if isinstance(annotation, ast.Subscript):
         base = _annotation_terminal(annotation.value)
         if base in {"list", "set", "frozenset"}:
-            element_name = _annotation_name(_slice_value(annotation.slice))
+            element_name = _annotation_name(_slice_value(annotation.slice), scope)
             return _pluralize(element_name) if element_name is not None else None
         if base == "tuple" and isinstance(annotation.slice, ast.Tuple) and len(annotation.slice.elts) == 2:
             element_annotation, ellipsis = annotation.slice.elts
             if isinstance(ellipsis, ast.Constant) and ellipsis.value is Ellipsis:
-                element_name = _annotation_name(element_annotation)
+                element_name = _annotation_name(element_annotation, scope)
                 return _pluralize(element_name) if element_name is not None else None
         if base not in _GENERIC_TYPE_NAMES:
-            return _type_name(base)
+            return _type_name(base, scope)
         return None
-    return _type_name(_annotation_terminal(annotation))
+    return _type_name(_annotation_terminal(annotation), scope)
 
 
 def _annotation_constraints(annotation: ast.expr | None) -> set[str]:
@@ -757,16 +757,38 @@ def _annotation_constraints(annotation: ast.expr | None) -> set[str]:
     return set()
 
 
-def _type_name(name: str) -> str | None:
+def _type_name(name: str, scope: ScopeInfo | None = None) -> str | None:
     normalized_name = name.lstrip("_")
     if (
         not normalized_name
         or normalized_name in _GENERIC_TYPE_NAMES
-        or normalized_name in _GENERIC_TYPE_VARIABLE_NAMES
+        or _is_type_parameter_name(scope, name)
         or not normalized_name[0].isupper()
     ):
         return None
     return _to_snake_case(normalized_name)
+
+
+def _is_type_parameter_name(scope: ScopeInfo | None, name: str) -> bool:
+    current = scope
+    while current is not None:
+        bindings = current.bindings.get(name)
+        if bindings:
+            return any(
+                isinstance(binding, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple) for binding in bindings
+            ) or any(
+                assignment.target.id == name and _is_typevar_call(assignment.value, current)
+                for assignment in current.candidates
+            )
+        current = current.parent
+    return False
+
+
+def _is_typevar_call(node: ast.expr, scope: ScopeInfo) -> bool:
+    return isinstance(node, ast.Call) and _qname(node.func, scope) in {
+        ("typing", "TypeVar"),
+        ("typing_extensions", "TypeVar"),
+    }
 
 
 def _comprehension_name(node: ast.ListComp | ast.SetComp | ast.GeneratorExp) -> str | None:
@@ -1022,7 +1044,6 @@ _GENERIC_TYPE_NAMES = {
     "Optional",
     "Union",
 }
-_GENERIC_TYPE_VARIABLE_NAMES = {"T", "K", "V", "KT", "VT"}
 _IRREGULAR_WORDS = {
     "analysis",
     "basis",

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
@@ -9,6 +9,14 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from .pymongo import call_candidate, collection_attributes, suppresses_producer_tail
+from .syntax import _annotation_terminal
+from .syntax import arguments as _arguments
+from .syntax import import_qname as _import_qname
+from .syntax import position as _position
+from .syntax import qname as _qname
+from .syntax import unwrap_nullable_annotation as _unwrap_nullable_annotation
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -49,6 +57,7 @@ class ScopeInfo:
     has_reflection: bool = False
     reachable_names: set[str] | None = None
     class_references: set[str] = field(default_factory=set)
+    mongodb_collection_attributes: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,11 +99,12 @@ class _Index:
         parent: ScopeInfo,
         *,
         register_parent: bool = True,
+        mongodb_collection_attributes: frozenset[str] = frozenset(),
     ) -> None:
         if register_parent:
             parent.bindings[node.name].append(node)
             parent.function_returns[node.name] = node.returns
-        child = ScopeInfo(node, parent)
+        child = ScopeInfo(node, parent, mongodb_collection_attributes=mongodb_collection_attributes)
         parent.children.append(child)
         self._build_scope(child, node.body)
 
@@ -103,7 +113,7 @@ class _Index:
         parent.class_references.update(
             child.id for child in ast.walk(node) if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
         )
-        visitor = _ClassVisitor(self, parent)
+        visitor = _ClassVisitor(self, parent, collection_attributes(node, parent))
         for statement in node.body:
             visitor.visit(statement)
 
@@ -273,15 +283,31 @@ class _ScopeVisitor(ast.NodeVisitor):
 
 
 class _ClassVisitor(ast.NodeVisitor):
-    def __init__(self, index: _Index, parent: ScopeInfo) -> None:
+    def __init__(
+        self,
+        index: _Index,
+        parent: ScopeInfo,
+        mongodb_collection_attributes: frozenset[str],
+    ) -> None:
         self.index = index
         self.parent = parent
+        self.mongodb_collection_attributes = mongodb_collection_attributes
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self.index.add_function(node, self.parent, register_parent=False)
+        self.index.add_function(
+            node,
+            self.parent,
+            register_parent=False,
+            mongodb_collection_attributes=self.mongodb_collection_attributes,
+        )
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self.index.add_function(node, self.parent, register_parent=False)
+        self.index.add_function(
+            node,
+            self.parent,
+            register_parent=False,
+            mongodb_collection_attributes=self.mongodb_collection_attributes,
+        )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.index.add_class(node, self.parent)
@@ -331,17 +357,17 @@ def _proposal_for(assignment: Assignment, meaningless_names: set[str]) -> Rename
     annotation_name = _annotation_name(assignment.annotation)
     if annotation_name is not None:
         candidates[annotation_name].add("annotation")
+    else:
+        for name, evidence in _expression_candidates(assignment.value, assignment.scope, assignment.target).items():
+            candidates[name].update(evidence)
 
-    for name, evidence in _expression_candidates(assignment.value, assignment.scope).items():
-        candidates[name].update(evidence)
+        if isinstance(assignment.value, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+            comprehension_name = _comprehension_name(assignment.value)
+            if comprehension_name is not None:
+                candidates[comprehension_name].update({"comprehension_element", "comprehension_iterable"})
 
-    if isinstance(assignment.value, ast.ListComp | ast.SetComp | ast.GeneratorExp):
-        comprehension_name = _comprehension_name(assignment.value)
-        if comprehension_name is not None:
-            candidates[comprehension_name].update({"comprehension_element", "comprehension_iterable"})
-
-    _add_use_candidates(candidates, constraints, assignment)
-    _refine_parser_candidates(candidates, constraints)
+        _add_use_candidates(candidates, constraints, assignment)
+        _refine_parser_candidates(candidates, constraints)
 
     if len(candidates) != 1:
         return None
@@ -439,11 +465,15 @@ def _refine_parser_candidates(candidates: dict[str, set[str]], constraints: set[
         candidates.pop("json_text", None)
 
 
-def _expression_candidates(value: ast.expr, scope: ScopeInfo) -> dict[str, set[str]]:
+def _expression_candidates(
+    value: ast.expr,
+    scope: ScopeInfo,
+    target: ast.Name,
+) -> dict[str, set[str]]:
     if isinstance(value, ast.Await):
-        return _expression_candidates(value.value, scope)
+        return _expression_candidates(value.value, scope, target)
     if isinstance(value, ast.Call):
-        return _call_candidates(value, scope)
+        return _call_candidates(value, scope, target)
     if isinstance(value, ast.Attribute) and _is_public_attribute(value.attr):
         return {value.attr: {"attribute"}}
     return {}
@@ -452,9 +482,9 @@ def _expression_candidates(value: ast.expr, scope: ScopeInfo) -> dict[str, set[s
 _DB_FETCH_METHOD_NAMES = {"fetchall": "rows", "fetchmany": "rows", "fetchone": "row", "to_list": "documents"}
 
 
-def _call_candidates(node: ast.Call, scope: ScopeInfo) -> dict[str, set[str]]:
+def _call_candidates(node: ast.Call, scope: ScopeInfo, target: ast.Name) -> dict[str, set[str]]:
     if isinstance(node.func, ast.Attribute) and node.func.attr == "json" and isinstance(node.func.value, ast.Call):
-        nested = _call_candidates(node.func.value, scope)
+        nested = _call_candidates(node.func.value, scope, target)
         if "response" in nested:
             return {"payload": {"http_json"}}
 
@@ -469,6 +499,10 @@ def _call_candidates(node: ast.Call, scope: ScopeInfo) -> dict[str, set[str]]:
     if isinstance(node.func, ast.Attribute) and node.func.attr in _DB_FETCH_METHOD_NAMES:
         return {_DB_FETCH_METHOD_NAMES[node.func.attr]: {"registry"}}
 
+    pymongo_candidate = call_candidate(node, scope, target)
+    if pymongo_candidate is not None:
+        return pymongo_candidate
+
     name = _call_terminal_name(node.func)
     if name is None:
         return {}
@@ -480,7 +514,9 @@ def _call_candidates(node: ast.Call, scope: ScopeInfo) -> dict[str, set[str]]:
     for prefix in ("get", "fetch", "load", "read", "parse", "create", "build", "make", "find", "list", "collect"):
         marker = f"{prefix}_"
         if name.startswith(marker) and len(name) > len(marker):
-            candidates[name.removeprefix(marker)] = {"producer"}
+            produced_name = name.removeprefix(marker)
+            if not suppresses_producer_tail(produced_name):
+                candidates[produced_name] = {"producer"}
             break
     if name.startswith(("is_", "has_", "can_", "should_")):
         candidates[name] = {"predicate"}
@@ -691,6 +727,7 @@ def _verb_parameter_proposals(
 
 
 def _annotation_name(annotation: ast.expr | None) -> str | None:
+    annotation = _unwrap_nullable_annotation(annotation)
     if annotation is None:
         return None
     if isinstance(annotation, ast.Subscript):
@@ -710,6 +747,7 @@ def _annotation_name(annotation: ast.expr | None) -> str | None:
 
 
 def _annotation_constraints(annotation: ast.expr | None) -> set[str]:
+    annotation = _unwrap_nullable_annotation(annotation)
     if _annotation_terminal(annotation) == "bool":
         return {"bool"}
     if _annotation_terminal(annotation) == "str":
@@ -719,20 +757,16 @@ def _annotation_constraints(annotation: ast.expr | None) -> set[str]:
     return set()
 
 
-def _annotation_terminal(annotation: ast.expr | None) -> str:
-    if isinstance(annotation, ast.Name):
-        return annotation.id
-    if isinstance(annotation, ast.Attribute):
-        return annotation.attr
-    if isinstance(annotation, ast.Subscript):
-        return _annotation_terminal(annotation.value)
-    return ""
-
-
 def _type_name(name: str) -> str | None:
-    if not name or name in _GENERIC_TYPE_NAMES or not name[0].isupper():
+    normalized_name = name.lstrip("_")
+    if (
+        not normalized_name
+        or normalized_name in _GENERIC_TYPE_NAMES
+        or normalized_name in _GENERIC_TYPE_VARIABLE_NAMES
+        or not normalized_name[0].isupper()
+    ):
         return None
-    return _to_snake_case(name)
+    return _to_snake_case(normalized_name)
 
 
 def _comprehension_name(node: ast.ListComp | ast.SetComp | ast.GeneratorExp) -> str | None:
@@ -757,26 +791,6 @@ def _attribute_role(attribute: str) -> str | None:
         return "match"
     if attribute in {"read", "write", "seek", "close", "fileno"}:
         return "file_handle"
-    return None
-
-
-def _qname(node: ast.expr, scope: ScopeInfo) -> tuple[str, ...] | None:
-    if isinstance(node, ast.Name):
-        return _import_qname(scope, node.id)
-    if isinstance(node, ast.Attribute):
-        parent = _qname(node.value, scope)
-        return (*parent, node.attr) if parent is not None else None
-    return None
-
-
-def _import_qname(scope: ScopeInfo, name: str) -> tuple[str, ...] | None:
-    current: ScopeInfo | None = scope
-    while current is not None:
-        if name in current.imports:
-            return current.imports[name]
-        if name in current.bindings:
-            return None
-        current = current.parent
     return None
 
 
@@ -909,16 +923,6 @@ def _iter_scopes(scope: ScopeInfo) -> Iterable[ScopeInfo]:
         yield from _iter_scopes(child)
 
 
-def _arguments(arguments: ast.arguments) -> Iterable[ast.arg]:
-    yield from arguments.posonlyargs
-    yield from arguments.args
-    yield from arguments.kwonlyargs
-    if arguments.vararg is not None:
-        yield arguments.vararg
-    if arguments.kwarg is not None:
-        yield arguments.kwarg
-
-
 def _condition_name(expression: ast.expr) -> str | None:
     if isinstance(expression, ast.Name) and isinstance(expression.ctx, ast.Load):
         return expression.id
@@ -936,10 +940,6 @@ def _is_reflection_call(node: ast.Call) -> bool:
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == "inspect"
     )
-
-
-def _position(node: ast.expr | ast.stmt) -> tuple[int, int]:
-    return (node.lineno, node.col_offset)
 
 
 def _target_key(target: ast.Name) -> TargetKey:
@@ -1019,7 +1019,10 @@ _GENERIC_TYPE_NAMES = {
     "set",
     "str",
     "tuple",
+    "Optional",
+    "Union",
 }
+_GENERIC_TYPE_VARIABLE_NAMES = {"T", "K", "V", "KT", "VT"}
 _IRREGULAR_WORDS = {
     "analysis",
     "basis",

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/analysis.py
@@ -44,7 +44,7 @@ class ScopeInfo:
     bindings: dict[str, list[ast.AST]] = field(default_factory=lambda: defaultdict(list))
     imports: dict[str, tuple[str, ...]] = field(default_factory=dict)
     explicit_modules: set[tuple[str, ...]] = field(default_factory=set)
-    function_returns: dict[str, ast.expr | None] = field(default_factory=dict)
+    function_returns: dict[str, tuple[ast.expr | None, ScopeInfo]] = field(default_factory=dict)
     candidates: list[Assignment] = field(default_factory=list)
     attributes: dict[str, list[ast.Attribute]] = field(default_factory=lambda: defaultdict(list))
     calls: dict[str, list[CallArgument]] = field(default_factory=lambda: defaultdict(list))
@@ -100,11 +100,15 @@ class _Index:
         *,
         register_parent: bool = True,
         mongodb_collection_attributes: frozenset[str] = frozenset(),
+        class_type_parameters: tuple[ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple, ...] = (),
     ) -> None:
         if register_parent:
             parent.bindings[node.name].append(node)
-            parent.function_returns[node.name] = node.returns
         child = ScopeInfo(node, parent, mongodb_collection_attributes=mongodb_collection_attributes)
+        for type_parameter in class_type_parameters:
+            child.bindings[type_parameter.name].append(type_parameter)
+        if register_parent:
+            parent.function_returns[node.name] = node.returns, child
         parent.children.append(child)
         self._build_scope(child, node.body)
 
@@ -113,7 +117,12 @@ class _Index:
         parent.class_references.update(
             child.id for child in ast.walk(node) if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
         )
-        visitor = _ClassVisitor(self, parent, collection_attributes(node, parent))
+        class_type_parameters = tuple(
+            type_parameter
+            for type_parameter in node.type_params
+            if isinstance(type_parameter, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
+        )
+        visitor = _ClassVisitor(self, parent, collection_attributes(node, parent), class_type_parameters)
         for statement in node.body:
             visitor.visit(statement)
 
@@ -288,10 +297,12 @@ class _ClassVisitor(ast.NodeVisitor):
         index: _Index,
         parent: ScopeInfo,
         mongodb_collection_attributes: frozenset[str],
+        class_type_parameters: tuple[ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple, ...],
     ) -> None:
         self.index = index
         self.parent = parent
         self.mongodb_collection_attributes = mongodb_collection_attributes
+        self.class_type_parameters = class_type_parameters
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self.index.add_function(
@@ -299,6 +310,7 @@ class _ClassVisitor(ast.NodeVisitor):
             self.parent,
             register_parent=False,
             mongodb_collection_attributes=self.mongodb_collection_attributes,
+            class_type_parameters=self.class_type_parameters,
         )
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -307,6 +319,7 @@ class _ClassVisitor(ast.NodeVisitor):
             self.parent,
             register_parent=False,
             mongodb_collection_attributes=self.mongodb_collection_attributes,
+            class_type_parameters=self.class_type_parameters,
         )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
@@ -526,10 +539,12 @@ def _call_candidates(node: ast.Call, scope: ScopeInfo, target: ast.Name) -> dict
         candidates[constructor_name] = {"constructor"}
 
     if isinstance(node.func, ast.Name):
-        return_annotation = _function_return_annotation(scope, node.func.id)
-        return_name = _annotation_name(return_annotation, scope)
-        if return_name is not None:
-            candidates.setdefault(return_name, set()).add("return_annotation")
+        function_return = _function_return_annotation(scope, node.func.id)
+        if function_return is not None:
+            return_annotation, declaration_scope = function_return
+            return_name = _annotation_name(return_annotation, declaration_scope)
+            if return_name is not None:
+                candidates.setdefault(return_name, set()).add("return_annotation")
     return candidates
 
 
@@ -816,7 +831,7 @@ def _attribute_role(attribute: str) -> str | None:
     return None
 
 
-def _function_return_annotation(scope: ScopeInfo, name: str) -> ast.expr | None:
+def _function_return_annotation(scope: ScopeInfo, name: str) -> tuple[ast.expr | None, ScopeInfo] | None:
     current: ScopeInfo | None = scope
     while current is not None:
         if name in current.function_returns:

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/pymongo.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/pymongo.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING, cast
+
+from .syntax import arguments, position, qname, unwrap_nullable_annotation
+
+if TYPE_CHECKING:
+    from .analysis import ScopeInfo
+
+_DOCUMENT_METHOD_NAMES = {
+    "find_one",
+    "find_one_and_delete",
+    "find_one_and_replace",
+    "find_one_and_update",
+}
+_UNINFORMATIVE_FINDER_TAILS = frozenset(name.removeprefix("find_") for name in _DOCUMENT_METHOD_NAMES)
+
+
+def collection_attributes(node: ast.ClassDef, scope: ScopeInfo) -> frozenset[str]:
+    initializer = next(
+        (
+            statement
+            for statement in node.body
+            if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef) and statement.name == "__init__"
+        ),
+        None,
+    )
+    if initializer is None:
+        return frozenset()
+
+    names = _argument_kinds(initializer, scope)
+    attributes: dict[str, str] = {}
+    receiver_name = _receiver_name(initializer)
+    for statement in initializer.body:
+        _record_assignment(statement, names, attributes, receiver_name, scope)
+    return frozenset(name for name, kind in attributes.items() if kind == "collection")
+
+
+def call_candidate(
+    node: ast.Call,
+    scope: ScopeInfo,
+    target: ast.Name,
+) -> dict[str, set[str]] | None:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in _DOCUMENT_METHOD_NAMES:
+        return None
+    if _expression_kind(node.func.value, scope, target) != "collection":
+        return None
+    return {"document": {"pymongo_collection", "pymongo_find_one"}}
+
+
+def suppresses_producer_tail(name: str) -> bool:
+    return name in _UNINFORMATIVE_FINDER_TAILS
+
+
+def _expression_kind(node: ast.expr, scope: ScopeInfo, target: ast.Name) -> str | None:
+    function = cast("ast.FunctionDef | ast.AsyncFunctionDef", scope.node)
+    names = _argument_kinds(function, scope)
+    attributes = dict.fromkeys(scope.mongodb_collection_attributes, "collection")
+    receiver_name = _receiver_name(function)
+    for statement in function.body:
+        if position(statement) >= position(target):
+            break
+        _record_assignment(statement, names, attributes, receiver_name, scope)
+    return _value_kind(node, names, attributes, receiver_name, scope)
+
+
+def _argument_kinds(node: ast.FunctionDef | ast.AsyncFunctionDef, scope: ScopeInfo) -> dict[str, str]:
+    return {
+        argument.arg: "client" for argument in arguments(node.args) if _is_client_annotation(argument.annotation, scope)
+    }
+
+
+def _record_assignment(
+    statement: ast.stmt,
+    names: dict[str, str],
+    attributes: dict[str, str],
+    receiver_name: str | None,
+    scope: ScopeInfo,
+) -> None:
+    if isinstance(statement, ast.Assign):
+        targets = statement.targets
+        value = statement.value
+    elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+        targets = [statement.target]
+        value = statement.value
+    else:
+        return
+
+    kind = _value_kind(value, names, attributes, receiver_name, scope)
+    for target in targets:
+        if isinstance(target, ast.Name):
+            if kind is None:
+                names.pop(target.id, None)
+            else:
+                names[target.id] = kind
+        else:
+            attribute_name = _receiver_attribute_name(target, receiver_name)
+            if attribute_name is None:
+                continue
+            if kind is None:
+                attributes.pop(attribute_name, None)
+            else:
+                attributes[attribute_name] = kind
+
+
+def _value_kind(
+    node: ast.expr,
+    names: dict[str, str],
+    attributes: dict[str, str],
+    receiver_name: str | None,
+    scope: ScopeInfo,
+) -> str | None:
+    if isinstance(node, ast.Name):
+        return names.get(node.id)
+    attribute_name = _receiver_attribute_name(node, receiver_name)
+    if attribute_name is not None:
+        return attributes.get(attribute_name)
+    if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+        kinds = {_value_kind(value, names, attributes, receiver_name, scope) for value in node.values}
+        return kinds.pop() if len(kinds) == 1 else None
+    if isinstance(node, ast.Subscript):
+        container_kind = _value_kind(node.value, names, attributes, receiver_name, scope)
+        return {"client": "database", "database": "collection"}.get(container_kind) if container_kind else None
+    if not isinstance(node, ast.Call):
+        return None
+    if _is_client_call(node, scope):
+        return "client"
+    if not isinstance(node.func, ast.Attribute):
+        return None
+    receiver_kind = _value_kind(node.func.value, names, attributes, receiver_name, scope)
+    if node.func.attr == "get_database" and receiver_kind == "client":
+        return "database"
+    if node.func.attr == "get_collection" and receiver_kind == "database":
+        return "collection"
+    return None
+
+
+def _is_client_annotation(annotation: ast.expr | None, scope: ScopeInfo) -> bool:
+    unwrapped = unwrap_nullable_annotation(annotation)
+    return unwrapped is not None and _is_client_qname(qname(unwrapped, scope))
+
+
+def _is_client_call(node: ast.Call, scope: ScopeInfo) -> bool:
+    return _is_client_qname(qname(node.func, scope))
+
+
+def _is_client_qname(qname: tuple[str, ...] | None) -> bool:
+    return qname is not None and qname[0] == "pymongo" and qname[-1] == "MongoClient"
+
+
+def _receiver_name(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    positional_arguments = [*node.args.posonlyargs, *node.args.args]
+    return positional_arguments[0].arg if positional_arguments else None
+
+
+def _receiver_attribute_name(node: ast.expr, receiver_name: str | None) -> str | None:
+    if (
+        receiver_name is not None
+        and isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == receiver_name
+    ):
+        return node.attr
+    return None

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/pymongo.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/pymongo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from .syntax import arguments, position, qname, unwrap_nullable_annotation
 
@@ -54,11 +54,13 @@ def suppresses_producer_tail(name: str) -> bool:
 
 
 def _expression_kind(node: ast.expr, scope: ScopeInfo, target: ast.Name) -> str | None:
-    function = cast("ast.FunctionDef | ast.AsyncFunctionDef", scope.node)
-    names = _argument_kinds(function, scope)
+    scope_node = scope.node
+    names = _argument_kinds(scope_node, scope) if isinstance(scope_node, ast.FunctionDef | ast.AsyncFunctionDef) else {}
     attributes = dict.fromkeys(scope.mongodb_collection_attributes, "collection")
-    receiver_name = _receiver_name(function)
-    for statement in function.body:
+    receiver_name = (
+        _receiver_name(scope_node) if isinstance(scope_node, ast.FunctionDef | ast.AsyncFunctionDef) else None
+    )
+    for statement in scope_node.body:
         if position(statement) >= position(target):
             break
         _record_assignment(statement, names, attributes, receiver_name, scope)
@@ -89,19 +91,29 @@ def _record_assignment(
 
     kind = _value_kind(value, names, attributes, receiver_name, scope)
     for target in targets:
+        if kind is None:
+            _clear_names(target, names)
+            attribute_name = _receiver_attribute_name(target, receiver_name)
+            if attribute_name is not None:
+                attributes.pop(attribute_name, None)
+            continue
         if isinstance(target, ast.Name):
-            if kind is None:
-                names.pop(target.id, None)
-            else:
-                names[target.id] = kind
+            names[target.id] = kind
         else:
             attribute_name = _receiver_attribute_name(target, receiver_name)
             if attribute_name is None:
                 continue
-            if kind is None:
-                attributes.pop(attribute_name, None)
-            else:
-                attributes[attribute_name] = kind
+            attributes[attribute_name] = kind
+
+
+def _clear_names(target: ast.expr, names: dict[str, str]) -> None:
+    if isinstance(target, ast.Name):
+        names.pop(target.id, None)
+    elif isinstance(target, ast.Tuple | ast.List):
+        for element in target.elts:
+            _clear_names(element, names)
+    elif isinstance(target, ast.Starred):
+        _clear_names(target.value, names)
 
 
 def _value_kind(

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/syntax.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars_suggestions/syntax.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class ScopeWithImports(Protocol):
+    @property
+    def parent(self) -> ScopeWithImports | None: ...
+
+    @property
+    def bindings(self) -> Mapping[str, list[ast.AST]]: ...
+
+    @property
+    def imports(self) -> Mapping[str, tuple[str, ...]]: ...
+
+
+def arguments(arguments: ast.arguments) -> tuple[ast.arg, ...]:
+    variadic_arguments = tuple(argument for argument in (arguments.vararg, arguments.kwarg) if argument is not None)
+    return (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs, *variadic_arguments)
+
+
+def position(node: ast.expr | ast.stmt) -> tuple[int, int]:
+    return node.lineno, node.col_offset
+
+
+def qname(node: ast.expr, scope: ScopeWithImports) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Name):
+        return import_qname(scope, node.id)
+    if isinstance(node, ast.Attribute):
+        parent = qname(node.value, scope)
+        return (*parent, node.attr) if parent is not None else None
+    return None
+
+
+def import_qname(scope: ScopeWithImports, name: str) -> tuple[str, ...] | None:
+    current: ScopeWithImports | None = scope
+    while current is not None:
+        if name in current.imports:
+            return current.imports[name]
+        if name in current.bindings:
+            return None
+        current = current.parent
+    return None
+
+
+def unwrap_nullable_annotation(annotation: ast.expr | None) -> ast.expr | None:
+    if annotation is None:
+        return None
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        members = _union_members(annotation)
+        non_none_members = [member for member in members if not _is_none_annotation(member)]
+        return (
+            non_none_members[0] if len(non_none_members) == 1 and len(non_none_members) != len(members) else annotation
+        )
+    if isinstance(annotation, ast.Subscript) and _annotation_terminal(annotation.value) == "Optional":
+        members = _subscript_members(annotation.slice)
+        return members[0] if len(members) == 1 else annotation
+    if isinstance(annotation, ast.Subscript) and _annotation_terminal(annotation.value) == "Union":
+        members = _subscript_members(annotation.slice)
+        non_none_members = [member for member in members if not _is_none_annotation(member)]
+        return (
+            non_none_members[0] if len(non_none_members) == 1 and len(non_none_members) != len(members) else annotation
+        )
+    return annotation
+
+
+def _union_members(node: ast.expr) -> list[ast.expr]:
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return [*_union_members(node.left), *_union_members(node.right)]
+    return [node]
+
+
+def _subscript_members(node: ast.expr) -> list[ast.expr]:
+    return node.elts if isinstance(node, ast.Tuple) else [node]
+
+
+def _is_none_annotation(node: ast.expr) -> bool:
+    return (isinstance(node, ast.Constant) and node.value is None) or _annotation_terminal(node) in {"None", "NoneType"}
+
+
+def _annotation_terminal(annotation: ast.expr | None) -> str:
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    if isinstance(annotation, ast.Subscript):
+        return _annotation_terminal(annotation.value)
+    return ""

--- a/tests/test_meaningless_vars_suggestions.py
+++ b/tests/test_meaningless_vars_suggestions.py
@@ -700,9 +700,17 @@ class Storage[RecordT]:
         return result
 """
 
+    targets = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store) and node.id == "result"
+    ]
+    load_target, fetch_target = targets
     proposals = _plans(source)
 
-    assert {proposal.name for proposal in proposals.values()} == {"response"}
+    assert proposals.get((load_target.lineno, load_target.col_offset)) is None
+    proposal = proposals[(fetch_target.lineno, fetch_target.col_offset)]
+    assert proposal.name == "response"
 
 
 def test_function_return_type_parameter_uses_the_declaration_scope() -> None:
@@ -889,6 +897,12 @@ def f(client):
 
 
 _WITH_RESULTS = {"data", "result", "results"}
+_PYMONGO_SINGLE_DOCUMENT_METHODS = (
+    "find_one",
+    "find_one_and_delete",
+    "find_one_and_replace",
+    "find_one_and_update",
+)
 
 
 @pytest.mark.parametrize(
@@ -917,7 +931,7 @@ def test_db_fetch_method_evidence_excludes_fetchnumpy() -> None:
 
 @pytest.mark.parametrize(
     "method_name",
-    ["find_one", "find_one_and_delete", "find_one_and_replace", "find_one_and_update"],
+    _PYMONGO_SINGLE_DOCUMENT_METHODS,
 )
 def test_pymongo_find_one_methods_produce_autofixable_documents(method_name: str) -> None:
     source = f"""from typing import Optional
@@ -958,8 +972,9 @@ def load():
     _assert_plan_for(source, "result", "document", Confidence.AUTO_FIX)
 
 
-def test_unproven_find_one_does_not_produce_a_generic_suggestion() -> None:
-    source = "def load(collection):\n    result = collection.find_one({})\n    return result\n"
+@pytest.mark.parametrize("method_name", _PYMONGO_SINGLE_DOCUMENT_METHODS)
+def test_unproven_find_one_does_not_produce_a_generic_suggestion(method_name: str) -> None:
+    source = f"def load(collection):\n    result = collection.{method_name}({{}})\n    return result\n"
 
     _assert_plan_for(source, "result", None, None)
 

--- a/tests/test_meaningless_vars_suggestions.py
+++ b/tests/test_meaningless_vars_suggestions.py
@@ -23,6 +23,7 @@ from pre_commit_hooks.ast_checks.meaningless_vars_suggestions.analysis import (
     _to_snake_case,
     plan_suggestions,
 )
+from pre_commit_hooks.ast_checks.meaningless_vars_suggestions.pymongo import call_candidate
 
 
 def _plans(
@@ -664,7 +665,6 @@ def test_regular_singularization(name: str, expected: str) -> None:
         ("Optional[User]", "user", set()),
         ("User | None", "user", set()),
         ("Optional[_DocumentType]", "document_type", set()),
-        ("T | None", None, set()),
         ("bool | None", None, {"bool"}),
         ("Union[User, None]", "user", set()),
     ],
@@ -674,6 +674,17 @@ def test_annotation_helpers(annotation: str, name: str | None, constraints: set[
 
     assert _annotation_name(expression) == name
     assert _annotation_constraints(expression) == constraints
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'from typing import TypeVar\nU = TypeVar("U")\ndef load():\n    result: U = fetch()\n    return result\n',
+        "def load[RecordT]():\n    result: RecordT = fetch()\n    return result\n",
+    ],
+)
+def test_active_type_parameters_do_not_produce_annotation_names(source: str) -> None:
+    _assert_plan_for(source, "result", None, None)
 
 
 def test_small_ast_helpers() -> None:
@@ -980,6 +991,11 @@ class Storage:
             Confidence.AUTO_FIX,
         ),
         (
+            'client = MongoClient()\n    first, second = client\n    collection = client["database"]["collection"]',
+            "document",
+            Confidence.AUTO_FIX,
+        ),
+        (
             'client = MongoClient()\n    collection: object = client["database"]["collection"]',
             "document",
             Confidence.AUTO_FIX,
@@ -1017,6 +1033,37 @@ class Storage:
 """
 
     _assert_plan_for(source, "result", None, None)
+
+
+def test_pymongo_provenance_rejects_nested_destructuring_rebindings() -> None:
+    source = """from pymongo import MongoClient
+
+def load():
+    client = MongoClient()
+    client, (other, *rest) = build_values()
+    collection = client["database"]["collection"]
+    result = collection.find_one({})
+    return result
+"""
+
+    _assert_plan_for(source, "result", None, None)
+
+
+def test_pymongo_call_candidate_supports_module_scope() -> None:
+    tree = ast.parse(
+        """from pymongo import MongoClient
+client = MongoClient()
+collection = client["database"]["collection"]
+result = collection.find_one({})
+"""
+    )
+    index = _Index(tree)
+    assignment = next(candidate for candidate in index.root.candidates if candidate.target.id == "result")
+
+    assert isinstance(assignment.value, ast.Call)
+    assert call_candidate(assignment.value, index.root, assignment.target) == {
+        "document": {"pymongo_collection", "pymongo_find_one"}
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meaningless_vars_suggestions.py
+++ b/tests/test_meaningless_vars_suggestions.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import pytest
 
-from pre_commit_hooks.ast_checks._meaningless_vars_suggestions import (
+from pre_commit_hooks.ast_checks.meaningless_vars_suggestions.analysis import (
     Confidence,
     RenameProposal,
     _annotation_constraints,
@@ -661,6 +661,12 @@ def test_regular_singularization(name: str, expected: str) -> None:
         ("str", None, {"text"}),
         ("bytes", None, {"bytes"}),
         ("list[User]", "users", set()),
+        ("Optional[User]", "user", set()),
+        ("User | None", "user", set()),
+        ("Optional[_DocumentType]", "document_type", set()),
+        ("T | None", None, set()),
+        ("bool | None", None, {"bool"}),
+        ("Union[User, None]", "user", set()),
     ],
 )
 def test_annotation_helpers(annotation: str, name: str | None, constraints: set[str]) -> None:
@@ -866,6 +872,151 @@ def test_db_fetch_method_evidence_excludes_fetchnumpy() -> None:
     source = "def f(conn):\n    results = conn.fetchnumpy()\n    return results\n"
 
     _assert_plan_for(source, "results", None, None, meaningless_names=_WITH_RESULTS)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["find_one", "find_one_and_delete", "find_one_and_replace", "find_one_and_update"],
+)
+def test_pymongo_find_one_methods_produce_autofixable_documents(method_name: str) -> None:
+    source = f"""from typing import Optional
+from pymongo import MongoClient
+
+class Storage:
+    def __init__(self, connection: Optional[MongoClient] = None):
+        self.connection = connection or MongoClient()
+        self.collection = self.connection[\"database\"][\"collection\"]
+
+    def load(self):
+        result = self.collection.{method_name}({{}})
+        return result
+"""
+
+    _assert_plan_for(source, "result", "document", Confidence.AUTO_FIX)
+
+
+@pytest.mark.parametrize(
+    ("imports", "client_name"),
+    [
+        ("from pymongo import MongoClient", "MongoClient"),
+        ("from pymongo import MongoClient as Client", "Client"),
+        ("import pymongo", "pymongo.MongoClient"),
+        ("import pymongo as pm", "pm.MongoClient"),
+    ],
+)
+def test_pymongo_import_forms_and_collection_factory_produce_documents(imports: str, client_name: str) -> None:
+    source = f"""{imports}
+
+def load():
+    client = {client_name}()
+    collection = client.get_database(\"database\").get_collection(\"collection\")
+    result = collection.find_one({{}})
+    return result
+"""
+
+    _assert_plan_for(source, "result", "document", Confidence.AUTO_FIX)
+
+
+def test_unproven_find_one_does_not_produce_a_generic_suggestion() -> None:
+    source = "def load(collection):\n    result = collection.find_one({})\n    return result\n"
+
+    _assert_plan_for(source, "result", None, None)
+
+
+def test_concrete_annotation_wins_over_pymongo_document_name() -> None:
+    source = """from pymongo import MongoClient
+
+def load():
+    client = MongoClient()
+    collection = client[\"database\"][\"collection\"]
+    result: CacheDocument = collection.find_one({})
+    return result
+"""
+
+    _assert_plan_for(source, "result", "cache_document", Confidence.AUTO_FIX)
+
+
+def test_pymongo_collection_provenance_survives_a_containing_block() -> None:
+    source = """from pymongo import MongoClient
+
+class Storage:
+    def __init__(self):
+        self.collection = MongoClient()["database"]["collection"]
+
+    def load(self, enabled):
+        if enabled:
+            result = self.collection.find_one({})
+            return result
+"""
+
+    _assert_plan_for(source, "result", "document", Confidence.AUTO_FIX)
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected_name", "expected_confidence"),
+    [
+        (
+            'client = MongoClient()\n    client = 0\n    collection = client["database"]["collection"]',
+            None,
+            None,
+        ),
+        (
+            'client = build_client()\n    collection = client["database"]["collection"]',
+            None,
+            None,
+        ),
+        (
+            (
+                "client = MongoClient()\n"
+                "    connection = client.close()\n"
+                '    collection = connection["database"]["collection"]'
+            ),
+            None,
+            None,
+        ),
+        (
+            'client = MongoClient()\n    first, second = 1, 2\n    collection = client["database"]["collection"]',
+            "document",
+            Confidence.AUTO_FIX,
+        ),
+        (
+            'client = MongoClient()\n    collection: object = client["database"]["collection"]',
+            "document",
+            Confidence.AUTO_FIX,
+        ),
+    ],
+)
+def test_pymongo_provenance_handles_rebindings_and_nonname_targets(
+    setup: str,
+    expected_name: str | None,
+    expected_confidence: Confidence | None,
+) -> None:
+    source = f"""from pymongo import MongoClient
+
+def load():
+    {setup}
+    result = collection.find_one({{}})
+    return result
+"""
+
+    _assert_plan_for(source, "result", expected_name, expected_confidence)
+
+
+def test_pymongo_provenance_rejects_rebound_instance_attributes() -> None:
+    source = """from pymongo import MongoClient
+
+class Storage:
+    def __init__(self, other):
+        self.connection = MongoClient()
+        self.connection = other
+        self.collection = self.connection["database"]["collection"]
+
+    def load(self):
+        result = self.collection.find_one({})
+        return result
+"""
+
+    _assert_plan_for(source, "result", None, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meaningless_vars_suggestions.py
+++ b/tests/test_meaningless_vars_suggestions.py
@@ -687,6 +687,36 @@ def test_active_type_parameters_do_not_produce_annotation_names(source: str) -> 
     _assert_plan_for(source, "result", None, None)
 
 
+def test_class_type_parameters_remain_local_to_methods() -> None:
+    source = """import requests
+
+class Storage[RecordT]:
+    def load(self) -> RecordT:
+        result: RecordT = read()
+        return result
+
+    def fetch(self):
+        result = requests.get("https://example.test")
+        return result
+"""
+
+    proposals = _plans(source)
+
+    assert {proposal.name for proposal in proposals.values()} == {"response"}
+
+
+def test_function_return_type_parameter_uses_the_declaration_scope() -> None:
+    source = """def load[T]() -> T:
+    raise NotImplementedError
+
+def fetch():
+    result = load()
+    return result
+"""
+
+    _assert_plan_for(source, "result", None, None)
+
+
 def test_small_ast_helpers() -> None:
     command = ast.parse('["git", "status"]', mode="eval").body
     length_call = ast.parse("len(values)", mode="eval").body


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic naming suggestions for PyMongo MongoDB document lookups, including common collection access patterns and aliased imports.
  * Added support for optional and union type annotations.
  * Improved collection provenance tracking across classes, functions, assignments, and rebinding.
  * Suppressed uninformative suggestions when collection provenance cannot be confirmed.

* **Documentation**
  * Added guidance on PyMongo rename provenance and recognized APIs and data producers.

* **Tests**
  * Expanded coverage for PyMongo inference, annotation handling, aliases, and safe suggestion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->