### PR TITLE
fix(misplaced-comment): preserve Sphinx attribute docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Changed
+
+- `misplaced-comment` leaves Sphinx `#:` variable documentation comments trailing multiline module-level assignments, where Sphinx recognizes them, instead of moving them into the expression.
+
 ## [0.0.51] - 2026-08-16
 
 ### Changed

--- a/docs/rules/misplaced-comment.md
+++ b/docs/rules/misplaced-comment.md
@@ -22,11 +22,11 @@ result = func(
 
 ## Features
 
-- Automatically moves comments from closing bracket lines to expression lines
+- Automatically moves comments from closing bracket lines to expression lines, except Sphinx `#:` documentation comments on module-level assignments
 - Places comments inline if they fit within 88 characters, matching this project's own line-length convention; otherwise places them as preceding comments on their own line
 - Never moves linter pragma comments (`noqa`, `type: ignore`, `pragma:`, etc.)
 - Inline suppression with `# pytriage: TR7`
-- Preserves the source file's PEP 263 declared encoding; lines untouched by a fix also keep their original newline style (CRLF/LF) — a line a fix rewrites gets a plain `\n`
+- Preserves the source file's PEP 263 declared encoding and newline style
 
 Its fix is a purely mechanical text move that never changes semantics, so it's always safe to include in a `--fix` run alongside every other check:
 

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -10,6 +10,7 @@ Inline ignore: # pytriage: TR7
 
 from __future__ import annotations
 
+import ast
 import functools
 import logging
 import re
@@ -29,7 +30,6 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
-    import ast
     from pathlib import Path
 
 logger = logging.getLogger("misplaced_comment")
@@ -89,6 +89,7 @@ class _MisplacedComment:
 
 def _scan_misplaced_comments(
     tokens: tuple[tokenize.TokenInfo, ...],
+    tree: ast.Module,
 ) -> list[_MisplacedComment]:
     """Find comments trailing bracket-only closing lines.
 
@@ -106,6 +107,11 @@ def _scan_misplaced_comments(
     for token in tokens:
         tokens_by_line.setdefault(token.start[0], []).append(token)
 
+    sphinx_attribute_comment_lines = {
+        node.end_lineno
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.end_lineno is not None
+    }
     found: list[_MisplacedComment] = []
     seen_bracket_lines: set[int] = set()
 
@@ -119,9 +125,15 @@ def _scan_misplaced_comments(
 
         line_tokens = tokens_by_line[bracket_line]
         comment_token = next((t for t in line_tokens if t.type == tokenize.COMMENT), None)
+        is_sphinx_attribute_comment = (
+            comment_token is not None
+            and comment_token.string.startswith("#:")
+            and bracket_line in sphinx_attribute_comment_lines
+        )
         if (
             comment_token is not None
             and not is_linter_pragma(comment_token.string)
+            and not is_sphinx_attribute_comment
             and is_bracket_only_line(line_tokens)
         ):
             found.append(
@@ -150,9 +162,9 @@ class MisplacedCommentCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["#"]
 
-    def check(self, _filepath: Path, _tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
         tokens = tuple(tokenize_source(source))
-        found = _scan_misplaced_comments(tokens)
+        found = _scan_misplaced_comments(tokens, tree)
         if not found:
             return []
 
@@ -179,11 +191,11 @@ class MisplacedCommentCheck(BaseCheck):
         filepath: Path,
         violations: list[Violation],
         source: str,
-        _tree: ast.Module,
+        tree: ast.Module,
         encoding: str = "utf-8",
     ) -> bool:
         tokens = tuple(tokenize_source(source))
-        found = _scan_misplaced_comments(tokens)
+        found = _scan_misplaced_comments(tokens, tree)
         if not found:
             return False
 

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from pre_commit_hooks.ast_checks._base import is_fix_failed
+from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks.misplaced_comment import MisplacedCommentCheck
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "misplaced_comments"
@@ -55,6 +56,40 @@ def test_check_detects_trailing_comment(source: str, line: int, *, fixable: bool
 )
 def test_check_returns_no_violations(source: str) -> None:
     assert MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_source", "expected_exit_code"),
+    [
+        (
+            "value = make_value(\n    argument\n)  #: Description\n",
+            "value = make_value(\n    argument\n)  #: Description\n",
+            0,
+        ),
+        (
+            "value: object = make_value(\n    argument\n)  #: Description\n",
+            "value: object = make_value(\n    argument\n)  #: Description\n",
+            0,
+        ),
+        (
+            "def make_value():\n    process(\n        argument\n    )  #: Description\n",
+            "def make_value():\n    process(\n        argument  #: Description\n    )\n",
+            1,
+        ),
+    ],
+    ids=["module-level-assignment", "module-level-annotated-assignment", "nested-expression"],
+)
+def test_cli_fix_handles_sphinx_attribute_comments(
+    source: str,
+    expected_source: str,
+    expected_exit_code: int,
+    tmp_path: Path,
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text(source)
+
+    assert main(["--select", "misplaced-comment", "--fix", str(filepath)]) == expected_exit_code
+    assert filepath.read_text() == expected_source
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sphinx attribute comments (`#:`) at the end of module-level assignments are now preserved and no longer reported as misplaced.
  - Fixes retain the file’s declared encoding and newline style.
  - Nested-expression comments continue to be moved to the appropriate preceding line when needed.

- **Documentation**
  - Updated rule documentation and changelog to describe the improved comment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->