### PR TITLE
fix(validate-function-name): prevent partial cross-file renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-16
+
 ### Changed
 
 - `misplaced-comment` leaves Sphinx `#:` variable documentation comments trailing multiline module-level assignments, where Sphinx recognizes them, instead of moving them into the expression.
 - `redundant-assignment` keeps separately named variables with identical right-hand-side expressions in the same scope, so comparisons can show results from independent evaluations without reports.
 - `redundant-assignment` no longer reports a value used only inside a lambda, preserving its capture and evaluation timing.
+- `validate-function-name` keeps a rename report-only when the existing name occurs in another tracked Python file, preventing a `--fix` run from leaving cross-file references stale.
 
 ## [0.0.51] - 2026-08-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ ignore = [
   "FBT001",
 ]
 "tests/performance/**" = ["S603"]
+"src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py" = ["S603"]
+"tests/validate_function_name/test_check.py" = ["S603"]
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip"

--- a/src/pre_commit_hooks/__init__.py
+++ b/src/pre_commit_hooks/__init__.py
@@ -1,3 +1,3 @@
 """Custom pre-commit hooks for code quality enforcement."""
 
-__version__ = "0.0.51"
+__version__ = "0.1.0"

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -46,7 +46,13 @@ from pre_commit_hooks.ast_checks._base import (
 )
 
 from .analysis import Suggestion, collect_suggestions
-from .autofix import apply_fix, index_function_nodes, is_autofix_safe, should_autofix
+from .autofix import (
+    _repository_reference_status,
+    apply_fix,
+    index_function_nodes,
+    is_autofix_safe,
+    should_autofix,
+)
 
 if TYPE_CHECKING:
     import ast
@@ -88,6 +94,8 @@ class ValidateFunctionNameCheck(BaseCheck):
 
         violations = []
         for suggestion in suggestions:
+            auto_fixable = not suggestion.requires_property and is_autofix_safe(function_index, suggestion)
+            reference_status = _repository_reference_status(filepath, suggestion.func_name) if auto_fixable else "safe"
             if suggestion.requires_property:
                 message = (
                     f"Function '{suggestion.func_name}' should use @property "
@@ -98,6 +106,10 @@ class ValidateFunctionNameCheck(BaseCheck):
                     f"Function '{suggestion.func_name}' should be renamed to "
                     f"'{suggestion.suggested_name}' ({suggestion.reason})"
                 )
+            if reference_status == "external":
+                message += "; manual rename required because the existing name occurs elsewhere in the repository"
+            elif reference_status == "unavailable":
+                message += "; manual rename required because repository references could not be checked"
 
             fix_data: ValidateFunctionNameFixData = {"suggestion": suggestion}
             violations.append(
@@ -107,7 +119,7 @@ class ValidateFunctionNameCheck(BaseCheck):
                     line=suggestion.lineno,
                     col=0,
                     message=message,
-                    fixable=not suggestion.requires_property and is_autofix_safe(function_index, suggestion),
+                    fixable=auto_fixable and reference_status == "safe",
                     # Violation.fix_data is intentionally untyped (dict[str,
                     # Any]) at this boundary; see ValidateFunctionNameFixData
                     # above for the shape check()/fix() actually agree on.
@@ -149,7 +161,10 @@ class ValidateFunctionNameCheck(BaseCheck):
             if not suggestion or suggestion.requires_property:
                 continue
 
-            if should_autofix(filepath, suggestion):
+            if (
+                should_autofix(filepath, suggestion)
+                and _repository_reference_status(filepath, suggestion.func_name) == "safe"
+            ):
                 try:
                     if apply_fix(filepath, suggestion):
                         applied_any = True

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
@@ -146,6 +146,7 @@ def _repository_reference_status(filepath: Path, name: str) -> RepositoryReferen
                 "grep",
                 "--files-with-matches",
                 "--null",
+                "--untracked",
                 "--fixed-strings",
                 "-e",
                 name,

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import ast
 import logging
 import re
-from typing import TYPE_CHECKING
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Literal
 
 from pre_commit_hooks.ast_checks._base import (
     atomic_write_text,
@@ -17,14 +20,12 @@ from pre_commit_hooks.ast_checks._scope import iter_within_scope
 
 from .analysis import IGNORE_PATTERN, Suggestion, attach_parents, read_source
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 logger = logging.getLogger("validate-function-name")
 
 _FuncNode = ast.FunctionDef | ast.AsyncFunctionDef
 
 type SourcePosition = tuple[int, int]  # (1-indexed line, 0-indexed character column)
+type RepositoryReferenceStatus = Literal["safe", "external", "unavailable"]
 
 
 def _count_nesting_depth(func_node: _FuncNode) -> int:
@@ -109,6 +110,64 @@ def should_autofix(filepath: Path, suggestion: Suggestion) -> bool:
 
     attach_parents(tree)
     return is_autofix_safe(index_function_nodes(tree), suggestion)
+
+
+def _repository_reference_status(filepath: Path, name: str) -> RepositoryReferenceStatus:
+    git = shutil.which("git")
+    if git is None:
+        logger.warning("Could not safely search repository references because git is unavailable")
+        return "unavailable"
+
+    try:
+        root_result = subprocess.run(  # noqa: S603
+            [git, "-C", filepath.parent, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.SubprocessError, FileNotFoundError, subprocess.TimeoutExpired:
+        logger.warning("Could not safely establish repository scope for %s", filepath)
+        return "unavailable"
+
+    if root_result.returncode != 0 or root_result.stderr:
+        if root_result.returncode == 128 and "not a git repository" in root_result.stderr:
+            return "safe"
+        logger.warning("Could not safely establish repository scope for %s", filepath)
+        return "unavailable"
+
+    root = Path(root_result.stdout.strip())
+    try:
+        reference_result = subprocess.run(  # noqa: S603
+            [
+                git,
+                "-C",
+                root,
+                "grep",
+                "--files-with-matches",
+                "--null",
+                "--fixed-strings",
+                "-e",
+                name,
+                "--",
+                ":(glob)**/*.py",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.SubprocessError, FileNotFoundError, subprocess.TimeoutExpired:
+        logger.warning("Could not safely search repository references for %s", name)
+        return "unavailable"
+
+    if reference_result.returncode not in (0, 1) or reference_result.stderr:
+        logger.warning("Could not safely search repository references for %s", name)
+        return "unavailable"
+
+    if any((root / path).resolve() != filepath.resolve() for path in reference_result.stdout.split("\0") if path):
+        return "external"
+    return "safe"
 
 
 def is_autofix_safe(function_index: FunctionIndex, suggestion: Suggestion) -> bool:

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
@@ -119,7 +119,7 @@ def _repository_reference_status(filepath: Path, name: str) -> RepositoryReferen
         return "unavailable"
 
     try:
-        root_result = subprocess.run(  # noqa: S603
+        root_result = subprocess.run(
             [git, "-C", filepath.parent, "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
@@ -138,7 +138,7 @@ def _repository_reference_status(filepath: Path, name: str) -> RepositoryReferen
 
     root = Path(root_result.stdout.strip())
     try:
-        reference_result = subprocess.run(  # noqa: S603
+        reference_result = subprocess.run(
             [
                 git,
                 "-C",

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -257,22 +257,10 @@ def test_check_marks_rename_unfixable_when_repository_search_errors(
     assert "Could not safely search repository references" in caplog.text
 
 
-def test_fix_refuses_a_rename_referenced_by_another_repository_file(tmp_path: Path) -> None:
+@pytest.mark.parametrize("tracked", [True, False], ids=["tracked", "untracked"])
+def test_fix_refuses_a_rename_referenced_by_another_repository_file(tmp_path: Path, *, tracked: bool) -> None:
     git, filepath, source = _repository_with_fixable_target(tmp_path)
-    _add_external_reference(filepath, git)
-
-    check = ValidateFunctionNameCheck()
-    violations = check.check(filepath, ast.parse(source), source)
-
-    assert len(violations) == 1
-    assert violations[0].fixable is False
-    assert check.fix(filepath, violations, source, ast.parse(source)) is False
-    assert filepath.read_text() == source
-
-
-def test_fix_refuses_a_rename_referenced_by_an_untracked_repository_file(tmp_path: Path) -> None:
-    git, filepath, source = _repository_with_fixable_target(tmp_path)
-    _add_external_reference(filepath, git, tracked=False)
+    _add_external_reference(filepath, git, tracked=tracked)
 
     check = ValidateFunctionNameCheck()
     violations = check.check(filepath, ast.parse(source), source)

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -23,18 +23,18 @@ if TYPE_CHECKING:
 def _repository_with_fixable_target(tmp_path: Path) -> tuple[str, Path, str]:
     git = shutil.which("git")
     assert git is not None
-    subprocess.run([git, "init", "-q"], check=True, cwd=tmp_path)  # noqa: S603
+    subprocess.run([git, "init", "-q"], check=True, cwd=tmp_path)
 
     filepath = tmp_path / "definitions.py"
     source = "def get_data() -> bool:\n    return True\n"
     filepath.write_text(source)
-    subprocess.run([git, "add", "definitions.py"], check=True, cwd=tmp_path)  # noqa: S603
+    subprocess.run([git, "add", "definitions.py"], check=True, cwd=tmp_path)
     return git, filepath, source
 
 
 def _add_external_reference(filepath: Path, git: str) -> None:
     (filepath.parent / "consumer.py").write_text("from definitions import get_data\n\nvalue = get_data()\n")
-    subprocess.run([git, "add", "consumer.py"], check=True, cwd=filepath.parent)  # noqa: S603
+    subprocess.run([git, "add", "consumer.py"], check=True, cwd=filepath.parent)
 
 
 def _check_fixability(tmp_path: Path) -> bool:

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -32,9 +32,10 @@ def _repository_with_fixable_target(tmp_path: Path) -> tuple[str, Path, str]:
     return git, filepath, source
 
 
-def _add_external_reference(filepath: Path, git: str) -> None:
+def _add_external_reference(filepath: Path, git: str, *, tracked: bool = True) -> None:
     (filepath.parent / "consumer.py").write_text("from definitions import get_data\n\nvalue = get_data()\n")
-    subprocess.run([git, "add", "consumer.py"], check=True, cwd=filepath.parent)
+    if tracked:
+        subprocess.run([git, "add", "consumer.py"], check=True, cwd=filepath.parent)
 
 
 def _check_fixability(tmp_path: Path) -> bool:
@@ -259,6 +260,19 @@ def test_check_marks_rename_unfixable_when_repository_search_errors(
 def test_fix_refuses_a_rename_referenced_by_another_repository_file(tmp_path: Path) -> None:
     git, filepath, source = _repository_with_fixable_target(tmp_path)
     _add_external_reference(filepath, git)
+
+    check = ValidateFunctionNameCheck()
+    violations = check.check(filepath, ast.parse(source), source)
+
+    assert len(violations) == 1
+    assert violations[0].fixable is False
+    assert check.fix(filepath, violations, source, ast.parse(source)) is False
+    assert filepath.read_text() == source
+
+
+def test_fix_refuses_a_rename_referenced_by_an_untracked_repository_file(tmp_path: Path) -> None:
+    git, filepath, source = _repository_with_fixable_target(tmp_path)
+    _add_external_reference(filepath, git, tracked=False)
 
     check = ValidateFunctionNameCheck()
     violations = check.check(filepath, ast.parse(source), source)

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -1,20 +1,47 @@
 from __future__ import annotations
 
 import ast
+import shutil
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
 
 import pre_commit_hooks.ast_checks.validate_function_name as module
 from pre_commit_hooks.ast_checks._base import FixValidationError, is_fix_errored, is_fix_rejected
-from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck
+from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck, autofix
 from tests._helpers import raises, restricted_permissions
 from tests.factories import ViolationFactory
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from pre_commit_hooks.ast_checks.validate_function_name.analysis import Suggestion
+
+
+def _repository_with_fixable_target(tmp_path: Path) -> tuple[str, Path, str]:
+    git = shutil.which("git")
+    assert git is not None
+    subprocess.run([git, "init", "-q"], check=True, cwd=tmp_path)  # noqa: S603
+
+    filepath = tmp_path / "definitions.py"
+    source = "def get_data() -> bool:\n    return True\n"
+    filepath.write_text(source)
+    subprocess.run([git, "add", "definitions.py"], check=True, cwd=tmp_path)  # noqa: S603
+    return git, filepath, source
+
+
+def _add_external_reference(filepath: Path, git: str) -> None:
+    (filepath.parent / "consumer.py").write_text("from definitions import get_data\n\nvalue = get_data()\n")
+    subprocess.run([git, "add", "consumer.py"], check=True, cwd=filepath.parent)  # noqa: S603
+
+
+def _check_fixability(tmp_path: Path) -> bool:
+    source = "def get_data() -> bool:\n    return True\n"
+    violations = ValidateFunctionNameCheck().check(tmp_path / "definitions.py", ast.parse(source), source)
+    assert len(violations) == 1
+    return violations[0].fixable
 
 
 def test_check_uses_given_tree_and_source_not_disk(tmp_path: Path) -> None:
@@ -157,6 +184,103 @@ def test_check_does_not_mark_unfixable_violation_fixable(tmp_path: Path) -> None
 
     assert len(violations) == 1
     assert violations[0].fixable is False
+
+
+def test_check_marks_rename_unfixable_when_git_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(autofix.shutil, "which", lambda _name: None)
+
+    with caplog.at_level("WARNING"):
+        assert _check_fixability(tmp_path) is False
+
+    assert "git is unavailable" in caplog.text
+
+
+def test_check_marks_rename_unfixable_when_repository_root_lookup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(autofix.subprocess, "run", raises(subprocess.SubprocessError, "simulated root lookup failure"))
+
+    with caplog.at_level("WARNING"):
+        assert _check_fixability(tmp_path) is False
+
+    assert "Could not safely establish repository scope" in caplog.text
+
+
+def test_check_marks_rename_unfixable_when_repository_root_lookup_returns_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        autofix.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 2, "", "simulated root lookup error"),
+    )
+
+    with caplog.at_level("WARNING"):
+        assert _check_fixability(tmp_path) is False
+
+    assert "Could not safely establish repository scope" in caplog.text
+
+
+def test_check_marks_rename_unfixable_when_repository_reference_search_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def fail_reference_search(command: Sequence[str | Path], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in command:
+            return subprocess.CompletedProcess(command, 0, str(tmp_path), "")
+        raise subprocess.SubprocessError("simulated reference search failure")
+
+    monkeypatch.setattr(autofix.subprocess, "run", fail_reference_search)
+
+    with caplog.at_level("WARNING"):
+        assert _check_fixability(tmp_path) is False
+
+    assert "Could not safely search repository references" in caplog.text
+
+
+def test_check_marks_rename_unfixable_when_repository_search_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def repository_search_error(command: Sequence[str | Path], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in command:
+            return subprocess.CompletedProcess(command, 0, str(tmp_path), "")
+        return subprocess.CompletedProcess(command, 2, "", "simulated search error")
+
+    monkeypatch.setattr(autofix.subprocess, "run", repository_search_error)
+
+    with caplog.at_level("WARNING"):
+        assert _check_fixability(tmp_path) is False
+
+    assert "Could not safely search repository references" in caplog.text
+
+
+def test_fix_refuses_a_rename_referenced_by_another_repository_file(tmp_path: Path) -> None:
+    git, filepath, source = _repository_with_fixable_target(tmp_path)
+    _add_external_reference(filepath, git)
+
+    check = ValidateFunctionNameCheck()
+    violations = check.check(filepath, ast.parse(source), source)
+
+    assert len(violations) == 1
+    assert violations[0].fixable is False
+    assert check.fix(filepath, violations, source, ast.parse(source)) is False
+    assert filepath.read_text() == source
+
+
+def test_fix_rechecks_repository_references_before_writing(tmp_path: Path) -> None:
+    git, filepath, source = _repository_with_fixable_target(tmp_path)
+
+    check = ValidateFunctionNameCheck()
+    violations = check.check(filepath, ast.parse(source), source)
+    assert len(violations) == 1
+    assert violations[0].fixable is True
+
+    _add_external_reference(filepath, git)
+
+    assert check.fix(filepath, violations, source, ast.parse(source)) is False
+    assert filepath.read_text() == source
 
 
 def test_fix_returns_false_when_apply_fix_fails_without_raising(


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic function renaming by checking references across the repository before applying changes.
  - Prevents potentially unsafe renames when external references are detected or repository checks are unavailable.
  - Reports cases requiring manual intervention.
  - Rechecks reference safety immediately before each rename.

- **Release**
  - Updated the package version to 0.1.0.
  - Added changelog documentation describing safer rename behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->