### PR TITLE
feat(redundant-assignment): report the same violations at any path

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -13,6 +13,15 @@
   },
   "overrides": [
     {
+      // Every release section repeats the same "Added"/"Changed"/"Fixed"
+      // headings, one level under its own version.
+      "filter": ["CHANGELOG.md"],
+      "config": {
+        "MD024": { "siblings_only": true },
+      },
+      "combine": "merge",
+    },
+    {
       "filter": ["CLAUDE.md"],
       "config": {
         "MD041": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Changed
+
+- `redundant-assignment` no longer treats a file differently for living under `tests/`/`test/` or being named `test_*.py`/`*_test.py`. Such a file used to get a quieter version of the check; it now reports exactly what the same code reports anywhere else, at both levels. To keep the check off your tests, list it under `[tool.ruff-extra-rules.per-file-ignores]`. See [ADR-0055](docs/adr/0055-redundant-assignment-ignores-the-file-path.md).
+
 ## [0.0.50] - 2026-08-15
 
 ### Changed

--- a/docs/adr/0007-redundant-assignment-test-file-heuristic-deliberate.md
+++ b/docs/adr/0007-redundant-assignment-test-file-heuristic-deliberate.md
@@ -1,5 +1,7 @@
 # redundant_assignment's test-file path heuristic is a deliberate, scoped convention
 
+**Superseded by [ADR-0055](0055-redundant-assignment-ignores-the-file-path.md).** The "no outside consumers" premise this decision rests on no longer holds, and the heuristic is removed rather than kept or made configurable; TR5 now judges an assignment without consulting the file's path.
+
 `redundant_assignment/semantic.py:_is_test_file()` (lines 11-30) relaxes TR5's semantic-value threshold when a file's path contains `tests`/`test` or its filename matches `test_*`/`*_test.py`. Unlike the structurally similar `VariableTracker` scope-tracking decision (`docs/adr/0002-redundant-assignment-scope-tracker-not-unified.md`), this heuristic had no ADR recording it as intentional — it read as an implicit, undocumented coupling between TR5's output and a file's location in the tree, and `README.md` never mentions it exists.
 
 This project's own `CLAUDE.md` states it is a personal hobby project not used by anyone else, and explicitly rules out designing for hypothetical future requirements. `_is_test_file()`'s hardcoded conventions happen to match this repo's own layout (`tests/`, `test_*.py`); a hypothetical outside consumer with a different layout (`spec/`, `__tests__/`) would get silently different behavior with no way to configure it — but no such consumer currently exists.

--- a/docs/adr/0055-redundant-assignment-ignores-the-file-path.md
+++ b/docs/adr/0055-redundant-assignment-ignores-the-file-path.md
@@ -1,0 +1,25 @@
+# TR5 judges an assignment without consulting the file's path
+
+TR5 scored a variable's semantic value differently depending on the file's location in the tree: a path containing a `tests`/`test` component, or a `test_*.py`/`*_test.py` filename, raised the score of descriptive names enough to suppress reports that the identical code in `src/` would get. ADR-0007 recorded that as deliberate on the grounds that this project had no outside consumers and its own layout matched the hardcoded convention.
+
+That premise no longer holds (see ADR-0054), and a project laid out as `spec/` or `__tests__/` had no way to state its intent. Issue [#135](https://github.com/alessio-locatelli/ruff-extra-rules/issues/135) asked for a configuration surface to name those directories.
+
+## Decision
+
+Whether an assignment is a violation is decided from the code alone. The heuristic is removed rather than made configurable, and no new configuration key is added. The path still decides which files TR5 runs on — `exclude` (ADR-0046) and `per-file-ignores` (ADR-0049) are unaffected — but once TR5 is given a file, where that file sits changes nothing about the answer.
+
+The default level, `conservative`, exists to report only assignments that are redundant on the code's own terms — not ones that merely lose a style argument. A relaxation that suppresses reports in one directory is therefore either hiding real violations there, or admitting that the suppressed reports were never sound to begin with; a path is not evidence about an assignment. Both readings are defects at the default level, and neither is fixed by letting a project spell the directory differently.
+
+Wanting a check quieter in a subtree remains a real need. It is answered by settings that already exist and are not specific to one rule: `per-file-ignores` (ADR-0049) switches TR5 off for a matching pattern, and a project that only wants the _broader_ set of reports outside its tests can scope `--redundant-assignment-level=permissive` to a second hook entry with its own `files:`.
+
+## Considered Options
+
+- **Make the directory convention configurable, as issue #135 proposed** — a `pyproject.toml` key naming the test paths, or deriving them from `[tool.pytest.ini_options] testpaths`: rejected. It preserves the defect and adds a key to maintain, a validation surface, and a cache-identity input, all to let a project pick which files get the less accurate answer. ADR-0049 already provides the general form of "this check, not these files."
+- **Keep the relaxation for `permissive` only**: rejected. It leaves the hardcoded path convention in the codebase, so the issue's complaint survives for the level that reports the most — and `permissive` is precisely the level whose reports are already understood to be arguable, where an author's own judgement, not a directory name, is what decides.
+- **Keep the relaxation and document it** (ADR-0007's decision): superseded.
+
+## Consequences
+
+- A file whose path or name matched the old convention can now report violations it did not before, at either level. TR5's own scoring is otherwise untouched, so the newly reported assignments are the ones the rest of the rules already judge redundant.
+- One class of latent cache bug is gone by construction: a cached TR5 result can no longer be wrong for the file's content because the file moved.
+- ADR-0007 is superseded and annotated rather than rewritten, per the convention in ADR-0042 and ADR-0044.

--- a/docs/rules/redundant-assignment.md
+++ b/docs/rules/redundant-assignment.md
@@ -51,7 +51,6 @@ print(msg)
   - Type annotations
 - **Safe autofix mode**: automatically inlines simple, low-value assignments when mechanically safe — see [ADR-0032](../adr/0032-redundant-assignment-autofix-safety-criteria.md) for the exact safety criteria
 - Inline suppression with `# pytriage: TR5`
-- **Test-file relaxation**: a file under a `tests`/`test` directory, or named `test_*.py`/`*_test.py`, gets a higher semantic-value score for descriptive variable names — test code idiomatically uses named intermediates (`mock_response`, `expected_total`) for readability far more than production code does, so fewer of them get flagged
 - Gracefully handles:
   - Augmented assignments (`x += 1`)
   - Conditional assignments in if/else blocks

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -115,7 +115,7 @@ class RedundantAssignmentCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return [" = "]
 
-    def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
         # Tokenized once and reused for both lookups below, rather than
         # each independently tokenizing the whole file (see
         # find_ignored_lines_and_classify_comments).
@@ -154,7 +154,7 @@ class RedundantAssignmentCheck(BaseCheck):
             if lifecycle.assignment.line in ignored_lines or any(use.line in ignored_lines for use in lifecycle.uses):
                 continue
 
-            if not should_report_violation(lifecycle, pattern, filepath, level=self._level):
+            if not should_report_violation(lifecycle, pattern, level=self._level):
                 continue
 
             # Pass the real source lines so the line-length check matches

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 import ast
 from enum import Enum, auto
-from typing import TYPE_CHECKING
 
 from .analysis import PatternType, UsageInfo, VariableLifecycle, is_preceded_by_call
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class AggressivenessLevel(Enum):
@@ -17,18 +13,6 @@ class AggressivenessLevel(Enum):
 
     CONSERVATIVE = auto()
     PERMISSIVE = auto()
-
-
-def _is_test_file(filepath: Path | None) -> bool:
-    if filepath is None:
-        return False
-
-    parts = filepath.parts
-    if "tests" in parts or "test" in parts:
-        return True
-
-    filename = filepath.name
-    return filename.startswith("test_") or filename.endswith("_test.py")
 
 
 # Transformative verbs that indicate semantic value
@@ -245,8 +229,6 @@ def calculate_semantic_value(
     rhs_node: ast.expr,
     *,
     has_type_annotation: bool = False,
-    is_test_context: bool = False,
-    filepath: Path | None = None,
 ) -> int:
     """The score ranges from 0-100:
     - 0-20: No semantic value (redundant assignment, can auto-fix)
@@ -254,52 +236,6 @@ def calculate_semantic_value(
     - 50-100: Clear value (skip entirely)
     """
     score = 0
-
-    # Test code benefits more from named intermediate variables for clarity,
-    # so apply a higher semantic value to descriptive variables here.
-    if is_test_context or (filepath and _is_test_file(filepath)):
-        if len(var_name.split("_")) >= 2:
-            # e.g. "camel_case_sample", "duffel_route", "mock_image"
-            score += 30
-
-        test_semantic_words = {
-            "mock",
-            "fake",
-            "sample",
-            "expected",
-            "actual",
-            "result",
-            "fixture",
-            "data",
-            "template",
-            "response",
-            "request",
-            "some",
-            "example",
-            "test",
-        }
-        var_lower = var_name.lower()
-        if any(word in var_lower for word in test_semantic_words):
-            score += 25
-
-        # A common pattern for making assertions clearer.
-        # Example: result = landmark.__eq__(None); assert result is NotImplemented  # noqa: ERA001
-        if isinstance(rhs_node, ast.Call) and var_lower in {
-            "result",
-            "output",
-            "value",
-            "response",
-            "landmark",
-        }:
-            score += 30
-
-        # Example: some_european_airports = ["AES", "BYJ", "BTS"]  # noqa: ERA001
-        if isinstance(rhs_node, ast.List | ast.Dict | ast.Set):
-            score += 25
-
-        # Example: days_with_routes_in_a_row = range(70)  # noqa: ERA001
-        if isinstance(rhs_node, ast.Call) and isinstance(rhs_node.func, ast.Name) and rhs_node.func.id == "range":
-            score += 25
 
     # e.g. "raw_headers = kwargs.get('headers')".
     if _adds_verbosity_or_context(var_name, rhs_source, rhs_node):
@@ -541,7 +477,6 @@ def _is_named_string_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool
 def should_report_violation(
     lifecycle: VariableLifecycle,
     pattern: PatternType,
-    filepath: Path | None = None,
     level: AggressivenessLevel = AggressivenessLevel.CONSERVATIVE,
 ) -> bool:
     assignment = lifecycle.assignment
@@ -670,7 +605,6 @@ def should_report_violation(
         rhs_source=assignment.rhs_source,
         rhs_node=assignment.rhs_node,
         has_type_annotation=assignment.has_type_annotation,
-        filepath=filepath,
     )
 
     return semantic_score <= _report_score_ceiling(level, pattern)

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -750,35 +750,6 @@ def get_user(data):
         ),
         (
             """
-def test_camel_to_under():
-    camel_case_sample = "RandomClassName"
-    assert camel_to_under(camel_case_sample) == "random_class_name"
-""",
-            "tests/test_utils.py",
-            "camel_case_sample",
-        ),
-        (
-            """
-def test_translate_templates():
-    templates = ["Hello", "Goodbye"]
-    translator = MockTranslator(templates)
-    assert translator.templates == templates
-""",
-            "test_translator.py",
-            "templates",
-        ),
-        (
-            """
-def test_landmark_equal_to_none():
-    landmark = Landmark(name="Tower", long_lat=(2.0, 48.0), score=0.9)
-    result = landmark.__eq__(None)
-    assert result is NotImplemented
-""",
-            "tests/test_model.py",
-            "result",
-        ),
-        (
-            """
 def test_prepare_photo():
     mock_image = MagicMock()
     mock_vision.Image.return_value = mock_image
@@ -787,30 +758,6 @@ def test_prepare_photo():
 """,
             "tests/test_vision.py",
             "mock_image",
-        ),
-        (
-            """
-def test_airport_connectivity():
-    some_european_airports = ["AES", "BYJ", "BTS"]
-    assert all(
-        iata in airport_connectivity.airports_by_continent
-        for iata in some_european_airports
-    )
-""",
-            "tests/test_kiwi_api.py",
-            "some_european_airports",
-        ),
-        (
-            """
-def generate_price_data():
-    days_with_routes_in_a_row = range(70)
-    return [
-        faker.pyint(min_value=50, max_value=MAX_PRICE_EUR)
-        for _ in days_with_routes_in_a_row
-    ]
-""",
-            "tests/test_flight_prices.py",
-            "days_with_routes_in_a_row",
         ),
         (
             """
@@ -1033,12 +980,7 @@ def func(c):
         "descriptive-suffix-size",
         "descriptive-suffix-length",
         "descriptive-suffix-id",
-        "test-file-detection-by-path",
-        "test-file-detection-by-name",
-        "test-result-variable",
-        "test-mock-object",
-        "semantic-test-data-list",
-        "range-with-descriptive-name",
+        "non-generic-call-result-name",
         "context-manager-assignment-inside-usage-outside",
         "with-block-if-condition-pattern",
         "with-block-match-subject-pattern",
@@ -1286,15 +1228,25 @@ def call_it():
     assert any(v.line == 3 and "'x'" in v.message for v in violations)
 
 
-def test_non_test_file_still_flags_simple_assignments() -> None:
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/test_processor.py",
+        "spec/processor_spec.py",
+        "__tests__/processor.py",
+    ],
+)
+@pytest.mark.parametrize("level", [AggressivenessLevel.CONSERVATIVE, AggressivenessLevel.PERMISSIVE])
+def test_reporting_does_not_depend_on_the_file_path(path: str, level: AggressivenessLevel) -> None:
     source = """
-def process_data():
-    x = "foo"
-    return x
+def test_landmark_equal_to_none():
+    landmark = Landmark(name="Tower", long_lat=(2.0, 48.0), score=0.9)
+    result = landmark.__eq__(None)
+    assert result is NotImplemented
 """
-    violations = _check(source, "src/processor.py")
-    assert len(violations) > 0
-    assert any("x" in v.message for v in violations)
+    violations = _check(source, path, level=level)
+    assert [v.message for v in violations] == [v.message for v in _check(source, "src/processor.py", level=level)]
+    assert any("'result'" in v.message for v in violations)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/redundant_assignment/test_semantic.py
+++ b/tests/redundant_assignment/test_semantic.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import pytest
 
@@ -16,7 +15,6 @@ from pre_commit_hooks.ast_checks.redundant_assignment.semantic import (
     _is_generic_call_result_name,
     _is_named_constant_pattern,
     _is_named_string_constant_pattern,
-    _is_test_file,
     _would_require_parentheses,
     calculate_semantic_value,
     should_autofix,
@@ -382,37 +380,6 @@ def test_calculate_semantic_value_chained_attributes() -> None:
     assert calculate_semantic_value("result", rhs_source, rhs_node, has_type_annotation=False) >= 20
 
 
-@pytest.mark.parametrize(
-    ("var_name", "rhs_source", "minimum"),
-    [
-        # Rule 10 intercepts variables used solely inside comprehensions
-        # before they reach calculate_semantic_value, so these need a
-        # direct test: multi-part name (+30) + "some" in
-        # test_semantic_words (+25) + list bonus (+25).
-        ("some_european_airports", '["AES", "BYJ", "BTS"]', 25),
-        ("my_mapping", '{"key": "value"}', 25),
-        # multi-part name (+30) + no test_semantic_words match (+0) +
-        # range bonus (+25).
-        ("days_with_routes_in_a_row", "range(70)", 25),
-        # Covers the False branch of the test_semantic_words check: no
-        # semantic test words present.
-        ("flight_count", "42", 0),
-    ],
-    ids=[
-        "test-context-list-literal",
-        "test-context-dict-literal",
-        "test-context-range-call",
-        "test-context-no-semantic-word",
-    ],
-)
-def test_calculate_semantic_value_test_context(var_name: str, rhs_source: str, minimum: int) -> None:
-    rhs_node = ast.parse(rhs_source, mode="eval").body
-    assert (
-        calculate_semantic_value(var_name, rhs_source, rhs_node, has_type_annotation=False, is_test_context=True)
-        >= minimum
-    )
-
-
 # ---------------------------------------------------------------------------
 # _adds_verbosity_or_context
 # ---------------------------------------------------------------------------
@@ -534,44 +501,6 @@ def test_is_named_constant_pattern(var_name: str, rhs_source: str, *, expected: 
 def test_is_named_string_constant_pattern(var_name: str, rhs_source: str, *, expected: bool) -> None:
     node = ast.parse(rhs_source, mode="eval").body
     assert _is_named_string_constant_pattern(var_name, node) is expected
-
-
-# ---------------------------------------------------------------------------
-# _is_test_file
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("path", "expected"),
-    [
-        (Path("tests/test_something.py"), True),
-        (Path("tests/utils/test_helpers.py"), True),
-        (Path("test/test_foo.py"), True),
-        (Path("test_example.py"), True),
-        (Path("src/test_module.py"), True),
-        (Path("example_test.py"), True),
-        (Path("src/module_test.py"), True),
-        (Path("src/module.py"), False),
-        (Path("main.py"), False),
-        (Path("setup.py"), False),
-        (None, False),
-    ],
-    ids=[
-        "tests-directory",
-        "nested-tests-directory",
-        "singular-test-directory",
-        "test-prefix",
-        "test-prefix-nested",
-        "test-suffix",
-        "test-suffix-nested",
-        "plain-module",
-        "main",
-        "setup",
-        "none",
-    ],
-)
-def test_is_test_file(path: Path | None, *, expected: bool) -> None:
-    assert _is_test_file(path) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -62,9 +62,7 @@ def test_cache_hit_after_set(cache_manager: CacheManager, sample_file: Path, cal
 
 
 def test_cache_invalidated_on_content_change(cache_manager: CacheManager, sample_file: Path) -> None:
-    test_result: dict[str, list[str]] = {"violations": []}
-
-    cache_manager.set_cached_result(sample_file, "test-hook", test_result)
+    cache_manager.set_cached_result(sample_file, "test-hook", {"violations": []})
     assert cache_manager.get_cached_result(sample_file, "test-hook") is not None
 
     sample_file.write_text("def bar():\n    return 42\n")
@@ -75,9 +73,8 @@ def test_cache_invalidated_on_content_change(cache_manager: CacheManager, sample
 
 def test_mtime_changed_but_content_same(cache_manager: CacheManager, sample_file: Path) -> None:
     original_content = sample_file.read_text()
-    test_result: dict[str, list[str]] = {"violations": []}
 
-    cache_manager.set_cached_result(sample_file, "test-hook", test_result)
+    cache_manager.set_cached_result(sample_file, "test-hook", {"violations": []})
 
     time.sleep(0.01)  # ensure mtime changes
     sample_file.write_text(original_content)
@@ -187,8 +184,7 @@ def test_compute_tree_hash(tmp_path: Path, mutate: Callable[[Path], object], *, 
 
 
 def test_atomic_write(cache_manager: CacheManager, sample_file: Path) -> None:
-    test_result: dict[str, list[str]] = {"violations": []}
-    cache_manager.set_cached_result(sample_file, "test-hook", test_result)
+    cache_manager.set_cached_result(sample_file, "test-hook", {"violations": []})
 
     tmp_files = list(cache_manager.cache_dir.rglob("*.tmp"))
     assert len(tmp_files) == 0


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * `redundant-assignment` now reports consistently regardless of test-file paths or names.
  * Test-specific suppression must use `per-file-ignores` or scoped rule settings.
* **Documentation**
  * Updated rule documentation and changelog to reflect consistent reporting behavior.
  * Added an architectural decision record documenting the change and superseding the previous guidance.
* **Maintenance**
  * Updated validation coverage and Markdown linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->