### PR TITLE
feat(redundant-assignment): report a name echoed as its own keyword

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -100,7 +100,7 @@ repos:
         args: ["--redundant-type-conversion-level=permissive"]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.0.49
+    rev: v0.0.50
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Changed
 
 - `redundant-assignment` no longer treats a file differently for living under `tests/`/`test/` or being named `test_*.py`/`*_test.py`. Such a file used to get a quieter version of the check; it now reports exactly what the same code reports anywhere else, at both levels. To keep the check off your tests, list it under `[tool.ruff-extra-rules.per-file-ignores]`. See [ADR-0055](docs/adr/0055-redundant-assignment-ignores-the-file-path.md).
+- `redundant-assignment` now reports an assignment whose only use is `func(name=name)` — a keyword argument echoing the variable's own name — at the default (conservative) level, no matter how descriptive `name` looks. The keyword already states the name at the same call site, so it can't be adding information the name alone provides. `func(name)` positional calls are unaffected. See [ADR-0056](docs/adr/0056-redundant-assignment-keyword-argument-echo.md).
 
 ## [0.0.50] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+## [0.0.51] - 2026-08-16
+
 ### Changed
 
 - `redundant-assignment` no longer treats a file differently for living under `tests/`/`test/` or being named `test_*.py`/`*_test.py`. Such a file used to get a quieter version of the check; it now reports exactly what the same code reports anywhere else, at both levels. To keep the check off your tests, list it under `[tool.ruff-extra-rules.per-file-ignores]`. See [ADR-0055](docs/adr/0055-redundant-assignment-ignores-the-file-path.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing
 
-This is a personal hobby project maintained solo, entirely through coding agents. It isn't set up to take third-party pull requests.
-
-Opening an issue is welcome — bug reports, questions, suggestions — and will be looked at on a best-effort basis, with no guaranteed response time.
+PRs are welcome! If you plan to contribute a major change, please open an issue or discussion first to ensure we share a common understanding of the intended submission. See `AGENTS.md` for linting requirements, testing guidelines, and the expected quality baseline.
 
 For the technical walkthrough of how checks are built (if you're forking this or just curious), see [docs/adding-a-check.md](docs/adding-a-check.md).
 

--- a/docs/adr/0056-redundant-assignment-keyword-argument-echo.md
+++ b/docs/adr/0056-redundant-assignment-keyword-argument-echo.md
@@ -1,0 +1,29 @@
+# TR5 reports a keyword-argument echo at the default level, regardless of name descriptiveness
+
+## Context
+
+TR5 exempts a descriptively-named assignment from being reported through several independent guards: `_is_named_constant_pattern` treats a multi-part name assigned a numeric literal as a deliberately named constant; `_is_generic_call_result_name` exempts a `Call` RHS whose name isn't a generic placeholder or a restatement of the callee; `_is_named_string_constant_pattern` exempts a module-level SCREAMING_SNAKE_CASE string constant; and `calculate_semantic_value` awards points for a descriptive prefix/suffix, a transformative verb, a multi-part name, and a name longer than its RHS, any of which can clear the reporting ceiling on their own. Each is sound in general — a descriptive name usually does carry information the value does not.
+
+Issue [#172](https://github.com/alessio-locatelli/ruff-extra-rules/issues/172) reported a case where that reasoning breaks down: `func(days_with_routes_in_a_row=days_with_routes_in_a_row)`. The keyword argument already states the name, at the same source position, so the name cannot be adding information the call site doesn't already carry — no matter how descriptive it looks in isolation, and no matter which of the guards above would otherwise credit it. None of them looks at the use site to notice this.
+
+## Decision
+
+`redundant-assignment` reports an assignment whose single use is `func(name=name)` — a keyword argument whose keyword is exactly the variable's own name — regardless of how descriptive the name is, at both aggressiveness levels including the conservative default.
+
+Every rule that judges mechanical or structural safety still applies unchanged: loop/control-flow position, comments, `await`, line length, required parentheses, non-deterministic RHS calls, and the control-flow/comprehension usage-site mismatches. Only the rules whose entire purpose is judging whether `name` itself is "descriptive enough" — the named-constant pattern, the generic-call-result-name check, the module-level string-constant convention, and the semantic-value scoring — are withheld for this one pattern. A verbatim keyword echo is exact, local evidence available from the assignment and its use site alone, unlike the rest of that scoring, which is a heuristic guess at descriptiveness.
+
+The pattern is decided from the assignment and its single use, never from the callee's signature. `func(name)` positional is unaffected: which parameter `name` binds to lives in the callee's signature, possibly in another file, and resolving that is a materially larger feature (defaults, `*args`/`**kwargs`, keyword-only parameters, decorators, overloads) than this decision covers. That case is tracked separately rather than folded into this one.
+
+This is a MINOR change per [docs/releases.md](../releases.md): a run that was previously clean on code matching this pattern can now report it, at the level that runs by default.
+
+## Considered Options
+
+- **Withhold only the two guards the issue's reproduction exercised (the named-constant pattern and the semantic-value scoring), leaving the `Call`-RHS and string-constant guards active** — rejected. Both of those guards are just as name-keyed as the two the issue names; leaving them active would still under-report a keyword echo whose RHS happens to be a call or a module-level string constant, contradicting "regardless of how descriptive."
+- **Report only at the permissive level** — rejected. The evidence a keyword echo supplies is exact, not a heuristic judgment call the way the rest of TR5's scoring is, so it doesn't belong behind the flag that exists specifically to gate heuristic-but-arguable reports.
+- **Also resolve same-file positional arguments to their callee's parameter name** — rejected for this decision; tracked as a separate, larger feature (see Context).
+
+## Consequences
+
+- An assignment whose only use is `func(name=name)` is now reported at the conservative (default) level regardless of `name`'s shape or RHS — where it previously wasn't reported at all (numeric-literal RHS), was reported only at `permissive` (other literal RHS), or depended on whether the name restated its callee (`Call` RHS).
+- No autofix change was needed for a `Constant`/`Name` RHS: it was already always safe to inline per [ADR-0032](0032-redundant-assignment-autofix-safety-criteria.md), so `func(days_with_routes_in_a_row=42)` is fixable the same way any other constant-RHS single use already was. A `Call`/`Attribute` RHS keyword echo is reported the same as any other RHS shape, but ADR-0032's existing immediate-use and argument-count criteria still gate whether `--fix` touches it.
+- `func(name)` (positional) is unaffected by this decision.

--- a/src/pre_commit_hooks/__init__.py
+++ b/src/pre_commit_hooks/__init__.py
@@ -1,3 +1,3 @@
 """Custom pre-commit hooks for code quality enforcement."""
 
-__version__ = "0.0.50"
+__version__ = "0.0.51"

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -82,6 +82,7 @@ class UsageInfo:
     # including when in_fstring_expression is True but the use is only
     # part of a larger field expression (e.g. `{x.attr}`).
     fstring_field_span: tuple[int, int] | None = None
+    is_keyword_argument_echo: bool = False
 
 
 @dataclass(slots=True)
@@ -895,6 +896,8 @@ class VariableTracker(ast.NodeVisitor):
         ):
             fstring_field_span = (immediate_parent.col_offset, immediate_parent.end_col_offset)
 
+        is_keyword_argument_echo = isinstance(immediate_parent, ast.keyword) and immediate_parent.arg == node.id
+
         # Name-load context isn't resolved to anything more specific than
         # "unknown" — that would need walking parent nodes with a real
         # parent-tracking system. Only the other two UsageContext values
@@ -917,6 +920,7 @@ class VariableTracker(ast.NodeVisitor):
             enclosing_stmt=self.current_stmt,
             in_fstring_expression=in_fstring_expression,
             fstring_field_span=fstring_field_span,
+            is_keyword_argument_echo=is_keyword_argument_echo,
         )
 
         key = (scope_id, node.id)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -474,12 +474,17 @@ def _is_named_string_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool
     return var_name.lstrip("_").isupper()
 
 
+def _is_keyword_argument_echo(lifecycle: VariableLifecycle) -> bool:
+    return lifecycle.is_single_use and lifecycle.uses[0].is_keyword_argument_echo
+
+
 def should_report_violation(
     lifecycle: VariableLifecycle,
     pattern: PatternType,
     level: AggressivenessLevel = AggressivenessLevel.CONSERVATIVE,
 ) -> bool:
     assignment = lifecycle.assignment
+    is_keyword_argument_echo = _is_keyword_argument_echo(lifecycle)
 
     # Don't report assignments inside loops - they often accumulate/track state
     # across iterations even if they appear to have single use per iteration
@@ -541,7 +546,7 @@ def should_report_violation(
     # Rule 7: Don't report "magic number" patterns - numeric/simple literals
     # where the variable name provides semantic meaning
     # Examples: max_search_depth = 10, line_spacing = 1.2, user_id = 101749141
-    if _is_named_constant_pattern(assignment.var_name, assignment.rhs_node):
+    if not is_keyword_argument_echo and _is_named_constant_pattern(assignment.var_name, assignment.rhs_node):
         return False
 
     # Rule 8: Don't report when assignment is outside control flow but usage is inside
@@ -569,6 +574,9 @@ def should_report_violation(
     # Inlining would become O(n) attribute lookups inside the comprehension.
     if lifecycle.uses and all(use.in_comprehension for use in lifecycle.uses):
         return False
+
+    if is_keyword_argument_echo:
+        return True
 
     # Rule 11 (conservative level only): a Call RHS returns some domain
     # object the tracker can't inspect, so a name that isn't a generic

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -377,6 +377,57 @@ def func():
     assert all(not use.in_comprehension for use in lifecycle.uses)
 
 
+@pytest.mark.parametrize(
+    ("source", "var_name", "expected"),
+    [
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            True,
+        ),
+        (
+            """
+def caller():
+    x = 42
+    return func(other=x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def caller():
+    x = 42
+    return func(x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def caller():
+    x = 42
+    return func(x=x + 1)
+""",
+            "x",
+            False,
+        ),
+    ],
+    ids=["keyword-echo", "different-keyword", "positional", "expression-value"],
+)
+def test_is_keyword_argument_echo(source: str, var_name: str, *, expected: bool) -> None:
+    lifecycle = _lifecycle_for(source, var_name)
+    assert lifecycle.uses[0].is_keyword_argument_echo is expected
+
+
 def test_for_iterator_use_is_not_in_loop() -> None:
     # `node.iter` evaluates exactly once, before any iteration — unlike a
     # use inside the loop body, it must not be marked in_loop.

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -293,6 +293,31 @@ def test_autofix_simple_constant(tmp_path: Path) -> None:
     assert "result = 42 + 10" in fixed_content
 
 
+def test_autofix_keyword_argument_echo(tmp_path: Path) -> None:
+    source = """def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
+"""
+    filepath = tmp_path / "source.py"
+    filepath.write_text(source)
+
+    tree = ast.parse(source)
+    check = RedundantAssignmentCheck()
+    violations = check.check(filepath, tree, source)
+
+    fixable_violations = [v for v in violations if v.fixable]
+    assert fixable_violations
+    assert check.fix(filepath, fixable_violations, source, tree) is True
+
+    fixed_content = filepath.read_text()
+    assert "days_with_routes_in_a_row = 42" not in fixed_content
+    assert "func(days_with_routes_in_a_row=42)" in fixed_content
+
+
 def test_autofix_simple_attribute(tmp_path: Path) -> None:
     source = """def f():
     v = obj.attr

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -1355,9 +1355,10 @@ def func_scope():
 
 
 @pytest.mark.parametrize(
-    "source",
+    ("source", "var_name", "reported"),
     [
-        """
+        (
+            """
 def func(days_with_routes_in_a_row: int) -> int:
     return days_with_routes_in_a_row
 
@@ -1366,7 +1367,11 @@ def caller() -> int:
     days_with_routes_in_a_row = 42
     return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
 """,
-        """
+            "days_with_routes_in_a_row",
+            True,
+        ),
+        (
+            """
 def func(days_with_routes_in_a_row: str) -> str:
     return days_with_routes_in_a_row
 
@@ -1375,46 +1380,38 @@ def caller() -> str:
     days_with_routes_in_a_row = "foo"
     return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
 """,
-    ],
-    ids=["numeric-literal", "string-literal"],
-)
-def test_keyword_argument_echo_reported_at_conservative_level(source: str) -> None:
-    violations = _check(source)
-    assert any("days_with_routes_in_a_row" in v.message for v in violations)
-
-
-def test_keyword_argument_echo_reported_despite_descriptive_prefix_and_call_rhs() -> None:
-    source = """
+            "days_with_routes_in_a_row",
+            True,
+        ),
+        (
+            """
 def caller():
     has_permission = check_something()
     return func(has_permission=has_permission)
-"""
-    violations = _check(source)
-    assert any("has_permission" in v.message for v in violations)
-
-
-def test_descriptive_name_not_echoed_as_own_keyword_keeps_exemption() -> None:
-    source = """
+""",
+            "has_permission",
+            True,
+        ),
+        (
+            """
 def caller() -> int:
     days_with_routes_in_a_row = 42
     return func(total_days=days_with_routes_in_a_row)
-"""
-    violations = _check(source)
-    assert all("days_with_routes_in_a_row" not in v.message for v in violations)
-
-
-def test_call_rhs_generic_name_guard_still_applies_when_not_a_keyword_echo() -> None:
-    source = """
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
 def caller():
     has_permission = check_something()
     return func(has_permission)
-"""
-    violations = _check(source)
-    assert all("has_permission" not in v.message for v in violations)
-
-
-def test_positional_argument_matching_parameter_name_not_flagged() -> None:
-    source = """
+""",
+            "has_permission",
+            False,
+        ),
+        (
+            """
 def func(days_with_routes_in_a_row: int) -> int:
     return days_with_routes_in_a_row
 
@@ -1422,9 +1419,26 @@ def func(days_with_routes_in_a_row: int) -> int:
 def caller() -> int:
     days_with_routes_in_a_row = 42
     return func(days_with_routes_in_a_row)
-"""
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+    ],
+    ids=[
+        "numeric-literal-echo",
+        "string-literal-echo",
+        "descriptive-prefix-call-rhs-echo",
+        "different-keyword-not-echo",
+        "call-rhs-positional-not-echo",
+        "positional-argument-not-echo",
+    ],
+)
+def test_keyword_argument_echo_reporting(source: str, var_name: str, *, reported: bool) -> None:
     violations = _check(source)
-    assert all("days_with_routes_in_a_row" not in v.message for v in violations)
+    if reported:
+        assert any(var_name in v.message for v in violations)
+    else:
+        assert all(var_name not in v.message for v in violations)
 
 
 def test_annotated_assignment_tracked() -> None:

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -1354,6 +1354,79 @@ def func_scope():
     assert "x" in violation.message
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
+""",
+        """
+def func(days_with_routes_in_a_row: str) -> str:
+    return days_with_routes_in_a_row
+
+
+def caller() -> str:
+    days_with_routes_in_a_row = "foo"
+    return func(days_with_routes_in_a_row=days_with_routes_in_a_row)
+""",
+    ],
+    ids=["numeric-literal", "string-literal"],
+)
+def test_keyword_argument_echo_reported_at_conservative_level(source: str) -> None:
+    violations = _check(source)
+    assert any("days_with_routes_in_a_row" in v.message for v in violations)
+
+
+def test_keyword_argument_echo_reported_despite_descriptive_prefix_and_call_rhs() -> None:
+    source = """
+def caller():
+    has_permission = check_something()
+    return func(has_permission=has_permission)
+"""
+    violations = _check(source)
+    assert any("has_permission" in v.message for v in violations)
+
+
+def test_descriptive_name_not_echoed_as_own_keyword_keeps_exemption() -> None:
+    source = """
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(total_days=days_with_routes_in_a_row)
+"""
+    violations = _check(source)
+    assert all("days_with_routes_in_a_row" not in v.message for v in violations)
+
+
+def test_call_rhs_generic_name_guard_still_applies_when_not_a_keyword_echo() -> None:
+    source = """
+def caller():
+    has_permission = check_something()
+    return func(has_permission)
+"""
+    violations = _check(source)
+    assert all("has_permission" not in v.message for v in violations)
+
+
+def test_positional_argument_matching_parameter_name_not_flagged() -> None:
+    source = """
+def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+"""
+    violations = _check(source)
+    assert all("days_with_routes_in_a_row" not in v.message for v in violations)
+
+
 def test_annotated_assignment_tracked() -> None:
     source = """
 def example():


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved redundant-assignment detection for values used as same-name keyword arguments in function calls.
  - These cases are now reported consistently while positional arguments and unrelated keyword names remain unaffected.
  - Autofix can remove the redundant assignment and inline its value.

- **Documentation**
  - Added release notes and decision documentation describing the updated behavior.

- **Chores**
  - Updated linting tool configurations and released version 0.0.51.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->