### PR TITLE
refactor(fix): use typed fixer outcomes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
         args: ["--redundant-type-conversion-level=permissive"]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.0.50
+    rev: v0.1.0
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Changed
+
+- `--fix` reports whether each fix was applied, declined for safety, rejected, interrupted, or failed to write, so an operational failure is visible without being confused with a safety decision.
+
 ## [0.1.0] - 2026-08-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ### Changed
 
-- `--fix` reports whether each fix was applied, declined for safety, rejected, interrupted, or failed to write, so an operational failure is visible without being confused with a safety decision.
+- `--fix` reports whether each fix was applied, declined for safety, rejected, aborted, errored, or failed to write, so an operational failure is visible without being confused with a safety decision.
 
 ## [0.1.0] - 2026-08-16
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,16 +50,19 @@ _Avoid_: autofix is fine informally; "fix" is the protocol method name
 
 **Fix rejection**:
 The outcome when `atomic_write_text()` refuses a fix because the content it was asked to write doesn't parse as valid Python. Reported as `[FIX REJECTED]`, distinct from `[FIXED]`/`[FIXABLE]` — it signals a bug in the check's own fix logic, not something re-running `--fix` will resolve.
-_Avoid_: failed fix, broken fix — "rejected" is the term the CLI output and `is_fix_rejected()`/`mark_fix_rejected()` use
+_Avoid_: failed fix, broken fix — "rejected" is the CLI term
 
 **Fix error**:
 The outcome when a check's own `fix()` raises an exception other than `FixValidationError` — a bug in the check's fix logic itself, distinct from a fix rejection (which means `fix()` ran to completion but its _output_ didn't parse). Reported as `[FIX ERRORED]`, also not something re-running `--fix` will resolve (see `docs/adr/0012-behavioral-contract-audit-internal-errors-exit-codes.md`).
-_Avoid_: fix rejection, crash — "errored" is the term the CLI output and `is_fix_errored()`/`mark_fix_errored()` use; a fix rejection never reaches this path since it's a normal, expected outcome, not an unhandled exception
+_Avoid_: fix rejection, crash — "errored" is the CLI term; a fix rejection never reaches this path since it's a normal, expected outcome, not an unhandled exception
 
 **Fix failure**:
-The outcome when a check's own `fix()` catches an `OSError` from `atomic_write_text()` itself (disk full, permission denied, missing parent directory) and returns `False` without raising — an environmental failure, distinct from a fix error (which means `fix()` itself raised, a bug in the check's own logic). Reported as `[FIX FAILED]`, with a hint about checking permissions/disk space rather than `[FIX ERRORED]`'s "this is a bug, please report it" (see `docs/adr/0017-behavioral-contract-audit-diagnostics-fix-modes-user-trust.md`).
-_Avoid_: fix error, fix rejection — "failed" is the term the CLI output and `is_fix_failed()`/`mark_fix_failed()` use; unlike a fix error, retrying `--fix` after fixing the underlying environmental issue may actually succeed
+The outcome when a check's own `fix()` catches an `OSError` from `atomic_write_text()` itself (disk full, permission denied, missing parent directory) and returns `FixOutcome.FAILED` — an environmental failure, distinct from a fix error (which means `fix()` itself raised, a bug in the check's own logic). Reported as `[FIX FAILED]`, with a hint about checking permissions/disk space rather than `[FIX ERRORED]`'s "this is a bug, please report it" (see `docs/adr/0017-behavioral-contract-audit-diagnostics-fix-modes-user-trust.md`).
+_Avoid_: fix error, fix rejection — "failed" is the CLI term; unlike a fix error, retrying `--fix` after fixing the underlying environmental issue may actually succeed
+
+**Fix outcome**:
+Each `fix()` call returns a `FixResult` with one `FixOutcome` for every input violation. The outcomes are applied, declined, rejected, aborted, errored, failed, and resolved indirectly. A declined fix is safe to leave unchanged and is reported as `[FIX DECLINED]` without an operational failure hint.
 
 **Indirect resolution**:
 The outcome when a violation is gone from the file's final state because some other fix removed it along the way, with no fix ever applied for the violation itself — usually a different check's fix, but a check's own fix can equally take a second violation of its own with it. Reported as `[RESOLVED INDIRECTLY]`, distinct from `[FIXED]` (a fix was applied for this violation and resolved it) and from an unfixed `[FIXABLE]` (there is nothing left to run `--fix` for). See `docs/adr/0053-indirect-resolution-outcome.md`.
-_Avoid_: side effect, collateral fix — "resolved indirectly" is the term the CLI output and `is_resolved_indirectly()`/`mark_resolved_indirectly()` use; also avoid calling it a fix, since no fix was applied for it
+_Avoid_: side effect, collateral fix — "resolved indirectly" is the CLI term; also avoid calling it a fix, since no fix was applied for it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,7 @@ _Avoid_: fix error, fix rejection — "failed" is the CLI term; unlike a fix err
 
 **Fix outcome**:
 Each `fix()` call returns a `FixResult` with one `FixOutcome` for every input violation. The outcomes are applied, declined, rejected, aborted, errored, failed, and resolved indirectly. A declined fix is safe to leave unchanged and is reported as `[FIX DECLINED]` without an operational failure hint.
+_Avoid_: skipped — use "declined" for `[FIX DECLINED]` because the check made a safety decision, not a generic omission
 
 **Indirect resolution**:
 The outcome when a violation is gone from the file's final state because some other fix removed it along the way, with no fix ever applied for the violation itself — usually a different check's fix, but a check's own fix can equally take a second violation of its own with it. Reported as `[RESOLVED INDIRECTLY]`, distinct from `[FIXED]` (a fix was applied for this violation and resolved it) and from an unfixed `[FIXABLE]` (there is nothing left to run `--fix` for). See `docs/adr/0053-indirect-resolution-outcome.md`.

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -10,6 +10,7 @@ import stat
 import tempfile
 import tokenize
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
@@ -17,6 +18,25 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from ._options import CheckOption
+
+
+class FixOutcome(Enum):
+    APPLIED = "applied"
+    DECLINED = "declined"
+    REJECTED = "rejected"
+    ABORTED = "aborted"
+    ERRORED = "errored"
+    FAILED = "failed"
+    RESOLVED_INDIRECTLY = "resolved_indirectly"
+
+
+@dataclass(frozen=True, slots=True)
+class FixResult:
+    outcomes: tuple[FixOutcome, ...]
+
+    @classmethod
+    def for_violations(cls, violations: list[Violation], outcome: FixOutcome) -> FixResult:
+        return cls((outcome,) * len(violations))
 
 
 @dataclass(slots=True)
@@ -35,6 +55,7 @@ class Violation:
     message: str
     fixable: bool
     fix_data: dict[str, Any] | None = None
+    fix_outcome: FixOutcome | None = None
 
 
 class ASTCheck(Protocol):
@@ -104,7 +125,7 @@ class ASTCheck(Protocol):
         source: str,
         tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         """`encoding` must match what `filepath` was originally read as, so a
         PEP 263 declaration round-trips correctly.
 
@@ -115,22 +136,17 @@ class ASTCheck(Protocol):
         rejection to every violation passed in. A check that writes more
         than once per `fix()` call (looping over violations individually,
         like `validate_function_name`) should instead catch
-        `FixValidationError` around each individual write and call
-        `mark_fix_rejected()` on that specific violation, so a later write
-        in the same call still gets attempted.
+        `FixValidationError` around each individual write and return a
+        rejected outcome for that specific violation, so a later write in
+        the same call still gets attempted.
 
         `ConcurrentModificationError` (also raised by `atomic_write_text()`)
         follows the same split as `FixValidationError` above: propagate
         uncaught for a single-write `fix()`, or catch it around each
-        individual write and call `mark_fix_aborted()` on that specific
+        individual write and return an aborted outcome for that specific
         violation for a multi-write one. See `docs/adr/0042-abort-fixes-on-concurrent-source-modification.md`.
 
-        `OSError` from `atomic_write_text()` (missing parent directory,
-        permission denied, disk full) is different: every implementation
-        must catch it itself and return `False`, matching this method's own
-        "`True`/`False`, never raises" contract — `CheckOrchestrator`'s own
-        outer `except Exception` only protects the full pipeline, not a
-        caller that calls a check's `fix()` directly.
+        Every returned result contains one outcome for each input violation.
         """
         ...
 
@@ -600,94 +616,3 @@ def find_ignored_lines_and_classify_comments(
 
     ignored_lines |= scanner.finalize()
     return ignored_lines, comment_lines - code_lines, comment_lines & code_lines
-
-
-def _mark(violation: Violation, outcome: str) -> None:
-    """The single place that writes the `fix_data` outcome convention every
-    `mark_*()` below shares.
-    """
-    if violation.fix_data is None:
-        violation.fix_data = {}
-    violation.fix_data[outcome] = True
-
-
-def mark_fixed(violation: Violation) -> None:
-    """Record that this check's own `fix()` resolved `violation`."""
-    _mark(violation, "fixed")
-
-
-def is_fixed(violation: Violation) -> bool:
-    """Whether `mark_fixed()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("fixed", False))
-
-
-def mark_resolved_indirectly(violation: Violation) -> None:
-    """Record that some other fix in the same run removed `violation` as a
-    side effect. Distinct from `mark_fixed()`: no fix was ever applied for
-    this violation itself, whichever check's fix took it away. See
-    `docs/adr/0053-indirect-resolution-outcome.md`.
-    """
-    _mark(violation, "resolved_indirectly")
-
-
-def is_resolved_indirectly(violation: Violation) -> bool:
-    """Whether `mark_resolved_indirectly()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("resolved_indirectly", False))
-
-
-def mark_fix_rejected(violation: Violation) -> None:
-    """Record that a fix was attempted for `violation` but rejected by
-    `atomic_write_text()` because it would have produced invalid syntax.
-    """
-    _mark(violation, "fix_rejected")
-
-
-def is_fix_rejected(violation: Violation) -> bool:
-    """Whether `mark_fix_rejected()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("fix_rejected", False))
-
-
-def mark_fix_aborted(violation: Violation) -> None:
-    """Record that a fix was attempted for `violation` but discarded by
-    `atomic_write_text()` because the file changed on disk after it was read
-    for this fix — an external edit or a concurrent process outside this
-    tool's own per-file fix lock (see `ConcurrentModificationError`).
-    """
-    _mark(violation, "fix_aborted")
-
-
-def is_fix_aborted(violation: Violation) -> bool:
-    """Whether `mark_fix_aborted()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("fix_aborted", False))
-
-
-def mark_fix_errored(violation: Violation) -> None:
-    """Record that `fix()` itself raised an exception other than
-    `FixValidationError` while attempting `violation` — a bug in the
-    check's own fix logic, distinct from `mark_fix_rejected()` (fix() ran
-    to completion but its *output* didn't parse).
-    """
-    _mark(violation, "fix_errored")
-
-
-def is_fix_errored(violation: Violation) -> bool:
-    """Whether `mark_fix_errored()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("fix_errored", False))
-
-
-def mark_fix_failed(violation: Violation) -> None:
-    """Record that `fix()` returned `False` (without raising) for
-    `violation` because it caught an `OSError` while writing the file back —
-    exactly the third outcome `ASTCheck.fix()`'s own docstring documents
-    ("OSError from atomic_write_text() ... every implementation must catch
-    it itself and return False"). Distinct from `mark_fix_errored()`: this
-    is an environmental failure (disk full, permission denied, missing
-    parent directory), not a bug in the check's own fix logic, so it must
-    not carry the same "this is a bug, please report it" hint.
-    """
-    _mark(violation, "fix_failed")
-
-
-def is_fix_failed(violation: Violation) -> bool:
-    """Whether `mark_fix_failed()` has already been called on `violation`."""
-    return bool(violation.fix_data and violation.fix_data.get("fix_failed", False))

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -125,30 +125,7 @@ class ASTCheck(Protocol):
         source: str,
         tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> FixResult:
-        """`encoding` must match what `filepath` was originally read as, so a
-        PEP 263 declaration round-trips correctly.
-
-        A check with a single write per `fix()` call needs no special
-        handling: let `FixValidationError` (raised by `atomic_write_text()`
-        if the fix would produce invalid syntax) propagate uncaught —
-        `CheckOrchestrator._apply_fixes` catches it and attributes the
-        rejection to every violation passed in. A check that writes more
-        than once per `fix()` call (looping over violations individually,
-        like `validate_function_name`) should instead catch
-        `FixValidationError` around each individual write and return a
-        rejected outcome for that specific violation, so a later write in
-        the same call still gets attempted.
-
-        `ConcurrentModificationError` (also raised by `atomic_write_text()`)
-        follows the same split as `FixValidationError` above: propagate
-        uncaught for a single-write `fix()`, or catch it around each
-        individual write and return an aborted outcome for that specific
-        violation for a multi-write one. See `docs/adr/0042-abort-fixes-on-concurrent-source-modification.md`.
-
-        Every returned result contains one outcome for each input violation.
-        """
-        ...
+    ) -> FixResult: ...
 
     OPTIONS: ClassVar[tuple[CheckOption, ...]]
     """This check's own configurable options, each named by the `__init__`

--- a/src/pre_commit_hooks/ast_checks/_diagnostics.py
+++ b/src/pre_commit_hooks/ast_checks/_diagnostics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-from ._base import is_fix_aborted, is_fix_errored, is_fix_failed, is_fix_rejected, is_fixed, is_resolved_indirectly
+from ._base import FixOutcome
 
 if TYPE_CHECKING:
     from ._base import Violation
@@ -51,51 +51,51 @@ def report(orchestrator: CheckOrchestrator, all_violations: dict[str, list[Viola
 
     for filepath, violations in sorted(all_violations.items()):
         for v in violations:
-            fixed = is_fixed(v)
-            rejected = is_fix_rejected(v)
-            errored = is_fix_errored(v)
-            failed = is_fix_failed(v)
-            aborted = is_fix_aborted(v)
-            resolved_indirectly = is_resolved_indirectly(v)
-            if fixed:
+            if v.fix_outcome is FixOutcome.APPLIED:
                 tag = "[FIXED] "
-            elif resolved_indirectly:
+            elif v.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY:
                 tag = "[RESOLVED INDIRECTLY] "
-            elif rejected:
+            elif v.fix_outcome is FixOutcome.REJECTED:
                 tag = "[FIX REJECTED] "
-            elif errored:
+            elif v.fix_outcome is FixOutcome.ERRORED:
                 tag = "[FIX ERRORED] "
-            elif failed:
+            elif v.fix_outcome is FixOutcome.FAILED:
                 tag = "[FIX FAILED] "
-            elif aborted:
+            elif v.fix_outcome is FixOutcome.ABORTED:
                 tag = "[FIX ABORTED] "
+            elif v.fix_outcome is FixOutcome.DECLINED:
+                tag = "[FIX DECLINED] "
             elif v.fixable:
                 tag = "[FIXABLE] "
             else:
                 tag = ""
-            if resolved_indirectly:
+            if v.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY:
                 hint = " it disappeared as a side effect of another fix in this run; nothing was applied for it."
-            elif rejected:
+            elif v.fix_outcome is FixOutcome.APPLIED:
+                hint = ""
+            elif v.fix_outcome is FixOutcome.REJECTED:
                 hint = (
                     " --fix produced invalid syntax, so the change was discarded — this is a bug, "
                     "please report it: https://github.com/alessio-locatelli/ruff-extra-rules/issues"
                 )
-            elif errored:
+            elif v.fix_outcome is FixOutcome.ERRORED:
                 hint = (
                     " --fix raised an unexpected internal error and was not applied — this is a bug, "
                     "please report it: https://github.com/alessio-locatelli/ruff-extra-rules/issues"
                 )
-            elif failed:
+            elif v.fix_outcome is FixOutcome.FAILED:
                 hint = (
                     " --fix could not write the file — check file permissions and available disk "
                     "space, then run with --fix again."
                 )
-            elif aborted:
+            elif v.fix_outcome is FixOutcome.ABORTED:
                 hint = (
                     " the file changed on disk while --fix was running, so the change was discarded — "
                     "run with --fix again."
                 )
-            elif v.fixable and not fixed:
+            elif v.fix_outcome is FixOutcome.DECLINED:
+                hint = " --fix left the source unchanged because this change is not safe to apply automatically."
+            elif v.fixable:
                 hint = " Run with --fix to inline automatically."
             else:
                 hint = ""

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -24,18 +24,10 @@ from ._base import (
     ASTCheck,
     CheckUnavailableError,
     ConcurrentModificationError,
+    FixOutcome,
+    FixResult,
     FixValidationError,
     Violation,
-    is_fix_aborted,
-    is_fix_errored,
-    is_fix_failed,
-    is_fix_rejected,
-    is_fixed,
-    mark_fix_aborted,
-    mark_fix_errored,
-    mark_fix_rejected,
-    mark_fixed,
-    mark_resolved_indirectly,
     read_source_with_encoding,
 )
 from ._per_file_ignores import PerFileIgnoreList
@@ -69,13 +61,16 @@ def _has_terminal_fix_state(violation: Violation) -> bool:
     outcome from a check's own per-violation `fix()` handling this run --
     i.e. the outcome is already decided and must never be second-guessed by
     a later, broader recheck (e.g. relabeled `[FIXED]` just because it's no
-    longer detected). Deliberately excludes `is_fixed()`: a fixed violation
+    longer detected). Deliberately excludes an applied outcome: a fixed violation
     is a normal, non-terminal-in-this-sense outcome each call site here
     already handles on its own.
     """
-    return (
-        is_fix_rejected(violation) or is_fix_errored(violation) or is_fix_failed(violation) or is_fix_aborted(violation)
-    )
+    return violation.fix_outcome in {
+        FixOutcome.REJECTED,
+        FixOutcome.ERRORED,
+        FixOutcome.FAILED,
+        FixOutcome.ABORTED,
+    }
 
 
 def _replace_check_violations(
@@ -125,8 +120,15 @@ def _record_indirect_resolutions(violations: list[Violation], initial_violations
         if missing <= 0:
             continue
         for violation in _unmatched_by_message(dropped, replacements)[:missing]:
-            mark_resolved_indirectly(violation)
+            violation.fix_outcome = FixOutcome.RESOLVED_INDIRECTLY
             violations.append(violation)
+
+
+def _set_fix_outcomes(violations: list[Violation], fix_result: FixResult) -> None:
+    if len(fix_result.outcomes) != len(violations):
+        raise ValueError("fix result did not include one outcome per violation")
+    for violation, outcome in zip(violations, fix_result.outcomes, strict=True):
+        violation.fix_outcome = outcome
 
 
 def _fingerprint_default(value: object) -> object:
@@ -487,7 +489,9 @@ class CheckOrchestrator:
         if cacheable_ids and not (incomplete_ids & cacheable_ids) and not self._fix_changed_file:
             # A violation marked fixed no longer exists in the file's
             # current content, so it must never be cached as still present.
-            cacheable_violations = [v for v in violations if v.check_id in cacheable_ids and not is_fixed(v)]
+            cacheable_violations = [
+                v for v in violations if v.check_id in cacheable_ids and v.fix_outcome is not FixOutcome.APPLIED
+            ]
             self._cache_violations(filepath, hook_name, cacheable_violations)
 
         return violations + extra_violations if extra_violations else violations
@@ -841,7 +845,7 @@ class CheckOrchestrator:
                     self.rule_failures.append((str(filepath), check.check_id))
                     for v in violations:
                         if v.check_id == check.check_id and v.fixable:
-                            mark_fix_errored(v)
+                            v.fix_outcome = FixOutcome.ERRORED
                     continue
                 current_source, encoding = read_result
                 current_tree = ast.parse(current_source, filename=filepath)
@@ -856,13 +860,13 @@ class CheckOrchestrator:
                     continue
 
                 try:
-                    check.fix(filepath, fresh_violations, current_source, current_tree, encoding)
+                    fix_result = check.fix(filepath, fresh_violations, current_source, current_tree, encoding)
                 except FixValidationError:
                     # atomic_write_text() refused to write — the file is
                     # untouched, so every violation this check just tried to
                     # fix is still exactly as it was. This is a bug in the
                     # check's fix logic, not an expected outcome. Debug-only
-                    # — mark_fix_rejected() below already reports this
+                    # — the returned outcome already reports this
                     # cleanly as [FIX REJECTED]; see _read_source's own
                     # docstring for why ERROR-level .exception() logging
                     # here would just be redundant noise.
@@ -872,15 +876,15 @@ class CheckOrchestrator:
                         filepath,
                         exc_info=True,
                     )
-                    for v in fresh_violations:
-                        mark_fix_rejected(v)
+                    fix_result = FixResult.for_violations(fresh_violations, FixOutcome.REJECTED)
+                    _set_fix_outcomes(fresh_violations, fix_result)
                 except ConcurrentModificationError:
                     # atomic_write_text() refused to write — the file is
                     # untouched, but this time it's not a bug in the check's
                     # fix logic: something else (an editor, a concurrent
                     # process outside this run's own per-file fix lock)
                     # modified the file after current_source was read above.
-                    # Debug-only — mark_fix_aborted() below already reports
+                    # Debug-only — the returned outcome already reports
                     # this cleanly as [FIX ABORTED]; see _read_source's own
                     # docstring for why ERROR-level .exception() logging here
                     # would just be redundant noise.
@@ -890,8 +894,8 @@ class CheckOrchestrator:
                         check.check_id,
                         exc_info=True,
                     )
-                    for v in fresh_violations:
-                        mark_fix_aborted(v)
+                    fix_result = FixResult.for_violations(fresh_violations, FixOutcome.ABORTED)
+                    _set_fix_outcomes(fresh_violations, fix_result)
                     # The external edit itself can shift line numbers too,
                     # same as a successful fix. See ADR-0042.
                     file_changed = True
@@ -913,9 +917,9 @@ class CheckOrchestrator:
                     # later one — re-check against the file's real state
                     # rather than assuming every violation in this batch is
                     # still broken, the same way the success path below
-                    # already must (a bool return isn't precise enough
+                    # already must (the returned outcomes are more precise
                     # either).
-                    # Debug-only — rule_failures/mark_fix_errored() below
+                    # Debug-only — rule_failures/the outcome assignment below
                     # already report this cleanly; see _read_source's own
                     # docstring for why ERROR-level .exception() logging
                     # here would just be redundant noise.
@@ -937,23 +941,22 @@ class CheckOrchestrator:
                         file_changed = True
                     for v in fresh_violations:
                         if (v.line, v.col, v.message) in still_present:
-                            mark_fix_errored(v)
-                        # else: already resolved (mark_fixed() already called
-                        # by the re-check above) before fix() raised.
+                            v.fix_outcome = FixOutcome.ERRORED
                 else:
-                    # A check's own bool return isn't precise enough to know
+                    # The reported outcome alone is not enough to know
                     # which violations were actually resolved: a
                     # per-violation guard (e.g. validate_function_name's
                     # should_autofix) can skip some violations while fixing
                     # others in the same call. Re-check against the file's
                     # real post-fix state instead of trusting the return
                     # value.
+                    _set_fix_outcomes(fresh_violations, fix_result)
                     still_present = self._mark_resolved_and_get_still_present(filepath, check, fresh_violations)
                     if len(still_present) < len(fresh_violations):
                         file_changed = True
                     # else: still present — either rejected (already marked
-                    # via mark_fix_rejected() inside a multi-write check's
-                    # own per-violation loop) or left alone by a
+                    # by the check's multi-write per-violation loop) or left
+                    # alone by a
                     # per-violation guard; either way, not fixed.
 
                 # fresh_violations replaces this check_id's stale entries
@@ -970,14 +973,14 @@ class CheckOrchestrator:
                 # check's violations keep their stale pre-fix snapshot and
                 # get reported as ordinary [FIXABLE], as if --fix had never
                 # even been attempted for them. Debug-only — rule_failures/
-                # mark_fix_errored() below already report this cleanly; see
+                # the outcome assignment below already report this cleanly; see
                 # _read_source's own docstring for why ERROR-level
                 # .exception() logging here would just be redundant noise.
                 logger.debug("Fix failed for %s on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
                 for v in violations:
                     if v.check_id == check.check_id and v.fixable:
-                        mark_fix_errored(v)
+                        v.fix_outcome = FixOutcome.ERRORED
 
         if file_changed:
             self._refresh_stale_positions(filepath, violations)
@@ -1044,7 +1047,7 @@ class CheckOrchestrator:
             if not check_entries or any(_has_terminal_fix_state(v) for v in check_entries):
                 continue
 
-            stale = [v for v in check_entries if not is_fixed(v)]
+            stale = [v for v in check_entries if v.fix_outcome is not FixOutcome.APPLIED]
             if not stale:
                 continue
 
@@ -1069,14 +1072,14 @@ class CheckOrchestrator:
         fresh_violations: list[Violation],
     ) -> set[ViolationKey]:
         """Re-check `filepath` against its actual current on-disk content
-        and call `mark_fixed()` on every violation in `fresh_violations`
+        and retain or assign an applied outcome for every violation in `fresh_violations`
         that's no longer present there — regardless of whether `check.fix()`
         returned normally or raised partway through. A check that writes
         more than once per `fix()` call (looping over violations
         individually, like `validate_function_name`) can have already
         committed some violations before a later one failed or raised;
         matching by `ViolationKey` against the file's real state, rather
-        than trusting a bool return or "fix() didn't raise", is what
+        than trusting the reported outcome alone, is what
         catches that.
 
         Returns the keys of `fresh_violations` still present, so a caller
@@ -1091,19 +1094,27 @@ class CheckOrchestrator:
         """
         post_read_result = self._read_source(filepath)
         if post_read_result is None:
+            for violation in fresh_violations:
+                if violation.fix_outcome is FixOutcome.APPLIED:
+                    violation.fix_outcome = FixOutcome.DECLINED
             return {(v.line, v.col, v.message) for v in fresh_violations}
 
         post_source, _post_encoding = post_read_result
         try:
             post_tree = ast.parse(post_source, filename=filepath)
         except SyntaxError:
+            for violation in fresh_violations:
+                if violation.fix_outcome is FixOutcome.APPLIED:
+                    violation.fix_outcome = FixOutcome.DECLINED
             return {(v.line, v.col, v.message) for v in fresh_violations}
         still_present: set[ViolationKey] = {
             (v.line, v.col, v.message) for v in check.check(filepath, post_tree, post_source) if v.fixable
         }
         for v in fresh_violations:
-            if (v.line, v.col, v.message) not in still_present and not _has_terminal_fix_state(v):
-                mark_fixed(v)
+            if (v.line, v.col, v.message) not in still_present and v.fix_outcome is None:
+                v.fix_outcome = FixOutcome.APPLIED
+            elif (v.line, v.col, v.message) in still_present and v.fix_outcome is FixOutcome.APPLIED:
+                v.fix_outcome = FixOutcome.DECLINED
         return still_present
 
 

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -57,14 +57,6 @@ def _fix_lock_path(filepath: Path) -> Path:
 
 
 def _has_terminal_fix_state(violation: Violation) -> bool:
-    """Whether `violation` already carries a rejected/errored/failed/aborted
-    outcome from a check's own per-violation `fix()` handling this run --
-    i.e. the outcome is already decided and must never be second-guessed by
-    a later, broader recheck (e.g. relabeled `[FIXED]` just because it's no
-    longer detected). Deliberately excludes an applied outcome: a fixed violation
-    is a normal, non-terminal-in-this-sense outcome each call site here
-    already handles on its own.
-    """
     return violation.fix_outcome in {
         FixOutcome.REJECTED,
         FixOutcome.ERRORED,
@@ -862,14 +854,6 @@ class CheckOrchestrator:
                 try:
                     fix_result = check.fix(filepath, fresh_violations, current_source, current_tree, encoding)
                 except FixValidationError:
-                    # atomic_write_text() refused to write — the file is
-                    # untouched, so every violation this check just tried to
-                    # fix is still exactly as it was. This is a bug in the
-                    # check's fix logic, not an expected outcome. Debug-only
-                    # — the returned outcome already reports this
-                    # cleanly as [FIX REJECTED]; see _read_source's own
-                    # docstring for why ERROR-level .exception() logging
-                    # here would just be redundant noise.
                     logger.debug(
                         "Fix for %s produced invalid syntax on %s; the file was left untouched.",
                         check.check_id,
@@ -879,15 +863,6 @@ class CheckOrchestrator:
                     fix_result = FixResult.for_violations(fresh_violations, FixOutcome.REJECTED)
                     _set_fix_outcomes(fresh_violations, fix_result)
                 except ConcurrentModificationError:
-                    # atomic_write_text() refused to write — the file is
-                    # untouched, but this time it's not a bug in the check's
-                    # fix logic: something else (an editor, a concurrent
-                    # process outside this run's own per-file fix lock)
-                    # modified the file after current_source was read above.
-                    # Debug-only — the returned outcome already reports
-                    # this cleanly as [FIX ABORTED]; see _read_source's own
-                    # docstring for why ERROR-level .exception() logging here
-                    # would just be redundant noise.
                     logger.debug(
                         "File %s changed on disk while fixing %s; the fix was discarded.",
                         filepath,
@@ -896,45 +871,15 @@ class CheckOrchestrator:
                     )
                     fix_result = FixResult.for_violations(fresh_violations, FixOutcome.ABORTED)
                     _set_fix_outcomes(fresh_violations, fix_result)
-                    # The external edit itself can shift line numbers too,
-                    # same as a successful fix. See ADR-0042.
                     file_changed = True
                     externally_modified = True
                 except Exception:
-                    # fix() itself raised — a bug in the check's own fix
-                    # logic, distinct from FixValidationError (which means
-                    # fix() ran to completion but atomic_write_text()
-                    # rejected its output). Caught here, specifically around
-                    # the fix() call, rather than only by this method's
-                    # outer except Exception below: that outer handler also
-                    # covers benign races (e.g. the file disappearing before
-                    # a re-read), which must not be reported as a fix bug.
-                    #
-                    # A check that writes more than once per fix() call
-                    # (looping over violations individually, like
-                    # validate_function_name) can have already committed some
-                    # of fresh_violations before this exception interrupted a
-                    # later one — re-check against the file's real state
-                    # rather than assuming every violation in this batch is
-                    # still broken, the same way the success path below
-                    # already must (the returned outcomes are more precise
-                    # either).
-                    # Debug-only — rule_failures/the outcome assignment below
-                    # already report this cleanly; see _read_source's own
-                    # docstring for why ERROR-level .exception() logging
-                    # here would just be redundant noise.
                     logger.debug(
                         "Fix for %s raised an unexpected exception on %s.",
                         check.check_id,
                         filepath,
                         exc_info=True,
                     )
-                    # Always recorded, even if every fresh_violations entry
-                    # turns out resolved below (e.g. fix() committed its
-                    # edits, then raised afterwards during unrelated
-                    # cleanup): an exception genuinely happened here, and
-                    # that must never become invisible to the user just
-                    # because nothing is left to mark [FIX ERRORED].
                     self.rule_failures.append((str(filepath), check.check_id))
                     still_present = self._mark_resolved_and_get_still_present(filepath, check, fresh_violations)
                     if len(still_present) < len(fresh_violations):
@@ -943,39 +888,13 @@ class CheckOrchestrator:
                         if (v.line, v.col, v.message) in still_present:
                             v.fix_outcome = FixOutcome.ERRORED
                 else:
-                    # The reported outcome alone is not enough to know
-                    # which violations were actually resolved: a
-                    # per-violation guard (e.g. validate_function_name's
-                    # should_autofix) can skip some violations while fixing
-                    # others in the same call. Re-check against the file's
-                    # real post-fix state instead of trusting the return
-                    # value.
                     _set_fix_outcomes(fresh_violations, fix_result)
                     still_present = self._mark_resolved_and_get_still_present(filepath, check, fresh_violations)
                     if len(still_present) < len(fresh_violations):
                         file_changed = True
-                    # else: still present — either rejected (already marked
-                    # by the check's multi-write per-violation loop) or left
-                    # alone by a
-                    # per-violation guard; either way, not fixed.
-
-                # fresh_violations replaces this check_id's stale entries
-                # wholesale: its positions are accurate as of just before
-                # this fix() call, strictly more current than the very
-                # first, pre-any-fix snapshot in `violations`.
                 violations[:] = [v for v in violations if v.check_id != check.check_id or not v.fixable]
                 violations.extend(fresh_violations)
             except Exception:
-                # Anything not already handled above: e.g. the re-parse or
-                # the fresh_violations recompute itself raising. Isolated
-                # per-check like every other failure here (ch. 5), but must
-                # still be surfaced — without a rule_failure + marking, this
-                # check's violations keep their stale pre-fix snapshot and
-                # get reported as ordinary [FIXABLE], as if --fix had never
-                # even been attempted for them. Debug-only — rule_failures/
-                # the outcome assignment below already report this cleanly; see
-                # _read_source's own docstring for why ERROR-level
-                # .exception() logging here would just be redundant noise.
                 logger.debug("Fix failed for %s on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
                 for v in violations:
@@ -1071,27 +990,6 @@ class CheckOrchestrator:
         check: ASTCheck,
         fresh_violations: list[Violation],
     ) -> set[ViolationKey]:
-        """Re-check `filepath` against its actual current on-disk content
-        and retain or assign an applied outcome for every violation in `fresh_violations`
-        that's no longer present there — regardless of whether `check.fix()`
-        returned normally or raised partway through. A check that writes
-        more than once per `fix()` call (looping over violations
-        individually, like `validate_function_name`) can have already
-        committed some violations before a later one failed or raised;
-        matching by `ViolationKey` against the file's real state, rather
-        than trusting the reported outcome alone, is what
-        catches that.
-
-        Returns the keys of `fresh_violations` still present, so a caller
-        with more context (e.g. "fix() itself raised for this check") can
-        mark those specifically, distinct from the ones already resolved by
-        this call. If the file couldn't be re-read or no longer parses,
-        conservatively returns every key unresolved rather than raising —
-        nothing is marked fixed on an unverifiable outcome. Never marks
-        fixed a violation already carrying a rejected/errored/failed/aborted
-        outcome from the check's own per-violation loop. See
-        `docs/adr/0042-abort-fixes-on-concurrent-source-modification.md`.
-        """
         post_read_result = self._read_source(filepath)
         if post_read_result is None:
             for violation in fresh_violations:

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -17,11 +17,12 @@ from typing import TYPE_CHECKING
 
 from ._base import (
     BaseCheck,
+    FixOutcome,
+    FixResult,
     Violation,
     atomic_write_text,
     find_ignored_lines,
     ignore_pattern_for,
-    mark_fix_failed,
 )
 
 if TYPE_CHECKING:
@@ -241,9 +242,9 @@ class ExcessiveBlankLinesCheck(BaseCheck):
         source: str,
         tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         if not violations:
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
         # Recompute independently rather than trusting the passed
         # violations, same as misplaced_comment.fix(): a stale or
@@ -251,25 +252,23 @@ class ExcessiveBlankLinesCheck(BaseCheck):
         # run to be collapsed anyway.
         file_violations = check_file_violations(source, tree)
         if not file_violations:
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
         ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
         if any(fv.anchor_line in ignored_lines for fv in file_violations):
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
         fixed_content = fix_file_content(source, tree)
         try:
             atomic_write_text(filepath, fixed_content, encoding, source)
         except OSError:
-            # Debug-only: mark_fix_failed() below already reports this
+            # Debug-only: the returned outcome already reports this
             # cleanly as [FIX FAILED] — an ERROR-level .exception() call
             # here would just leak a redundant raw traceback onto the
             # user's stderr by default (nothing in this codebase configures
             # logging, so Python's own lastResort handler prints WARNING+
             # straight to stderr).
             logger.debug("Failed to write %s", filepath, exc_info=True)
-            for v in violations:
-                mark_fix_failed(v)
-            return False
+            return FixResult.for_violations(violations, FixOutcome.FAILED)
         else:
-            return True
+            return FixResult.for_violations(violations, FixOutcome.APPLIED)

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -901,10 +901,13 @@ class MeaninglessVarsCheck(BaseCheck):
         tree: ast.Module,
         encoding: str = "utf-8",
     ) -> FixResult:
-        fixable = [cast("MeaninglessVarsFixData", v.fix_data) for v in violations if v.fixable and v.fix_data]
+        fixable_violations = [v for v in violations if v.fixable and v.fix_data]
+        fixable = [cast("MeaninglessVarsFixData", v.fix_data) for v in fixable_violations]
 
         if not fixable:
             return FixResult.for_violations(violations, FixOutcome.DECLINED)
+
+        fixable_ids = {id(violation) for violation in fixable_violations}
 
         # Re-derived fresh, like check() does, rather than threaded through
         # fix_data: a stale ignored_lines snapshot from check()-time could
@@ -922,6 +925,13 @@ class MeaninglessVarsCheck(BaseCheck):
             # logging, so Python's own lastResort handler prints WARNING+
             # straight to stderr).
             logger.debug("Failed to apply fixes to %s", filepath, exc_info=True)
-            return FixResult(tuple(FixOutcome.FAILED if v.fixable else FixOutcome.DECLINED for v in violations))
+            return FixResult(
+                tuple(
+                    FixOutcome.FAILED if id(violation) in fixable_ids else FixOutcome.DECLINED
+                    for violation in violations
+                )
+            )
         else:
-            return FixResult(tuple(outcome if v.fixable else FixOutcome.DECLINED for v in violations))
+            return FixResult(
+                tuple(outcome if id(violation) in fixable_ids else FixOutcome.DECLINED for violation in violations)
+            )

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -15,12 +15,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from ._base import (
     BaseCheck,
+    FixOutcome,
+    FixResult,
     Violation,
     atomic_write_text,
     byte_col_to_char_col,
     find_ignored_lines,
     ignore_pattern_for,
-    mark_fix_failed,
     split_lines_like_ast,
 )
 from ._options import EnumOption
@@ -736,7 +737,7 @@ def _apply_fixes(
     *,
     ignored_lines: set[int],
     encoding: str = "utf-8",
-) -> bool:
+) -> FixOutcome:
     """Scope-aware: groups violations by scope and replaces ALL uses of a
     variable within that scope, not just the assignment position.
 
@@ -791,7 +792,7 @@ def _apply_fixes(
             all_replacements.extend(items)
 
     if not all_replacements:
-        return False
+        return FixOutcome.DECLINED
 
     # Step 4: Sort reverse and apply replacements
     all_replacements.sort(key=lambda x: (x[0], x[1]), reverse=True)
@@ -812,7 +813,7 @@ def _apply_fixes(
         lines[line_idx] = line[:col] + new_name + line[col + name_len :]
 
     atomic_write_text(filepath, "".join(lines), encoding, source)
-    return True
+    return FixOutcome.APPLIED
 
 
 class MeaninglessVarsCheck(BaseCheck):
@@ -899,11 +900,11 @@ class MeaninglessVarsCheck(BaseCheck):
         source: str,
         tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         fixable = [cast("MeaninglessVarsFixData", v.fix_data) for v in violations if v.fixable and v.fix_data]
 
         if not fixable:
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
         # Re-derived fresh, like check() does, rather than threaded through
         # fix_data: a stale ignored_lines snapshot from check()-time could
@@ -912,16 +913,15 @@ class MeaninglessVarsCheck(BaseCheck):
         ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
 
         try:
-            return _apply_fixes(filepath, fixable, source, tree, ignored_lines=ignored_lines, encoding=encoding)
+            outcome = _apply_fixes(filepath, fixable, source, tree, ignored_lines=ignored_lines, encoding=encoding)
         except OSError:
-            # Debug-only: mark_fix_failed() below already reports this
+            # Debug-only: the returned outcome already reports this
             # cleanly as [FIX FAILED] — an ERROR-level .exception() call
             # here would just leak a redundant raw traceback onto the
             # user's stderr by default (nothing in this codebase configures
             # logging, so Python's own lastResort handler prints WARNING+
             # straight to stderr).
             logger.debug("Failed to apply fixes to %s", filepath, exc_info=True)
-            for v in violations:
-                if v.fixable:
-                    mark_fix_failed(v)
-            return False
+            return FixResult(tuple(FixOutcome.FAILED if v.fixable else FixOutcome.DECLINED for v in violations))
+        else:
+            return FixResult(tuple(outcome if v.fixable else FixOutcome.DECLINED for v in violations))

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -20,12 +20,13 @@ from typing import TYPE_CHECKING
 
 from ._base import (
     BaseCheck,
+    FixOutcome,
+    FixResult,
     Violation,
     atomic_write_text,
     ignore_pattern_for,
     ignored_lines_from_tokens,
     line_terminator,
-    mark_fix_failed,
     tokenize_source,
 )
 
@@ -193,15 +194,16 @@ class MisplacedCommentCheck(BaseCheck):
         source: str,
         tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         tokens = tuple(tokenize_source(source))
         found = _scan_misplaced_comments(tokens, tree)
         if not found:
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
         ignored_lines = ignored_lines_from_tokens(tokens, IGNORE_PATTERN)
         lines = source.splitlines(keepends=True)
         fixed_any = False
+        fixed_lines: set[int] = set()
 
         for item in found:
             if item.bracket_line in ignored_lines:
@@ -230,20 +232,23 @@ class MisplacedCommentCheck(BaseCheck):
             bracket_terminator = line_terminator(lines[bracket_line_idx])
             lines[bracket_line_idx] = lines[bracket_line_idx][: item.comment_col].rstrip() + bracket_terminator
             fixed_any = True
+            fixed_lines.add(item.bracket_line)
 
         if fixed_any:
             try:
                 atomic_write_text(filepath, "".join(lines), encoding, source)
             except OSError:
-                # Debug-only: mark_fix_failed() below already reports this
+                # Debug-only: the returned outcome already reports this
                 # cleanly as [FIX FAILED] — an ERROR-level .exception() call
                 # here would just leak a redundant raw traceback onto the
                 # user's stderr by default (nothing in this codebase
                 # configures logging, so Python's own lastResort handler
                 # prints WARNING+ straight to stderr).
                 logger.debug("Failed to write %s", filepath, exc_info=True)
-                for v in violations:
-                    mark_fix_failed(v)
-                return False
+                return FixResult(
+                    tuple(FixOutcome.FAILED if v.line in fixed_lines else FixOutcome.DECLINED for v in violations)
+                )
 
-        return fixed_any
+        return FixResult(
+            tuple(FixOutcome.APPLIED if v.line in fixed_lines else FixOutcome.DECLINED for v in violations)
+        )

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -238,12 +238,6 @@ class MisplacedCommentCheck(BaseCheck):
             try:
                 atomic_write_text(filepath, "".join(lines), encoding, source)
             except OSError:
-                # Debug-only: the returned outcome already reports this
-                # cleanly as [FIX FAILED] — an ERROR-level .exception() call
-                # here would just leak a redundant raw traceback onto the
-                # user's stderr by default (nothing in this codebase
-                # configures logging, so Python's own lastResort handler
-                # prints WARNING+ straight to stderr).
                 logger.debug("Failed to write %s", filepath, exc_info=True)
                 return FixResult(
                     tuple(FixOutcome.FAILED if v.line in fixed_lines else FixOutcome.DECLINED for v in violations)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
+    FixResult,
     Violation,
     byte_col_to_char_col,
     find_ignored_lines_and_classify_comments,
@@ -173,5 +174,5 @@ class RedundantAssignmentCheck(BaseCheck):
         source: str,
         _tree: ast.Module,
         encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         return apply_fixes(filepath, violations, source, encoding)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
@@ -172,12 +172,6 @@ def apply_fixes(
         try:
             atomic_write_text(filepath, new_source, encoding, source)
         except OSError:
-            # Debug-only: the returned outcome already reports this
-            # cleanly as [FIX FAILED] — an ERROR-level .exception() call
-            # here would just leak a redundant raw traceback onto the
-            # user's stderr by default (nothing in this codebase configures
-            # logging, so Python's own lastResort handler prints WARNING+
-            # straight to stderr).
             logger.debug("Failed to write %s", filepath, exc_info=True)
             applied_ids = {id(violation) for violation in applied_violations}
             return FixResult(

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/autofix.py
@@ -7,7 +7,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, TypedDict, cast
 
-from pre_commit_hooks.ast_checks._base import Violation, atomic_write_text, byte_col_to_char_col, mark_fix_failed
+from pre_commit_hooks.ast_checks._base import FixOutcome, FixResult, Violation, atomic_write_text, byte_col_to_char_col
 
 from .semantic import exceeds_line_length_when_inlined, is_safe_to_splice_into_fstring
 
@@ -43,7 +43,7 @@ def apply_fixes(
     violations: list[Violation],
     source: str,
     encoding: str = "utf-8",
-) -> bool:
+) -> FixResult:
     """A VERY conservative implementation that only fixes violations marked as
     fixable by strict semantic analysis. It only handles the simplest cases:
     - Not in loops or control flow
@@ -55,7 +55,7 @@ def apply_fixes(
     fixable_violations = [v for v in violations if v.fixable]
 
     if not fixable_violations:
-        return False
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
     source_lines = source.splitlines(keepends=True)
 
@@ -172,19 +172,21 @@ def apply_fixes(
         try:
             atomic_write_text(filepath, new_source, encoding, source)
         except OSError:
-            # Debug-only: mark_fix_failed() below already reports this
+            # Debug-only: the returned outcome already reports this
             # cleanly as [FIX FAILED] — an ERROR-level .exception() call
             # here would just leak a redundant raw traceback onto the
             # user's stderr by default (nothing in this codebase configures
             # logging, so Python's own lastResort handler prints WARNING+
             # straight to stderr).
             logger.debug("Failed to write %s", filepath, exc_info=True)
-            for v in applied_violations:
-                mark_fix_failed(v)
-            return False
-        return True
+            applied_ids = {id(violation) for violation in applied_violations}
+            return FixResult(
+                tuple(FixOutcome.FAILED if id(v) in applied_ids else FixOutcome.DECLINED for v in violations)
+            )
+        applied_ids = {id(violation) for violation in applied_violations}
+        return FixResult(tuple(FixOutcome.APPLIED if id(v) in applied_ids else FixOutcome.DECLINED for v in violations))
 
-    return False
+    return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
 
 def _cleanup_blank_lines_around_removals(source_lines: list[str], removed_lines: set[int]) -> None:

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -165,10 +165,9 @@ class RedundantSuperInitCheck(BaseCheck):
     def fix(
         self,
         _filepath: Path,
-        _violations: list[Violation],
+        violations: list[Violation],
         _source: str,
         _tree: ast.Module,
         _encoding: str = "utf-8",
     ) -> FixResult:
-        """No autofix support."""
-        return FixResult.for_violations(_violations, FixOutcome.DECLINED)
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -13,7 +13,7 @@ import ast
 import logging
 from typing import TYPE_CHECKING
 
-from ._base import BaseCheck, Violation, find_ignored_lines, ignore_pattern_for
+from ._base import BaseCheck, FixOutcome, FixResult, Violation, find_ignored_lines, ignore_pattern_for
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -169,6 +169,6 @@ class RedundantSuperInitCheck(BaseCheck):
         _source: str,
         _tree: ast.Module,
         _encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         """No autofix support."""
-        return False
+        return FixResult.for_violations(_violations, FixOutcome.DECLINED)

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -8,7 +8,14 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from pre_commit_hooks.ast_checks._base import BaseCheck, Violation, find_ignored_lines, ignore_pattern_for
+from pre_commit_hooks.ast_checks._base import (
+    BaseCheck,
+    FixOutcome,
+    FixResult,
+    Violation,
+    find_ignored_lines,
+    ignore_pattern_for,
+)
 from pre_commit_hooks.ast_checks._options import EnumOption
 
 from .analysis import decide_candidates
@@ -147,8 +154,8 @@ class RedundantTypeConversionCheck(BaseCheck):
         _source: str,
         _tree: ast.Module,
         _encoding: str = "utf-8",
-    ) -> bool:
-        return False
+    ) -> FixResult:
+        return FixResult.for_violations(_violations, FixOutcome.DECLINED)
 
     def reconcile_direct_inputs(self, _direct_inputs: list[Path]) -> list[Path]:
         session = peek_session()

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -150,12 +150,12 @@ class RedundantTypeConversionCheck(BaseCheck):
     def fix(
         self,
         _filepath: Path,
-        _violations: list[Violation],
+        violations: list[Violation],
         _source: str,
         _tree: ast.Module,
         _encoding: str = "utf-8",
     ) -> FixResult:
-        return FixResult.for_violations(_violations, FixOutcome.DECLINED)
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
     def reconcile_direct_inputs(self, _direct_inputs: list[Path]) -> list[Path]:
         session = peek_session()

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -38,11 +38,10 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
     ConcurrentModificationError,
+    FixOutcome,
+    FixResult,
     FixValidationError,
     Violation,
-    mark_fix_aborted,
-    mark_fix_errored,
-    mark_fix_rejected,
 )
 
 from .analysis import Suggestion, collect_suggestions
@@ -136,7 +135,7 @@ class ValidateFunctionNameCheck(BaseCheck):
         _source: str,
         _tree: ast.Module,
         _encoding: str = "utf-8",
-    ) -> bool:
+    ) -> FixResult:
         """Apply fixes for function naming violations.
 
         Note: apply_fix() re-reads the file itself (and detects its own
@@ -148,11 +147,11 @@ class ValidateFunctionNameCheck(BaseCheck):
         just-written file to stay correct against the current file state.
         """
         if not violations:
-            return False
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
-        applied_any = False
+        outcomes = [FixOutcome.DECLINED] * len(violations)
 
-        for violation in violations:
+        for index, violation in enumerate(violations):
             if not violation.fix_data:
                 continue
 
@@ -161,45 +160,33 @@ class ValidateFunctionNameCheck(BaseCheck):
             if not suggestion or suggestion.requires_property:
                 continue
 
-            if (
-                should_autofix(filepath, suggestion)
-                and _repository_reference_status(filepath, suggestion.func_name) == "safe"
-            ):
-                try:
-                    if apply_fix(filepath, suggestion):
-                        applied_any = True
-                except FixValidationError:
-                    # Reject only this rename; a rename earlier in this loop
-                    # already committed and stays, and a later one is still
-                    # attempted (mark_fix_rejected() lets the orchestrator's
-                    # post-fix re-check attribute the rejection to this
-                    # specific violation instead of the whole batch).
-                    mark_fix_rejected(violation)
-                except ConcurrentModificationError:
-                    # The file changed on disk between should_autofix()'s own
-                    # read above and apply_fix()'s write -- not a bug, so
-                    # distinct from the Exception branch below. Same
-                    # per-violation scoping as FixValidationError: a rename
-                    # earlier in this loop already committed and stays, and a
-                    # later one is still attempted.
-                    mark_fix_aborted(violation)
-                except Exception:
-                    # A bug in apply_fix() itself, distinct from
-                    # FixValidationError above: mark it so the orchestrator's
-                    # post-fix re-check reports this specific violation as
-                    # [FIX ERRORED] rather than an ordinary, retryable
-                    # [FIXABLE] — re-running --fix would just fail here
-                    # identically again.
-                    # Debug-only: mark_fix_errored() below already reports
-                    # this cleanly as [FIX ERRORED] — an ERROR-level
-                    # .exception() call here would just leak a redundant raw
-                    # traceback onto the user's stderr by default (nothing
-                    # in this codebase configures logging, so Python's own
-                    # lastResort handler prints WARNING+ straight to
-                    # stderr).
-                    logger_check.debug(
-                        "Failed to apply fix for %s in %s", suggestion.func_name, filepath, exc_info=True
-                    )
-                    mark_fix_errored(violation)
+            outcome = should_autofix(filepath, suggestion)
+            if outcome is not FixOutcome.APPLIED:
+                outcomes[index] = outcome
+                continue
+            if _repository_reference_status(filepath, suggestion.func_name) != "safe":
+                continue
+            try:
+                outcomes[index] = apply_fix(filepath, suggestion)
+            except FixValidationError:
+                outcomes[index] = FixOutcome.REJECTED
+            except ConcurrentModificationError:
+                outcomes[index] = FixOutcome.ABORTED
+            except Exception:
+                # A bug in apply_fix() itself, distinct from
+                # FixValidationError above: mark it so the orchestrator's
+                # post-fix re-check reports this specific violation as
+                # [FIX ERRORED] rather than an ordinary, retryable
+                # [FIXABLE] — re-running --fix would just fail here
+                # identically again.
+                # Debug-only: the outcome assignment below already reports
+                # this cleanly as [FIX ERRORED] — an ERROR-level
+                # .exception() call here would just leak a redundant raw
+                # traceback onto the user's stderr by default (nothing
+                # in this codebase configures logging, so Python's own
+                # lastResort handler prints WARNING+ straight to
+                # stderr).
+                logger_check.debug("Failed to apply fix for %s in %s", suggestion.func_name, filepath, exc_info=True)
+                outcomes[index] = FixOutcome.ERRORED
 
-        return applied_any
+        return FixResult(tuple(outcomes))

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Literal
 
 from pre_commit_hooks.ast_checks._base import (
+    ConcurrentModificationError,
+    FixOutcome,
+    FixValidationError,
     atomic_write_text,
     byte_col_to_char_col,
     find_ignored_lines,
@@ -92,7 +95,7 @@ def index_function_nodes(tree: ast.Module) -> FunctionIndex:
     }
 
 
-def should_autofix(filepath: Path, suggestion: Suggestion) -> bool:
+def should_autofix(filepath: Path, suggestion: Suggestion) -> FixOutcome:
     """Re-reads and re-parses `filepath` from disk, then defers to `is_autofix_safe`.
 
     Only used by `fix()`, which needs the file's current on-disk state (an
@@ -106,10 +109,10 @@ def should_autofix(filepath: Path, suggestion: Suggestion) -> bool:
         tree = ast.parse(read_source(filepath))
     except (OSError, SyntaxError, UnicodeDecodeError, LookupError) as error:
         logger.warning("Filepath: %s. Error: %s", filepath, repr(error))
-        return False
+        return FixOutcome.FAILED
 
     attach_parents(tree)
-    return is_autofix_safe(index_function_nodes(tree), suggestion)
+    return FixOutcome.APPLIED if is_autofix_safe(index_function_nodes(tree), suggestion) else FixOutcome.DECLINED
 
 
 def _repository_reference_status(filepath: Path, name: str) -> RepositoryReferenceStatus:
@@ -400,7 +403,7 @@ def _resolve_rename_scope(tree: ast.Module, func_node: _FuncNode) -> tuple[ast.A
     return tree, False
 
 
-def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
+def apply_fix(filepath: Path, suggestion: Suggestion) -> FixOutcome:
     """AST-scoped rename: renames the function definition itself plus true
     call-site references (`Name`/`Attribute` nodes reached via normal AST
     traversal) within the scope the function is visible in. Never touches
@@ -411,19 +414,19 @@ def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
         source, encoding = read_source_with_encoding(filepath)
     except (OSError, SyntaxError, UnicodeDecodeError, LookupError) as error:
         logger.warning("Filepath: %s. Error: %s", filepath, repr(error))
-        return False
+        return FixOutcome.FAILED
 
     try:
         tree = ast.parse(source)
     except SyntaxError as syntax_error:
         logger.warning("Filepath: %s. Error: %s", filepath, repr(syntax_error))
-        return False
+        return FixOutcome.FAILED
 
     attach_parents(tree)
 
     func_node = _find_function_node(tree, suggestion.func_name, suggestion.lineno)
     if func_node is None:
-        return False
+        return FixOutcome.DECLINED
 
     lines = source.splitlines(keepends=True)
 
@@ -435,7 +438,7 @@ def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
     # same scope means some Load references may no longer point at this
     # function; refuse to rename call sites we can't safely tell apart.
     if not is_method and _is_rebound_in_scope(scope_node, func_node.name, func_node):
-        return False
+        return FixOutcome.DECLINED
 
     collector = _ReferenceCollector(func_node.name, func_node, lines, is_method=is_method)
     collector.visit(scope_node)
@@ -446,7 +449,7 @@ def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
     # docs/adr/0050-format-suppression-pragmas.md.
     ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
     if any(line_num in ignored_lines for line_num, _col in positions):
-        return False
+        return FixOutcome.DECLINED
 
     old_name = func_node.name
     new_name = suggestion.suggested_name
@@ -467,8 +470,12 @@ def apply_fix(filepath: Path, suggestion: Suggestion) -> bool:
 
     try:
         atomic_write_text(filepath, new_source, encoding, source)
-    except OSError as os_error:
-        logger.warning("Filepath: %s. Error: %s", filepath, repr(os_error))
-        return False
+    except OSError as error:
+        logger.warning("Filepath: %s. Error: %s", filepath, repr(error))
+        return FixOutcome.FAILED
+    except FixValidationError:
+        return FixOutcome.REJECTED
+    except ConcurrentModificationError:
+        return FixOutcome.ABORTED
     else:
-        return True
+        return FixOutcome.APPLIED

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import is_fix_failed
+from pre_commit_hooks.ast_checks._base import FixOutcome
 from pre_commit_hooks.ast_checks.redundant_assignment import RedundantAssignmentCheck
 from pre_commit_hooks.ast_checks.redundant_assignment.autofix import (
     _can_safely_inline,
@@ -60,7 +60,7 @@ def test_fix_method_with_fixable_violations(checked: CheckedFn, check: Redundant
     assert len(violations) >= 1
     assert any(v.fixable for v in violations)
 
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert "x = " not in fixed_content
@@ -80,7 +80,7 @@ def test_fix_two_assignments_used_on_the_same_line(checked: CheckedFn, check: Re
 """
     filepath, tree, violations = checked(source)
 
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert "x = " not in fixed_content
@@ -101,18 +101,18 @@ def test_fix_chained_assignment_where_use_line_is_another_assign_line(
 """
     filepath, tree, violations = checked(source)
 
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert "y = " not in fixed_content
     assert "return x" in fixed_content
 
 
-def test_fix_write_failure_returns_false(
+def test_fix_write_failure_reports_failed_outcome(
     tmp_path: Path, check: RedundantAssignmentCheck, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # apply_fixes() must catch atomic_write_text()'s OSError and return
-    # False, like every other check's fix(), instead of letting it
+    # apply_fixes() must catch atomic_write_text()'s OSError and return a
+    # failed outcome instead of letting it
     # propagate uncaught.
     source = """def func_scope():
     x = "foo"
@@ -126,16 +126,13 @@ def test_fix_write_failure_returns_false(
     violations = check.check(filepath, tree, source)
 
     with caplog.at_level("DEBUG"):
-        assert check.fix(filepath, violations, source, tree) is False
+        fix_result = check.fix(filepath, violations, source, tree)
+    assert FixOutcome.APPLIED not in fix_result.outcomes
     # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.
-    assert all(is_fix_failed(v) for v in violations)
-    # mark_fix_failed() above already reports this cleanly; a raw traceback
-    # on stderr by default would just be redundant noise (ch. 7: "MUST NOT
-    # emit uncontrolled human-oriented text into a machine-readable output
-    # stream").
+    assert fix_result.outcomes == (FixOutcome.FAILED,) * len(violations)
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -209,7 +206,7 @@ def test_autofix_declines_fix_for_invalid_or_unsafe_fix_data(
     violation = ViolationFactory.build(
         check_id="redundant-assignment", error_code="TR5", fixable=True, fix_data=fix_data
     )
-    assert check.fix(write_source(source), [violation], source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in check.fix(write_source(source), [violation], source, ast.parse(source)).outcomes
 
 
 def test_autofix_skips_multiline_rhs() -> None:
@@ -232,7 +229,7 @@ x = "foo"
 func(x=x)
 """
     violation = ViolationFactory.build(check_id="redundant-assignment", error_code="TR5", fixable=False, fix_data=None)
-    assert apply_fixes(Path("test.py"), [violation], source) is False
+    assert FixOutcome.APPLIED not in apply_fixes(Path("test.py"), [violation], source).outcomes
 
 
 @pytest.mark.parametrize(
@@ -319,7 +316,7 @@ def test_autofix_inlines_simple_redundant_assignment(
     filepath, tree, violations = checked(source)
 
     assert any(v.fixable for v in violations)
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert removed not in fixed_content
@@ -360,7 +357,7 @@ def test_autofix_respects_word_boundaries(
     filepath, tree, violations = checked(source)
 
     assert any(v.fixable for v in violations)
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
     assert expected in filepath.read_text()
 
 
@@ -398,7 +395,7 @@ def test_zero_arg_call_immediate_single_use_is_fixable(checked: CheckedFn, check
     assert check_violations
     assert all(v.fixable for v in check_violations)
 
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert "check = " not in fixed_content
@@ -665,7 +662,7 @@ def test_autofix_splices_string_literal_into_fstring_field(checked: CheckedFn, c
     filepath, tree, violations = checked(source)
 
     assert any(v.fixable for v in violations)
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
     fixed_content = filepath.read_text()
     assert "org = " not in fixed_content

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -8,6 +8,7 @@ import pytest
 
 import pre_commit_hooks.ast_checks.redundant_type_conversion as tri006_module
 import pre_commit_hooks.ast_checks.redundant_type_conversion.daemon as daemon_module
+from pre_commit_hooks.ast_checks._base import FixOutcome, Violation
 from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks.redundant_type_conversion import RedundantTypeConversionCheck
 from pre_commit_hooks.ast_checks.redundant_type_conversion.confidence import ConfidenceLevel
@@ -78,7 +79,10 @@ def test_prefilter_pattern_matches_the_configured_levels_eligible_constructors(
 
 def test_fix_always_declines() -> None:
     check = RedundantTypeConversionCheck()
-    assert check.fix(Path("test.py"), [], "x = 1\n", ast.parse("x = 1\n")).outcomes == ()
+    violation = Violation(
+        check_id="redundant-type-conversion", error_code="TR6", line=1, col=0, message="x", fixable=False
+    )
+    assert check.fix(Path("test.py"), [violation], "x = 1\n", ast.parse("x = 1\n")).outcomes == (FixOutcome.DECLINED,)
 
 
 def test_check_never_calls_get_session_when_the_file_has_no_real_candidate(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -76,9 +76,9 @@ def test_prefilter_pattern_matches_the_configured_levels_eligible_constructors(
     assert set(pattern) == expected  # pytriage: TR6
 
 
-def test_fix_never_applies_a_fix() -> None:
+def test_fix_always_declines() -> None:
     check = RedundantTypeConversionCheck()
-    assert check.fix(Path("test.py"), [], "x = 1\n", ast.parse("x = 1\n")) is False
+    assert check.fix(Path("test.py"), [], "x = 1\n", ast.parse("x = 1\n")).outcomes == ()
 
 
 def test_check_never_calls_get_session_when_the_file_has_no_real_candidate(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,6 +9,8 @@ import pytest
 
 from pre_commit_hooks.ast_checks._base import (
     ConcurrentModificationError,
+    FixOutcome,
+    FixResult,
     FixValidationError,
     atomic_write_text,
     byte_col_to_char_col,
@@ -18,15 +20,7 @@ from pre_commit_hooks.ast_checks._base import (
     find_ignored_lines_and_classify_comments,
     ignore_pattern_for,
     ignored_lines_from_tokens,
-    is_fix_aborted,
-    is_fix_errored,
-    is_fix_failed,
-    is_fix_rejected,
     line_terminator,
-    mark_fix_aborted,
-    mark_fix_errored,
-    mark_fix_failed,
-    mark_fix_rejected,
     normalize_for_tokenize,
     split_lines_like_ast,
     tokenize_source,
@@ -51,6 +45,12 @@ def test_byte_col_to_char_col(line: str, needle: bytes) -> None:
     byte_offset = line.encode("utf-8").index(needle)
     char_offset = line.index(needle.decode())
     assert byte_col_to_char_col(line, byte_offset) == char_offset
+
+
+def test_fix_result_keeps_a_distinct_outcome_for_each_violation() -> None:
+    fix_result = FixResult((FixOutcome.APPLIED, FixOutcome.DECLINED, FixOutcome.FAILED))
+
+    assert fix_result.outcomes == (FixOutcome.APPLIED, FixOutcome.DECLINED, FixOutcome.FAILED)
 
 
 @pytest.mark.parametrize(
@@ -526,100 +526,10 @@ def test_atomic_write_text_aborts_when_disk_content_no_longer_decodes(tmp_path: 
     assert target.read_bytes() == b"x = \xff\xfe broken bytes\n"
 
 
-@pytest.mark.parametrize(
-    "fix_data",
-    [None, {"other_key": 1}],
-    ids=["no-fix-data", "existing-fix-data"],
-)
-def test_mark_fix_rejected(fix_data: dict[str, int] | None) -> None:
-    violation = ViolationFactory.build(fix_data=fix_data)
-    assert not is_fix_rejected(violation)
+def test_violation_stores_terminal_fix_outcome_separately_from_fix_data() -> None:
+    violation = ViolationFactory.build(fix_data={"other_key": 1})
 
-    mark_fix_rejected(violation)
+    violation.fix_outcome = FixOutcome.FAILED
 
-    assert is_fix_rejected(violation)
-    assert violation.fix_data is not None
-    if fix_data is not None:
-        assert violation.fix_data["other_key"] == 1
-
-
-def test_is_fix_rejected_false_when_only_marked_fixed() -> None:
-    violation = ViolationFactory.build(fix_data={"fixed": True})
-    assert not is_fix_rejected(violation)
-
-
-@pytest.mark.parametrize(
-    "fix_data",
-    [None, {"other_key": 1}],
-    ids=["no-fix-data", "existing-fix-data"],
-)
-def test_mark_fix_errored(fix_data: dict[str, int] | None) -> None:
-    violation = ViolationFactory.build(fix_data=fix_data)
-    assert not is_fix_errored(violation)
-
-    mark_fix_errored(violation)
-
-    assert is_fix_errored(violation)
-    assert violation.fix_data is not None
-    if fix_data is not None:
-        assert violation.fix_data["other_key"] == 1
-
-
-def test_is_fix_errored_false_when_only_marked_rejected() -> None:
-    # mark_fix_rejected() and mark_fix_errored() record distinct outcomes
-    # (fix() ran but produced invalid syntax, vs. fix() itself raised) —
-    # neither must be conflated with the other.
-    violation = ViolationFactory.build(fix_data={"fix_rejected": True})
-    assert not is_fix_errored(violation)
-
-
-@pytest.mark.parametrize(
-    "fix_data",
-    [None, {"other_key": 1}],
-    ids=["no-fix-data", "existing-fix-data"],
-)
-def test_mark_fix_failed(fix_data: dict[str, int] | None) -> None:
-    violation = ViolationFactory.build(fix_data=fix_data)
-    assert not is_fix_failed(violation)
-
-    mark_fix_failed(violation)
-
-    assert is_fix_failed(violation)
-    assert violation.fix_data is not None
-    if fix_data is not None:
-        assert violation.fix_data["other_key"] == 1
-
-
-def test_is_fix_failed_false_when_only_marked_errored() -> None:
-    # mark_fix_errored() (fix() itself raised — a bug) and mark_fix_failed()
-    # (fix() caught its own OSError and returned False — an environmental
-    # failure) record distinct outcomes; neither must be conflated with the
-    # other.
-    violation = ViolationFactory.build(fix_data={"fix_errored": True})
-    assert not is_fix_failed(violation)
-
-
-@pytest.mark.parametrize(
-    "fix_data",
-    [None, {"other_key": 1}],
-    ids=["no-fix-data", "existing-fix-data"],
-)
-def test_mark_fix_aborted(fix_data: dict[str, int] | None) -> None:
-    violation = ViolationFactory.build(fix_data=fix_data)
-    assert not is_fix_aborted(violation)
-
-    mark_fix_aborted(violation)
-
-    assert is_fix_aborted(violation)
-    assert violation.fix_data is not None
-    if fix_data is not None:
-        assert violation.fix_data["other_key"] == 1
-
-
-def test_is_fix_aborted_false_when_only_marked_failed() -> None:
-    # mark_fix_failed() (fix() caught its own OSError, e.g. disk full) and
-    # mark_fix_aborted() (atomic_write_text() detected the file changed on
-    # disk mid-fix) record distinct outcomes; neither must be conflated with
-    # the other.
-    violation = ViolationFactory.build(fix_data={"fix_failed": True})
-    assert not is_fix_aborted(violation)
+    assert violation.fix_outcome is FixOutcome.FAILED
+    assert violation.fix_data == {"other_key": 1}

--- a/tests/test_excessive_blank_lines.py
+++ b/tests/test_excessive_blank_lines.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import is_fix_failed
+from pre_commit_hooks.ast_checks._base import FixOutcome
 from pre_commit_hooks.ast_checks.excessive_blank_lines import (
     ExcessiveBlankLinesCheck,
     fix_file_content,
@@ -109,7 +109,7 @@ def test_fix_ignores_stale_violation(source: str, tmp_path: Path) -> None:
     # rather than trusting it.
     stale_violation = ViolationFactory.build(check_id=check.check_id, error_code=check.error_code)
 
-    assert check.fix(test_file, [stale_violation], source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in check.fix(test_file, [stale_violation], source, ast.parse(source)).outcomes
     assert test_file.read_text() == source
 
 
@@ -117,13 +117,13 @@ def test_fix_file_content_empty_source_returns_unchanged() -> None:
     assert fix_file_content("", ast.parse("")) == ""
 
 
-def test_fix_with_no_violations_returns_false(tmp_path: Path) -> None:
+def test_fix_with_no_violations_declines(tmp_path: Path) -> None:
     source = "x = 1\n"
     test_file = tmp_path / "module.py"
     test_file.write_text(source)
 
     check = ExcessiveBlankLinesCheck()
-    assert check.fix(test_file, [], source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in check.fix(test_file, [], source, ast.parse(source)).outcomes
 
 
 def test_fix_leading_blank_lines_before_first_code_with_no_header(
@@ -136,11 +136,11 @@ def test_fix_leading_blank_lines_before_first_code_with_no_header(
 
     check = ExcessiveBlankLinesCheck()
     violations = check.check(test_file, tree, source)
-    assert check.fix(test_file, violations, source, tree)
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_text() == "\nimport os\n"
 
 
-def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_fix_write_failure_reports_failed_outcome(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     bad_source = (FIXTURES_DIR / "bad" / "header_spacing.py").read_text()
 
     # Point at a path inside a directory that doesn't exist so write_text()
@@ -151,16 +151,13 @@ def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptu
     check = ExcessiveBlankLinesCheck()
     violations = check.check(test_file, tree, bad_source)
     with caplog.at_level("DEBUG"):
-        assert check.fix(test_file, violations, bad_source, tree) is False
+        fix_result = check.fix(test_file, violations, bad_source, tree)
+    assert FixOutcome.APPLIED not in fix_result.outcomes
     # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.
-    assert all(is_fix_failed(v) for v in violations)
-    # mark_fix_failed() above already reports this cleanly; a raw traceback
-    # on stderr by default would just be redundant noise (ch. 7: "MUST NOT
-    # emit uncontrolled human-oriented text into a machine-readable output
-    # stream").
+    assert fix_result.outcomes == (FixOutcome.FAILED,) * len(violations)
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -174,6 +171,6 @@ def test_fix_collapses_header_blank_lines(tmp_path: Path) -> None:
     tree = ast.parse(bad_source)
     check = ExcessiveBlankLinesCheck()
     violations = check.check(test_file, tree, bad_source)
-    assert check.fix(test_file, violations, bad_source, tree)
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, bad_source, tree).outcomes
 
     assert test_file.read_text() == good_source

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import is_fix_failed
+from pre_commit_hooks.ast_checks._base import FixOutcome
 from pre_commit_hooks.ast_checks.meaningless_vars import (
     MeaninglessVarsCheck,
     MeaninglessVarsLevel,
@@ -582,7 +582,7 @@ def fetch_users():
         assert violations[0].fixable
 
         success = check.fix(filepath, violations, source, tree)
-        assert success
+        assert success.outcomes == (FixOutcome.APPLIED,)
 
         fixed_content = filepath.read_text()
 
@@ -612,7 +612,7 @@ def fetch_users():
     assert violations[0].fixable
 
     success = check.fix(filepath, violations, source, tree)
-    assert success is False
+    assert success.outcomes == (FixOutcome.DECLINED,)
     assert filepath.read_text() == source
 
 
@@ -632,7 +632,7 @@ def test_autofix_no_fixable_violations() -> None:
         non_fixable = [v for v in violations if not v.fixable]
 
         success = check.fix(filepath, non_fixable, source, tree)
-        assert not success
+        assert success.outcomes == (FixOutcome.DECLINED,) * len(non_fixable)
 
 
 def test_autofix_follows_closure_reference_into_nested_function() -> None:
@@ -657,7 +657,7 @@ def test_autofix_follows_closure_reference_into_nested_function() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -687,7 +687,7 @@ def test_autofix_follows_closure_reference_into_lambda() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -707,7 +707,7 @@ def test_autofix_follows_closure_reference_into_comprehension() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -736,7 +736,7 @@ def test_walrus_rebinding_suppresses_suggestion() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -869,7 +869,7 @@ def test_autofix_renames_reference_evaluated_in_enclosing_scope(source: str, exp
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1091,7 +1091,7 @@ def test_autofix_does_not_rename_shadowed_reference_in_nested_scope(source: str,
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1135,7 +1135,7 @@ def test_autofix_never_offered_for_name_referenced_via_nonlocal() -> None:
         assert violations
         assert all(not v.fixable for v in violations)
 
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1273,7 +1273,7 @@ def test_autofix_never_offered_when_same_scope_rebinds_via_non_name_construct(so
         assert violations
         assert all(not v.fixable for v in violations)
 
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1347,7 +1347,7 @@ def test_autofix_avoids_cross_scope_suggestion_collision() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1375,7 +1375,7 @@ def test_autofix_avoids_suggestion_colliding_with_existing_nested_name() -> None
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1402,7 +1402,7 @@ def test_autofix_avoids_suggestion_colliding_with_nested_parameter_name() -> Non
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1435,7 +1435,7 @@ def outer(response):
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1466,7 +1466,7 @@ def test_autofix_renames_walrus_target_inside_default_evaluated_in_enclosing_sco
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1509,7 +1509,7 @@ def test_autofix_follows_closure_through_scope_that_itself_contains_a_shadowing_
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1548,7 +1548,7 @@ def test_autofix_avoids_suggestion_collision_when_nested_closure_precedes_captur
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1583,7 +1583,7 @@ def outer(response):
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1621,7 +1621,7 @@ def test_autofix_still_follows_annotation_closure_without_deferred_annotations()
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1715,7 +1715,7 @@ def test_autofix_follows_closure_into_type_parameter_bound_and_default() -> None
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1760,7 +1760,7 @@ def test_autofix_does_not_rename_type_parameter_bound_referencing_a_peer_type_pa
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1804,7 +1804,7 @@ def test_autofix_does_not_reuse_a_nested_functions_own_mapping_for_its_default()
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1843,7 +1843,7 @@ def test_autofix_does_not_rename_a_nested_functions_own_type_parameter_bound_via
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1873,7 +1873,7 @@ def test_autofix_does_not_rename_type_alias_bound_referencing_a_peer_type_parame
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1915,7 +1915,7 @@ def test_autofix_follows_closure_into_type_alias_value() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -1963,7 +1963,7 @@ def test_autofix_follows_closure_into_generic_functions_own_annotation_despite_b
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -2008,7 +2008,7 @@ def test_autofix_does_not_rename_generic_functions_own_annotation_referencing_a_
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -2052,7 +2052,7 @@ def outer(response):
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -2081,7 +2081,7 @@ def test_scope_names_ignore_unnamed_except_and_match_captures() -> None:
         tree = ast.parse(source)
         check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
         violations = check.check(filepath, tree, source)
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -2228,7 +2228,7 @@ def process():
         violations = check.check(filepath, tree, source)
         assert len(violations) == 1
 
-        assert check.fix(filepath, violations, source, tree) is True
+        assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
 
         fixed_content = filepath.read_text()
 
@@ -2254,7 +2254,7 @@ def test_check_reports_character_offset_not_byte_offset_before_multibyte_text() 
     assert violations[0].col == 6
 
 
-def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_fix_write_failure_reports_failed_outcome(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     source = """import requests
 
 def process():
@@ -2279,19 +2279,14 @@ def other():
     assert {v.fixable for v in violations} == {True, False}
 
     with caplog.at_level("DEBUG"):
-        assert check.fix(filepath, violations, source, tree) is False
+        fix_result = check.fix(filepath, violations, source, tree)
     # the write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again. A
     # non-fixable violation was never part of this attempt at all, so it
     # must be left alone rather than also marked failed.
-    for v in violations:
-        assert is_fix_failed(v) is v.fixable
-    # mark_fix_failed() above already reports this cleanly; a raw traceback
-    # on stderr by default would just be redundant noise (ch. 7: "MUST NOT
-    # emit uncontrolled human-oriented text into a machine-readable output
-    # stream").
+    assert fix_result.outcomes == tuple(FixOutcome.FAILED if v.fixable else FixOutcome.DECLINED for v in violations)
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import FixOutcome
+from pre_commit_hooks.ast_checks._base import FixOutcome, Violation
 from pre_commit_hooks.ast_checks.meaningless_vars import (
     MeaninglessVarsCheck,
     MeaninglessVarsLevel,
@@ -581,8 +581,8 @@ def fetch_users():
         assert len(violations) == 1
         assert violations[0].fixable
 
-        success = check.fix(filepath, violations, source, tree)
-        assert success.outcomes == (FixOutcome.APPLIED,)
+        fix_result = check.fix(filepath, violations, source, tree)
+        assert fix_result.outcomes == (FixOutcome.APPLIED,)
 
         fixed_content = filepath.read_text()
 
@@ -611,9 +611,35 @@ def fetch_users():
     assert len(violations) == 1
     assert violations[0].fixable
 
-    success = check.fix(filepath, violations, source, tree)
-    assert success.outcomes == (FixOutcome.DECLINED,)
+    fix_result = check.fix(filepath, violations, source, tree)
+    assert fix_result.outcomes == (FixOutcome.DECLINED,)
     assert filepath.read_text() == source
+
+
+def test_autofix_declines_fixable_violation_without_fix_data(tmp_path: Path) -> None:
+    source = """import requests
+
+def fetch_users():
+    data = requests.get(url)
+    return data.status_code
+"""
+    filepath = tmp_path / "test.py"
+    filepath.write_text(source)
+    tree = ast.parse(source)
+    check = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)
+    (candidate,) = check.check(filepath, tree, source)
+    stale_violation = Violation(
+        check_id=candidate.check_id,
+        error_code=candidate.error_code,
+        line=candidate.line,
+        col=candidate.col,
+        message=candidate.message,
+        fixable=True,
+    )
+
+    fix_result = check.fix(filepath, [candidate, stale_violation], source, tree)
+
+    assert fix_result.outcomes == (FixOutcome.APPLIED, FixOutcome.DECLINED)
 
 
 def test_autofix_no_fixable_violations() -> None:
@@ -2277,6 +2303,17 @@ def other():
     # included specifically so the marking loop below has both a fixable
     # and a non-fixable violation to distinguish between.
     assert {v.fixable for v in violations} == {True, False}
+    candidate = next(violation for violation in violations if violation.fixable)
+    violations.append(
+        Violation(
+            check_id=candidate.check_id,
+            error_code=candidate.error_code,
+            line=candidate.line,
+            col=candidate.col,
+            message=candidate.message,
+            fixable=True,
+        )
+    )
 
     with caplog.at_level("DEBUG"):
         fix_result = check.fix(filepath, violations, source, tree)
@@ -2286,7 +2323,9 @@ def other():
     # re-running --fix, which would just fail identically again. A
     # non-fixable violation was never part of this attempt at all, so it
     # must be left alone rather than also marked failed.
-    assert fix_result.outcomes == tuple(FixOutcome.FAILED if v.fixable else FixOutcome.DECLINED for v in violations)
+    assert fix_result.outcomes == tuple(
+        FixOutcome.FAILED if violation is candidate else FixOutcome.DECLINED for violation in violations
+    )
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import is_fix_failed
+from pre_commit_hooks.ast_checks._base import FixOutcome
 from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks.misplaced_comment import MisplacedCommentCheck
 
@@ -124,7 +124,7 @@ def test_fix_moves_trailing_comment(source: str, fixed_source: str, tmp_path: Pa
     check = MisplacedCommentCheck()
     violations = check.check(test_file, tree, source)
 
-    assert check.fix(test_file, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_text() == fixed_source
 
 
@@ -145,7 +145,7 @@ def test_fix_is_noop_when_nothing_to_fix(source: str, tmp_path: Path) -> None:
     test_file = tmp_path / "test.py"
     test_file.write_text(source)
 
-    assert MisplacedCommentCheck().fix(test_file, [], source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in MisplacedCommentCheck().fix(test_file, [], source, ast.parse(source)).outcomes
     assert test_file.read_text() == source
 
 
@@ -186,7 +186,7 @@ def test_fix_preserves_crlf_on_touched_lines(source: str, fixed_source: str, tmp
     check = MisplacedCommentCheck()
     violations = check.check(test_file, tree, source)
 
-    assert check.fix(test_file, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_bytes() == fixed_source.encode()
 
 
@@ -205,14 +205,13 @@ def test_check_and_fix_detect_comment_on_cr_only_source(tmp_path: Path) -> None:
     violations = check.check(test_file, tree, source)
 
     assert len(violations) == 1
-    assert check.fix(test_file, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_bytes() == b"foo(\r    bar,  # comment\r)\r"
 
 
-def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # fix() must catch atomic_write_text()'s OSError and return False,
-    # like every other check's fix(), instead of letting it propagate
-    # uncaught.
+def test_fix_write_failure_reports_failed_outcome(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    # fix() must catch atomic_write_text()'s OSError and return a failed
+    # outcome instead of letting it propagate uncaught.
     source = "result = func(\n    arg\n)  # Comment here\n"
 
     # Point at a path inside a directory that doesn't exist so the
@@ -224,16 +223,13 @@ def test_fix_write_failure_returns_false(tmp_path: Path, caplog: pytest.LogCaptu
     violations = check.check(filepath, tree, source)
 
     with caplog.at_level("DEBUG"):
-        assert check.fix(filepath, violations, source, tree) is False
+        fix_result = check.fix(filepath, violations, source, tree)
+    assert FixOutcome.APPLIED not in fix_result.outcomes
     # The write failure must be attributed to the violations it
     # actually affected, not left indistinguishable from "never attempted"
     # — the orchestrator's own report otherwise misleadingly suggests
     # re-running --fix, which would just fail identically again.
-    assert all(is_fix_failed(v) for v in violations)
-    # mark_fix_failed() above already reports this cleanly; a raw traceback
-    # on stderr by default would just be redundant noise (ch. 7: "MUST NOT
-    # emit uncontrolled human-oriented text into a machine-readable output
-    # stream").
+    assert fix_result.outcomes == (FixOutcome.FAILED,) * len(violations)
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -253,7 +249,7 @@ def test_fixes_match_golden_fixtures(fixture_name: str, tmp_path: Path) -> None:
     check = MisplacedCommentCheck()
     violations = check.check(test_file, tree, source)
 
-    assert check.fix(test_file, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_text() == good_fixture.read_text()
 
 
@@ -280,5 +276,5 @@ def test_preserves_linter_pragma_comments(tmp_path: Path) -> None:
     violations = check.check(test_file, tree, source)
 
     assert violations == []
-    assert check.fix(test_file, violations, source, tree) is False
+    assert FixOutcome.APPLIED not in check.fix(test_file, violations, source, tree).outcomes
     assert test_file.read_text() == good_fixture.read_text()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -25,21 +25,21 @@ from pre_commit_hooks._lsp import LSPError
 from pre_commit_hooks.ast_checks import ALL_CHECKS, _cli, _discovery, _orchestrator
 from pre_commit_hooks.ast_checks._base import (
     CheckUnavailableError,
+    FixOutcome,
+    FixResult,
     Violation,
     atomic_write_text,
-    is_fix_aborted,
-    is_fix_errored,
-    is_fix_failed,
-    is_fix_rejected,
-    is_fixed,
-    is_resolved_indirectly,
-    mark_fix_failed,
 )
 from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks._diagnostics import report
 from pre_commit_hooks.ast_checks._discovery import ExcludePattern, expand_directories, filter_excluded_files
 from pre_commit_hooks.ast_checks._options import CheckOption, EnumOption
-from pre_commit_hooks.ast_checks._orchestrator import CheckOrchestrator, _group_by_check_id, load_checks
+from pre_commit_hooks.ast_checks._orchestrator import (
+    CheckOrchestrator,
+    _group_by_check_id,
+    _set_fix_outcomes,
+    load_checks,
+)
 from pre_commit_hooks.ast_checks._per_file_ignores import PerFileIgnore, PerFileIgnoreList
 from pre_commit_hooks.ast_checks.excessive_blank_lines import ExcessiveBlankLinesCheck
 from pre_commit_hooks.ast_checks.meaningless_vars import MeaninglessVarsCheck, MeaninglessVarsLevel
@@ -647,10 +647,8 @@ def test_apply_fixes_handles_utf8_bom(tmp_path: Path) -> None:
 
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()], fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
-    fix_data = violations[str(filepath)][0].fix_data
 
-    assert fix_data is not None
-    assert fix_data["fixed"] is True
+    assert violations[str(filepath)][0].fix_outcome is FixOutcome.APPLIED
     assert filepath.read_bytes().startswith(b"\xef\xbb\xbf")
     assert filepath.read_text(encoding="utf-8-sig") == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
@@ -674,8 +672,7 @@ def test_apply_fixes_recomputes_stale_positions(tmp_path: Path) -> None:
     violations = orchestrator.process_files([str(filepath)])
 
     redundant_assignment_fixed = any(
-        v.check_id == "redundant-assignment" and v.fix_data and v.fix_data.get("fixed")
-        for v in violations[str(filepath)]
+        v.check_id == "redundant-assignment" and v.fix_outcome is FixOutcome.APPLIED for v in violations[str(filepath)]
     )
     assert redundant_assignment_fixed
 
@@ -823,7 +820,7 @@ def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tm
     method_violation = next(
         v for v in violations[str(filepath)] if v.check_id == "validate-function-name" and "get_active" in v.message
     )
-    assert not is_fixed(method_violation)
+    assert method_violation.fix_outcome is not FixOutcome.APPLIED
     assert method_violation.line == actual_method_line
 
 
@@ -849,10 +846,10 @@ def test_refresh_stale_positions_never_drops_an_unrelated_open_violation_sharing
     # different scopes would produce identical violation text.
     shared_message = "Meaningless variable name 'data' found. Consider renaming to 'response'."
     terminal = ViolationFactory.build(
-        check_id="meaningless-vars", message=shared_message, fixable=True, fix_data={"fix_failed": True}
+        check_id="meaningless-vars", message=shared_message, fixable=True, fix_outcome=FixOutcome.FAILED
     )
     open_violation = ViolationFactory.build(
-        check_id="meaningless-vars", message=shared_message, fixable=True, fix_data=None
+        check_id="meaningless-vars", message=shared_message, fixable=True, fix_outcome=FixOutcome.DECLINED
     )
     violations = [terminal, open_violation]
 
@@ -905,7 +902,9 @@ def test_refresh_stale_positions_records_rule_failure_when_check_raises(
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
     # A still-open (unmarked) violation for this check_id, so there's
     # something for the reconciliation pass to actually attempt refreshing.
-    stale_violation = ViolationFactory.build(check_id="meaningless-vars", fixable=True, fix_data=None)
+    stale_violation = ViolationFactory.build(
+        check_id="meaningless-vars", fixable=True, fix_data=None, fix_outcome=FixOutcome.DECLINED
+    )
     violations = [stale_violation]
 
     orchestrator._refresh_stale_positions(filepath, violations)
@@ -914,6 +913,46 @@ def test_refresh_stale_positions_records_rule_failure_when_check_raises(
     # Left exactly as it was -- the check crashed before it could report
     # anything current to replace it with.
     assert violations == [stale_violation]
+
+
+def test_fix_result_requires_one_outcome_per_violation() -> None:
+    violations = [ViolationFactory.build(), ViolationFactory.build()]
+
+    with pytest.raises(ValueError, match="one outcome per violation"):
+        _set_fix_outcomes(violations, FixResult((FixOutcome.APPLIED,)))
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [FixOutcome.REJECTED, FixOutcome.ERRORED, FixOutcome.DECLINED],
+)
+def test_post_fix_verification_preserves_a_reported_outcome_when_the_file_cannot_be_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: FixOutcome
+) -> None:
+    filepath = tmp_path / "module.py"
+    violation = ViolationFactory.build(fix_outcome=outcome)
+    orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
+    monkeypatch.setattr(CheckOrchestrator, "_read_source", lambda _self, _filepath: None)
+
+    assert orchestrator._mark_resolved_and_get_still_present(filepath, MeaninglessVarsCheck(), [violation]) == {
+        (violation.line, violation.col, violation.message)
+    }
+    assert violation.fix_outcome is outcome
+
+
+def test_post_fix_verification_declines_an_unconfirmed_applied_outcome(tmp_path: Path) -> None:
+    filepath = tmp_path / "module.py"
+    source = "import requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
+    filepath.write_text(source)
+    check = MeaninglessVarsCheck()
+    (violation,) = check.check(filepath, ast.parse(source), source)
+    violation.fix_outcome = FixOutcome.APPLIED
+    orchestrator = CheckOrchestrator(checks=[check])
+
+    assert orchestrator._mark_resolved_and_get_still_present(filepath, check, [violation]) == {
+        (violation.line, violation.col, violation.message)
+    }
+    assert violation.fix_outcome is FixOutcome.DECLINED
 
 
 def test_fix_honors_pep263_encoding_declaration(tmp_path: Path) -> None:
@@ -927,7 +966,7 @@ def test_fix_honors_pep263_encoding_declaration(tmp_path: Path) -> None:
     orchestrator = CheckOrchestrator(checks=checks, fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
 
-    assert violations[str(filepath)][0].fix_data == {"fixed": True}
+    assert violations[str(filepath)][0].fix_outcome is FixOutcome.APPLIED
     fixed_content = filepath.read_bytes().decode("latin-1")
     assert "x  # caf\xe9" in fixed_content
     assert ")\n" in fixed_content
@@ -942,7 +981,7 @@ def test_fix_preserves_crlf_line_endings(tmp_path: Path) -> None:
     orchestrator = CheckOrchestrator(checks=checks, fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
 
-    assert violations[str(filepath)][0].fix_data == {"fixed": True}
+    assert violations[str(filepath)][0].fix_outcome is FixOutcome.APPLIED
     fixed_content = filepath.read_bytes()
     assert b"\r\nother = 1\r\n" in fixed_content
     assert b"x  # comment" in fixed_content
@@ -1400,8 +1439,8 @@ class _AlwaysRerunProbeCheck:
 
     def fix(
         self, _filepath: Path, _violations: list[Violation], _source: str, _tree: ast.Module, _encoding: str = "utf-8"
-    ) -> bool:
-        return False
+    ) -> FixResult:
+        return FixResult.for_violations(_violations, FixOutcome.DECLINED)
 
     def reconcile_direct_inputs(self, _already_processed: list[Path]) -> list[Path]:
         return []
@@ -1441,9 +1480,9 @@ class _MarkerFixableCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         atomic_write_text(filepath, source + _CLEAN_MARKER, encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 class _MarkerRemovingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
@@ -1473,9 +1512,9 @@ class _MarkerRemovingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         atomic_write_text(filepath, source.replace(_CLEAN_MARKER, ""), encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 def test_fix_mode_falls_through_when_an_always_rerun_fix_invalidates_a_cached_cacheable_result(
@@ -1508,7 +1547,7 @@ def test_fix_mode_falls_through_when_an_always_rerun_fix_invalidates_a_cached_ca
     # recompute must not happen: it would find the file already clean and
     # silently lose its own [FIXED] outcome. The marker-remover's own fix
     # must still be reported.
-    assert is_fixed(by_check["marker-remover"])
+    assert by_check["marker-remover"].fix_outcome is FixOutcome.APPLIED
 
 
 def test_always_rerun_probe_check_fix_is_a_no_op(tmp_path: Path) -> None:
@@ -1518,7 +1557,7 @@ def test_always_rerun_probe_check_fix_is_a_no_op(tmp_path: Path) -> None:
     # convention for a check with no autofix (e.g.
     # RedundantTypeConversionCheck's own test_fix_never_applies_a_fix).
     probe = _AlwaysRerunProbeCheck()
-    assert probe.fix(tmp_path / "module.py", [], "x = 1\n", ast.parse("x = 1\n")) is False
+    assert probe.fix(tmp_path / "module.py", [], "x = 1\n", ast.parse("x = 1\n")).outcomes == ()
 
 
 class _DrainingProbeCheck(_AlwaysRerunProbeCheck):
@@ -1973,11 +2012,11 @@ class _AppendingFixCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         if self.write_delay_seconds:
             time.sleep(self.write_delay_seconds)
         atomic_write_text(filepath, f"{source}# {self.marker}\n", encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 def test_check_file_serializes_concurrent_fixes_to_the_same_file_across_orchestrators(
@@ -2040,11 +2079,11 @@ class _ExternallyModifiedFixCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         if self.simulate_external_edit:
             filepath.write_text(f"{source}# external edit\n", encoding=encoding)
         atomic_write_text(filepath, f"{source}# my fix\n", encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 def test_apply_fixes_applies_normally_when_nothing_else_touches_the_file(tmp_path: Path) -> None:
@@ -2058,7 +2097,7 @@ def test_apply_fixes_applies_normally_when_nothing_else_touches_the_file(tmp_pat
     violations = orchestrator.process_files([str(filepath)])
 
     violation = violations[str(filepath)][0]
-    assert violation.fix_data == {"fixed": True}
+    assert violation.fix_outcome is FixOutcome.APPLIED
     assert filepath.read_text() == "x = 1\n# my fix\n"
 
 
@@ -2071,10 +2110,10 @@ def test_apply_fixes_aborts_when_file_is_externally_modified_during_fix(tmp_path
     violations = orchestrator.process_files([str(filepath)])
 
     violation = violations[str(filepath)][0]
-    assert is_fix_aborted(violation)
-    assert not is_fix_rejected(violation)
-    assert not is_fix_errored(violation)
-    assert not (violation.fix_data and violation.fix_data.get("fixed"))
+    assert violation.fix_outcome is FixOutcome.ABORTED
+    assert violation.fix_outcome is not FixOutcome.REJECTED
+    assert violation.fix_outcome is not FixOutcome.ERRORED
+    assert violation.fix_outcome is not FixOutcome.APPLIED
     # The check's own fix was discarded; the externally written content
     # (what a real concurrent editor/process would have left behind) is what
     # survives on disk, not a silent merge of both writes.
@@ -2411,7 +2450,7 @@ def test_fix_mode_does_not_cache_a_check_id_with_a_rejected_fix(
 
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()], fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
-    assert is_fix_rejected(violations[str(filepath)][0])
+    assert violations[str(filepath)][0].fix_outcome is FixOutcome.REJECTED
 
     assert orchestrator.cache.get_cached_result(filepath, orchestrator.cache.hook_name) is None
 
@@ -2569,9 +2608,7 @@ def test_apply_fixes_skips_check_with_no_fixable_violations(tmp_path: Path) -> N
     violations = orchestrator.process_files([str(filepath)])
 
     by_check = {v.check_id: v for v in violations[str(filepath)]}
-    meaningless_vars_fix_data = by_check["meaningless-vars"].fix_data
-    assert meaningless_vars_fix_data is not None
-    assert meaningless_vars_fix_data.get("fixed") is True
+    assert by_check["meaningless-vars"].fix_outcome is FixOutcome.APPLIED
     assert by_check["redundant-super-init"].fixable is False
 
 
@@ -2601,12 +2638,8 @@ def test_apply_fixes_does_not_mark_fixed_a_violation_fix_left_untouched(tmp_path
 
     by_func_name = {v.fix_data["suggestion"].func_name: v for v in violations[str(filepath)] if v.fix_data}
 
-    get_config_fix_data = by_func_name["get_config"].fix_data
-    get_data_fix_data = by_func_name["get_data"].fix_data
-    assert get_config_fix_data is not None
-    assert get_data_fix_data is not None
-    assert get_config_fix_data["fixed"] is True
-    assert not get_data_fix_data.get("fixed")
+    assert by_func_name["get_config"].fix_outcome is FixOutcome.APPLIED
+    assert by_func_name["get_data"].fix_outcome is not FixOutcome.APPLIED
     fixed_content = filepath.read_text()
     assert "def get_config" not in fixed_content
     assert "def get_data(self):" in fixed_content
@@ -2639,12 +2672,8 @@ def test_apply_fixes_distinguishes_violations_with_identical_messages(tmp_path: 
     by_line = {v.line: v for v in violations[str(filepath)]}
     assert by_line[1].message == by_line[7].message
 
-    free_function_fix_data = by_line[1].fix_data
-    method_fix_data = by_line[7].fix_data
-    assert free_function_fix_data is not None
-    assert method_fix_data is not None
-    assert free_function_fix_data.get("fixed") is True
-    assert not method_fix_data.get("fixed")
+    assert by_line[1].fix_outcome is FixOutcome.APPLIED
+    assert by_line[7].fix_outcome is not FixOutcome.APPLIED
     assert "def load_data():" in filepath.read_text()
     assert "def get_data(self):" in filepath.read_text()
 
@@ -2678,10 +2707,10 @@ def test_apply_fixes_marks_violation_rejected_when_fix_produces_invalid_syntax(
     meaningless_vars_violation = by_check["meaningless-vars"]
     blank_lines_violation = by_check["excessive-blank-lines"]
 
-    assert is_fix_rejected(meaningless_vars_violation)
-    assert not (meaningless_vars_violation.fix_data and meaningless_vars_violation.fix_data.get("fixed"))
-    assert not is_fix_rejected(blank_lines_violation)
-    assert blank_lines_violation.fix_data == {"fixed": True}
+    assert meaningless_vars_violation.fix_outcome is FixOutcome.REJECTED
+    assert meaningless_vars_violation.fix_outcome is not FixOutcome.APPLIED
+    assert blank_lines_violation.fix_outcome is not FixOutcome.REJECTED
+    assert blank_lines_violation.fix_outcome is FixOutcome.APPLIED
     assert "data = requests.get(url)" in filepath.read_text()
 
 
@@ -2712,11 +2741,11 @@ def test_apply_fixes_marks_violation_errored_when_fix_raises_unexpectedly(
     meaningless_vars_violation = by_check["meaningless-vars"]
     blank_lines_violation = by_check["excessive-blank-lines"]
 
-    assert is_fix_errored(meaningless_vars_violation)
-    assert not is_fix_rejected(meaningless_vars_violation)
-    assert not (meaningless_vars_violation.fix_data and meaningless_vars_violation.fix_data.get("fixed"))
-    assert not is_fix_errored(blank_lines_violation)
-    assert blank_lines_violation.fix_data == {"fixed": True}
+    assert meaningless_vars_violation.fix_outcome is FixOutcome.ERRORED
+    assert meaningless_vars_violation.fix_outcome is not FixOutcome.REJECTED
+    assert meaningless_vars_violation.fix_outcome is not FixOutcome.APPLIED
+    assert blank_lines_violation.fix_outcome is not FixOutcome.ERRORED
+    assert blank_lines_violation.fix_outcome is FixOutcome.APPLIED
     assert "data = requests.get(url)" in filepath.read_text()
 
 
@@ -2769,12 +2798,11 @@ def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
     data_violation = by_line[4]
     result_violation = by_line[8]
 
-    assert data_violation.fix_data is not None
-    assert data_violation.fix_data.get("fixed") is True
-    assert not is_fix_errored(data_violation)
+    assert data_violation.fix_outcome is FixOutcome.APPLIED
+    assert data_violation.fix_outcome is not FixOutcome.ERRORED
 
-    assert is_fix_errored(result_violation)
-    assert not (result_violation.fix_data and result_violation.fix_data.get("fixed"))
+    assert result_violation.fix_outcome is FixOutcome.ERRORED
+    assert result_violation.fix_outcome is not FixOutcome.APPLIED
 
     fixed_content = filepath.read_text()
     assert "response = requests.get(url)" in fixed_content
@@ -2812,9 +2840,8 @@ def test_apply_fixes_records_rule_failure_when_fix_raises_after_resolving_everyt
     violations = orchestrator.process_files([str(filepath)])
 
     violation = violations[str(filepath)][0]
-    assert violation.fix_data is not None
-    assert violation.fix_data.get("fixed") is True
-    assert not is_fix_errored(violation)
+    assert violation.fix_outcome is FixOutcome.APPLIED
+    assert violation.fix_outcome is not FixOutcome.ERRORED
     assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
@@ -2837,7 +2864,7 @@ def _write_get_config_and_get_active_module(tmp_path: Path) -> Path:
 def _run_vfn_fix_with_patched_apply_fix(
     filepath: Path,
     monkeypatch: pytest.MonkeyPatch,
-    flaky_apply_fix: Callable[[Path, Suggestion], bool],
+    flaky_apply_fix: Callable[[Path, Suggestion], FixOutcome],
 ) -> dict[str, Violation]:
     monkeypatch.setattr(vfn_module, "apply_fix", flaky_apply_fix)
 
@@ -2859,7 +2886,7 @@ def test_apply_fixes_marks_only_the_rejected_violation_of_a_multi_write_check(
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             atomic_write_text(fp, "def broken(:\n", "utf-8", fp.read_text())
         return original_apply_fix(fp, suggestion)
@@ -2867,13 +2894,10 @@ def test_apply_fixes_marks_only_the_rejected_violation_of_a_multi_write_check(
     by_func_name = _run_vfn_fix_with_patched_apply_fix(filepath, monkeypatch, flaky_apply_fix)
     get_config_violation = by_func_name["get_config"]
     get_active_violation = by_func_name["get_active"]
-    get_config_fix_data = get_config_violation.fix_data
-    assert get_config_fix_data is not None
-
-    assert get_config_fix_data.get("fixed") is True
-    assert not is_fix_rejected(get_config_violation)
-    assert is_fix_rejected(get_active_violation)
-    assert not (get_active_violation.fix_data and get_active_violation.fix_data.get("fixed"))
+    assert get_config_violation.fix_outcome is FixOutcome.APPLIED
+    assert get_config_violation.fix_outcome is not FixOutcome.REJECTED
+    assert get_active_violation.fix_outcome is FixOutcome.REJECTED
+    assert get_active_violation.fix_outcome is not FixOutcome.APPLIED
 
     fixed_content = filepath.read_text()
     assert "def get_config" not in fixed_content
@@ -2891,7 +2915,7 @@ def test_apply_fixes_marks_only_the_aborted_violation_of_a_multi_write_check(
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             atomic_write_text(fp, "def get_active(user):\n    pass\n", "utf-8", "not the real current content")
         return original_apply_fix(fp, suggestion)
@@ -2899,13 +2923,10 @@ def test_apply_fixes_marks_only_the_aborted_violation_of_a_multi_write_check(
     by_func_name = _run_vfn_fix_with_patched_apply_fix(filepath, monkeypatch, flaky_apply_fix)
     get_config_violation = by_func_name["get_config"]
     get_active_violation = by_func_name["get_active"]
-    get_config_fix_data = get_config_violation.fix_data
-    assert get_config_fix_data is not None
-
-    assert get_config_fix_data.get("fixed") is True
-    assert not is_fix_aborted(get_config_violation)
-    assert is_fix_aborted(get_active_violation)
-    assert not (get_active_violation.fix_data and get_active_violation.fix_data.get("fixed"))
+    assert get_config_violation.fix_outcome is FixOutcome.APPLIED
+    assert get_config_violation.fix_outcome is not FixOutcome.ABORTED
+    assert get_active_violation.fix_outcome is FixOutcome.ABORTED
+    assert get_active_violation.fix_outcome is not FixOutcome.APPLIED
 
     fixed_content = filepath.read_text()
     assert "def get_config" not in fixed_content
@@ -2925,7 +2946,7 @@ def test_apply_fixes_keeps_aborted_violation_aborted_even_when_the_external_edit
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             stale_source = fp.read_text()
             # Simulate a concurrent process independently renaming the
@@ -2937,12 +2958,11 @@ def test_apply_fixes_keeps_aborted_violation_aborted_even_when_the_external_edit
 
     by_func_name = _run_vfn_fix_with_patched_apply_fix(filepath, monkeypatch, flaky_apply_fix)
     get_active_violation = by_func_name["get_active"]
-    assert is_fix_aborted(get_active_violation)
-    assert not (get_active_violation.fix_data and get_active_violation.fix_data.get("fixed"))
+    assert get_active_violation.fix_outcome is FixOutcome.ABORTED
+    assert get_active_violation.fix_outcome is not FixOutcome.APPLIED
 
     get_config_violation = by_func_name["get_config"]
-    assert get_config_violation.fix_data is not None
-    assert get_config_violation.fix_data.get("fixed") is True
+    assert get_config_violation.fix_outcome is FixOutcome.APPLIED
 
     assert 'def is_active(user: dict) -> bool:\n    return user.get("status") == "active"\n' in filepath.read_text()
 
@@ -2964,7 +2984,7 @@ def test_apply_fixes_keeps_aborted_violation_aborted_when_the_external_edit_leav
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             fp.write_text("this is not valid python (((\n")
             atomic_write_text(fp, "def get_active(user):\n    pass\n", "utf-8", "stale content that won't match")
@@ -2972,13 +2992,13 @@ def test_apply_fixes_keeps_aborted_violation_aborted_when_the_external_edit_leav
 
     by_func_name = _run_vfn_fix_with_patched_apply_fix(filepath, monkeypatch, flaky_apply_fix)
     get_active_violation = by_func_name["get_active"]
-    assert is_fix_aborted(get_active_violation)
-    assert not is_fix_errored(get_active_violation)
-    assert not (get_active_violation.fix_data and get_active_violation.fix_data.get("fixed"))
+    assert get_active_violation.fix_outcome is FixOutcome.ABORTED
+    assert get_active_violation.fix_outcome is not FixOutcome.ERRORED
+    assert get_active_violation.fix_outcome is not FixOutcome.APPLIED
 
     get_config_violation = by_func_name["get_config"]
-    assert not is_fix_errored(get_config_violation)
-    assert not (get_config_violation.fix_data and get_config_violation.fix_data.get("fixed"))
+    assert get_config_violation.fix_outcome is not FixOutcome.ERRORED
+    assert get_config_violation.fix_outcome is not FixOutcome.APPLIED
 
     assert filepath.read_text() == "this is not valid python (((\n"
 
@@ -2996,7 +3016,7 @@ def test_apply_fixes_marks_errored_violation_of_a_multi_write_check_when_apply_f
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             raise RuntimeError("simulated apply_fix bug")
         return original_apply_fix(fp, suggestion)
@@ -3004,14 +3024,11 @@ def test_apply_fixes_marks_errored_violation_of_a_multi_write_check_when_apply_f
     by_func_name = _run_vfn_fix_with_patched_apply_fix(filepath, monkeypatch, flaky_apply_fix)
     get_config_violation = by_func_name["get_config"]
     get_active_violation = by_func_name["get_active"]
-    get_config_fix_data = get_config_violation.fix_data
-    assert get_config_fix_data is not None
-
-    assert get_config_fix_data.get("fixed") is True
-    assert not is_fix_errored(get_config_violation)
-    assert is_fix_errored(get_active_violation)
-    assert not is_fix_rejected(get_active_violation)
-    assert not (get_active_violation.fix_data and get_active_violation.fix_data.get("fixed"))
+    assert get_config_violation.fix_outcome is FixOutcome.APPLIED
+    assert get_config_violation.fix_outcome is not FixOutcome.ERRORED
+    assert get_active_violation.fix_outcome is FixOutcome.ERRORED
+    assert get_active_violation.fix_outcome is not FixOutcome.REJECTED
+    assert get_active_violation.fix_outcome is not FixOutcome.APPLIED
 
     fixed_content = filepath.read_text()
     assert "def get_config" not in fixed_content
@@ -3092,10 +3109,13 @@ def _recompute_raises(
     monkeypatch.setattr(MeaninglessVarsCheck, "check", flaky_check)
 
 
-def _fix_returns_false(
+def _fix_declines(
     _orchestrator: CheckOrchestrator, _meaningless_vars: MeaninglessVarsCheck, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(MeaninglessVarsCheck, "fix", lambda *_a, **_k: False)
+    def decline_fix(_self: object, _filepath: Path, violations: list[Violation], *_args: object) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)
+
+    monkeypatch.setattr(MeaninglessVarsCheck, "fix", decline_fix)
 
 
 def _fix_raises(
@@ -3111,7 +3131,7 @@ def _fix_raises(
         _disappear_after_fix,
         _recompute_finds_no_fixable_violations,
         _recompute_raises,
-        _fix_returns_false,
+        _fix_declines,
         _fix_raises,
     ],
     ids=[
@@ -3119,7 +3139,7 @@ def _fix_raises(
         "file-disappears-after-fix",
         "recompute-finds-no-fixable-violations",
         "recompute-raises",
-        "fix-returns-false",
+        "fix-declines",
         "fix-raises",
     ],
 )
@@ -3139,7 +3159,7 @@ def test_apply_fixes_marks_nothing_fixed(
 
     violations = orchestrator.process_files([str(filepath)])
     v = violations[str(filepath)][0]
-    assert not (v.fix_data and v.fix_data.get("fixed"))
+    assert v.fix_outcome is not FixOutcome.APPLIED
 
 
 class _LineRemovingFixCheck(_AlwaysRerunProbeCheck):
@@ -3174,9 +3194,9 @@ class _LineRemovingFixCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         atomic_write_text(filepath, source.replace(self.target, ""), encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 class _LineFlaggingCheck(_AlwaysRerunProbeCheck):
@@ -3206,8 +3226,8 @@ class _LineFlaggingCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, _filepath: Path, _violations: list[Violation], _source: str, _tree: ast.Module, _encoding: str = "utf-8"
-    ) -> bool:
-        return False
+    ) -> FixResult:
+        return FixResult.for_violations(_violations, FixOutcome.DECLINED)
 
 
 class _UnfixableLineFlaggingCheck(_LineFlaggingCheck):
@@ -3255,9 +3275,9 @@ class _PairFlaggingFixCheck(_AlwaysRerunProbeCheck):
 
     def fix(
         self, filepath: Path, _violations: list[Violation], source: str, _tree: ast.Module, encoding: str = "utf-8"
-    ) -> bool:
+    ) -> FixResult:
         atomic_write_text(filepath, source.replace(_FLAGGED_LINE, ""), encoding, source)
-        return True
+        return FixResult.for_violations(_violations, FixOutcome.APPLIED)
 
 
 def _run_line_probes(tmp_path: Path, checks: list[ASTCheck], source: str = "") -> dict[str, list[Violation]]:
@@ -3290,10 +3310,10 @@ def test_apply_fixes_marks_a_violation_another_checks_fix_removed_as_resolved_in
     (flagged,) = by_check["line-flagger"]
     (removed,) = by_check["line-remover"]
 
-    assert is_resolved_indirectly(flagged)
-    assert not is_fixed(flagged)
-    assert is_fixed(removed)
-    assert not is_resolved_indirectly(removed)
+    assert flagged.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY
+    assert flagged.fix_outcome is not FixOutcome.APPLIED
+    assert removed.fix_outcome is FixOutcome.APPLIED
+    assert removed.fix_outcome is not FixOutcome.RESOLVED_INDIRECTLY
 
 
 def test_apply_fixes_leaves_a_surviving_violation_open_when_another_check_fixes_an_unrelated_line(
@@ -3303,10 +3323,10 @@ def test_apply_fixes_leaves_a_surviving_violation_open_when_another_check_fixes_
     by_check = _run_line_probes(tmp_path, [_LineRemovingFixCheck(target=_UNRELATED_LINE), _LineFlaggingCheck()])
     (flagged,) = by_check["line-flagger"]
 
-    assert not is_resolved_indirectly(flagged)
-    assert not is_fixed(flagged)
+    assert flagged.fix_outcome is not FixOutcome.RESOLVED_INDIRECTLY
+    assert flagged.fix_outcome is not FixOutcome.APPLIED
     assert flagged.fix_data is None
-    assert is_fixed(by_check["line-remover"][0])
+    assert by_check["line-remover"][0].fix_outcome is FixOutcome.APPLIED
 
 
 def test_apply_fixes_marks_only_the_violation_another_checks_fix_actually_removed(tmp_path: Path) -> None:
@@ -3323,8 +3343,8 @@ def test_apply_fixes_marks_only_the_violation_another_checks_fix_actually_remove
     removed = by_message[f"{_FLAGGED_LINE.strip()} flagged"]
     survivor = by_message[f"{_SECOND_FLAGGED_LINE.strip()} flagged"]
 
-    assert is_resolved_indirectly(removed)
-    assert not is_resolved_indirectly(survivor)
+    assert removed.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY
+    assert survivor.fix_outcome is not FixOutcome.RESOLVED_INDIRECTLY
     assert survivor.fix_data is None
     assert survivor.line == 2
 
@@ -3336,18 +3356,18 @@ def test_apply_fixes_keeps_a_failed_fix_distinguishable_from_an_indirect_resolut
     # fix then removed the violation anyway. [FIX FAILED] reports something
     # the user may need to act on (a full disk, a read-only file), which
     # relabeling it as resolved would hide.
-    def failing_fix(_self: object, _fp: Path, violations: list[Violation], *_args: object, **_kwargs: object) -> bool:
-        for v in violations:
-            mark_fix_failed(v)
-        return False
+    def failing_fix(
+        _self: object, _fp: Path, violations: list[Violation], *_args: object, **_kwargs: object
+    ) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.FAILED)
 
     monkeypatch.setattr(_LineFlaggingCheck, "fix", failing_fix)
 
     (flagged,) = _run_line_probes(tmp_path, [_LineFlaggingCheck(), _LineRemovingFixCheck()])["line-flagger"]
 
-    assert is_fix_failed(flagged)
-    assert not is_resolved_indirectly(flagged)
-    assert not is_fixed(flagged)
+    assert flagged.fix_outcome is FixOutcome.FAILED
+    assert flagged.fix_outcome is not FixOutcome.RESOLVED_INDIRECTLY
+    assert flagged.fix_outcome is not FixOutcome.APPLIED
 
 
 def test_apply_fixes_marks_a_non_fixable_violation_another_checks_fix_removed_as_resolved_indirectly(
@@ -3358,7 +3378,7 @@ def test_apply_fixes_marks_a_non_fixable_violation_another_checks_fix_removed_as
         "unfixable-line-flagger"
     ]
 
-    assert is_resolved_indirectly(flagged)
+    assert flagged.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY
 
 
 def test_apply_fixes_does_not_attribute_a_disappearance_to_a_fix_when_the_file_was_edited_externally(
@@ -3378,7 +3398,7 @@ def test_apply_fixes_does_not_attribute_a_disappearance_to_a_fix_when_the_file_w
 
     by_check = _run_line_probes(tmp_path, [_LineRemovingFixCheck(), _LineFlaggingCheck()])
 
-    assert is_fix_aborted(by_check["line-remover"][0])
+    assert by_check["line-remover"][0].fix_outcome is FixOutcome.ABORTED
     assert "line-flagger" not in by_check
 
 
@@ -3390,9 +3410,9 @@ def test_apply_fixes_marks_a_violation_its_own_checks_fix_took_with_it(tmp_path:
     # must not name a different check (ADR-0053).
     by_message = {v.message: v for v in _run_line_probes(tmp_path, [_PairFlaggingFixCheck()])["pair-flagger"]}
 
-    assert is_fixed(by_message["fixable half"])
-    assert is_resolved_indirectly(by_message["unfixable half"])
-    assert not is_fixed(by_message["unfixable half"])
+    assert by_message["fixable half"].fix_outcome is FixOutcome.APPLIED
+    assert by_message["unfixable half"].fix_outcome is FixOutcome.RESOLVED_INDIRECTLY
+    assert by_message["unfixable half"].fix_outcome is not FixOutcome.APPLIED
 
 
 def _run_shipped_fix_pair(tmp_path: Path, source: str) -> dict[str, list[Violation]]:
@@ -3417,9 +3437,9 @@ def test_apply_fixes_marks_a_shipped_checks_violation_another_shipped_fix_remove
     )
     (meaningless,) = by_check["meaningless-vars"]
 
-    assert is_resolved_indirectly(meaningless)
-    assert not is_fixed(meaningless)
-    assert is_fixed(by_check["redundant-assignment"][0])
+    assert meaningless.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY
+    assert meaningless.fix_outcome is not FixOutcome.APPLIED
+    assert by_check["redundant-assignment"][0].fix_outcome is FixOutcome.APPLIED
 
 
 def test_apply_fixes_does_not_double_report_a_violation_whose_message_another_fix_rewrote(tmp_path: Path) -> None:
@@ -3433,8 +3453,10 @@ def test_apply_fixes_does_not_double_report_a_violation_whose_message_another_fi
         tmp_path, "import requests\n\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
     )
 
-    assert [is_fixed(v) for violations in by_check.values() for v in violations] == [True, True]
-    assert not any(is_resolved_indirectly(v) for violations in by_check.values() for v in violations)
+    assert [v.fix_outcome is FixOutcome.APPLIED for violations in by_check.values() for v in violations] == [True, True]
+    assert not any(
+        v.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY for violations in by_check.values() for v in violations
+    )
 
 
 def test_report_prints_an_indirectly_resolved_violation_distinctly(
@@ -3453,7 +3475,8 @@ def test_report_prints_an_indirectly_resolved_violation_distinctly(
     err = capsys.readouterr().err
     assert "[RESOLVED INDIRECTLY]" in err
     assert "it disappeared as a side effect of another fix in this run" in err
-    assert "Run with --fix" not in err
+    indirect_line = next(line for line in err.splitlines() if "[RESOLVED INDIRECTLY]" in line)
+    assert "Run with --fix" not in indirect_line
     assert "please report it" not in err
 
 
@@ -3717,7 +3740,6 @@ def test_main_reports_non_fixable_violation(tmp_path: Path, capsys: pytest.Captu
     assert "TR3" in err
     assert "[FIXABLE]" not in err
     assert "[FIXED]" not in err
-    assert "Run with --fix" not in err
 
 
 def test_main_reports_column_alongside_line(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -3761,7 +3783,8 @@ def test_main_fix_flag_marks_violation_fixed(tmp_path: Path, capsys: pytest.Capt
 
     err = capsys.readouterr().err
     assert "[FIXED]" in err
-    assert "Run with --fix" not in err
+    fixed_line = next(line for line in err.splitlines() if "[FIXED]" in line)
+    assert "Run with --fix" not in fixed_line
     # ch. 32: "MUST verify that the reported result matches the actual final
     # file state" -- the rejected/errored/failed variants of this test
     # already assert the file stays untouched; only the success path was
@@ -3852,7 +3875,7 @@ def test_main_fix_flag_reports_failed_fix(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
     # A fix() that catches its own OSError (disk full, permission denied)
-    # and returns False per ASTCheck.fix()'s own documented contract must
+    # and returns a failure outcome must
     # be reported distinctly from [FIXED] and the ordinary [FIXABLE]/"Run
     # with --fix" hint -- re-running --fix would just fail identically
     # again, and unlike [FIX ERRORED] this isn't a bug in the check's own
@@ -3874,12 +3897,36 @@ def test_main_fix_flag_reports_failed_fix(
     assert "[FIX ERRORED]" not in err
     assert "[FIX REJECTED]" not in err
     assert "Run with --fix" not in err
+    assert "could not write the file" in err
     assert "data = requests.get(url)" in filepath.read_text()
     # [FIX FAILED] above already reports this; a raw traceback alongside it
     # on stderr would just be redundant noise (ch. 7: "MUST NOT emit
     # uncontrolled human-oriented text into a machine-readable output
     # stream").
     assert all(record.levelname == "DEBUG" for record in caplog.records)
+
+
+def test_main_fix_flag_reports_declined_fix_without_operational_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def declined_fix(
+        _self: object, _fp: Path, violations: list[Violation], *_args: object, **_kwargs: object
+    ) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)
+
+    monkeypatch.setattr(MeaninglessVarsCheck, "fix", declined_fix)
+    filepath = tmp_path / "module.py"
+    filepath.write_text(
+        "import requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
+    )
+
+    assert main([str(filepath), "--select", "meaningless-vars", "--fix"]) == 1
+
+    err = capsys.readouterr().err
+    assert "[FIX DECLINED]" in err
+    assert "not safe to apply automatically" in err
+    assert "could not write the file" not in err
+    assert "file permissions" not in err
 
 
 def test_main_fix_flag_reports_aborted_fix(
@@ -3984,8 +4031,8 @@ def test_main_reports_rule_failure_when_reread_fails_mid_fix_loop(
     assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: TR6
     meaningless_vars_violation = next(v for v in violations[str(filepath)] if v.check_id == "meaningless-vars")
     super_init_violation = next(v for v in violations[str(filepath)] if v.check_id == "redundant-super-init")
-    assert is_fix_errored(meaningless_vars_violation)
-    assert not is_fix_errored(super_init_violation)
+    assert meaningless_vars_violation.fix_outcome is FixOutcome.ERRORED
+    assert super_init_violation.fix_outcome is not FixOutcome.ERRORED
     # The re-read failure means nothing was ever written back.
     assert "data = requests.get(url)" in filepath.read_text()
 
@@ -4517,7 +4564,7 @@ def test_process_files_handles_a_large_file(tmp_path: Path) -> None:
 
     assert orchestrator.unprocessable_files == []
     assert orchestrator.rule_failures == []
-    fixed = [v for v in violations[str(filepath)] if is_fixed(v)]
+    fixed = [v for v in violations[str(filepath)] if v.fix_outcome is FixOutcome.APPLIED]
     assert len(fixed) == function_count
     assert "data = requests.get" not in filepath.read_text(encoding="utf-8")
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3453,7 +3453,9 @@ def test_apply_fixes_does_not_double_report_a_violation_whose_message_another_fi
         tmp_path, "import requests\n\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
     )
 
-    assert [v.fix_outcome is FixOutcome.APPLIED for violations in by_check.values() for v in violations] == [True, True]
+    outcomes = [v.fix_outcome for violations in by_check.values() for v in violations]
+    assert len(outcomes) == 2
+    assert all(outcome is FixOutcome.APPLIED for outcome in outcomes)
     assert not any(
         v.fix_outcome is FixOutcome.RESOLVED_INDIRECTLY for violations in by_check.values() for v in violations
     )

--- a/tests/test_redundant_super_init.py
+++ b/tests/test_redundant_super_init.py
@@ -54,10 +54,14 @@ def test_get_prefilter_pattern() -> None:
 
 
 def test_fix_always_declines() -> None:
-    source = "class Foo:\n    pass\n"
+    source = (
+        "class Base:\n    def __init__(self):\n        pass\n\n\n"
+        "class Child(Base):\n    def __init__(self, **kwargs):\n        super().__init__(**kwargs)\n"
+    )
     tree = ast.parse(source)
     check = RedundantSuperInitCheck()
     violations = check.check(Path("test.py"), tree, source)
+    assert violations
     assert check.fix(Path("test.py"), violations, source, tree, "utf-8").outcomes == (FixOutcome.DECLINED,) * len(
         violations
     )

--- a/tests/test_redundant_super_init.py
+++ b/tests/test_redundant_super_init.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from pre_commit_hooks.ast_checks._base import FixOutcome
 from pre_commit_hooks.ast_checks.redundant_super_init import RedundantSuperInitCheck
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "redundant_super_init"
@@ -52,12 +53,14 @@ def test_get_prefilter_pattern() -> None:
     assert RedundantSuperInitCheck().get_prefilter_pattern() == ["super().__init__"]
 
 
-def test_fix_always_returns_false() -> None:
+def test_fix_always_declines() -> None:
     source = "class Foo:\n    pass\n"
     tree = ast.parse(source)
     check = RedundantSuperInitCheck()
     violations = check.check(Path("test.py"), tree, source)
-    assert check.fix(Path("test.py"), violations, source, tree, "utf-8") is False
+    assert check.fix(Path("test.py"), violations, source, tree, "utf-8").outcomes == (FixOutcome.DECLINED,) * len(
+        violations
+    )
 
 
 def test_violation_has_expected_line_and_no_fixable() -> None:

--- a/tests/validate_function_name/test_autofix.py
+++ b/tests/validate_function_name/test_autofix.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import pre_commit_hooks.ast_checks.validate_function_name.autofix as autofix_module
+from pre_commit_hooks.ast_checks._base import ConcurrentModificationError, FixOutcome, FixValidationError
 from pre_commit_hooks.ast_checks.validate_function_name.analysis import (
     Suggestion,
     process_file,
@@ -186,7 +188,7 @@ def test_should_autofix(
     tmp_path: Path, make_case: Callable[[Path], tuple[Path, Suggestion]], *, expected: bool
 ) -> None:
     filepath, suggestion = make_case(tmp_path)
-    assert should_autofix(filepath, suggestion) is expected
+    assert (should_autofix(filepath, suggestion) is FixOutcome.APPLIED) is expected
 
 
 def test_apply_fix_does_not_corrupt_unrelated_string_literal(tmp_path: Path) -> None:
@@ -205,7 +207,7 @@ def test_apply_fix_does_not_corrupt_unrelated_string_literal(tmp_path: Path) -> 
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     assert f"def {suggestion.suggested_name}(self):" in file_content
@@ -234,7 +236,7 @@ def test_apply_fix_does_not_rename_unrelated_class_method(tmp_path: Path) -> Non
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -261,7 +263,7 @@ def test_apply_fix_renames_recursive_call(tmp_path: Path) -> None:
         suggested_name="fetch_data",
         reason="test",
     )
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -289,7 +291,7 @@ def test_apply_fix_updates_call_site_of_nested_target_function(tmp_path: Path) -
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -311,7 +313,7 @@ def test_apply_fix_updates_free_function_call_sites(tmp_path: Path) -> None:
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -338,7 +340,7 @@ def test_apply_fix_refuses_when_a_call_site_line_is_format_suppressed(tmp_path: 
     suggestion = _suggestion_for(test_file, "get_data")
     original_content = test_file.read_text()
 
-    assert apply_fix(test_file, suggestion) is False
+    assert apply_fix(test_file, suggestion) is FixOutcome.DECLINED
     assert test_file.read_text() == original_content
 
 
@@ -360,7 +362,7 @@ def test_apply_fix_renames_call_site_on_line_with_non_ascii_text(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -388,7 +390,7 @@ def test_apply_fix_leaves_subclass_super_call_untouched(tmp_path: Path) -> None:
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -423,7 +425,7 @@ def test_apply_fix_does_not_rename_nested_shadowing_function(tmp_path: Path) -> 
 
     suggestion = _suggestion_for(test_file, "get_data")
     assert suggestion.lineno == 1
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -451,7 +453,7 @@ def test_apply_fix_does_not_rename_parameter_shadowed_call(tmp_path: Path) -> No
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -476,7 +478,7 @@ def test_apply_fix_does_not_rename_lambda_parameter_shadowed_reference(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -500,7 +502,7 @@ def test_apply_fix_renames_reference_inside_non_shadowing_lambda(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -526,7 +528,7 @@ def test_apply_fix_does_not_rename_call_shadowed_by_nested_class(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     assert "    class get_data:\n        pass\n    return get_data()\n" in file_content
@@ -549,7 +551,7 @@ def test_apply_fix_does_not_rename_call_shadowed_by_local_import(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     assert "    from other_module import get_data\n    return get_data()\n" in file_content
@@ -573,7 +575,7 @@ def test_apply_fix_does_not_rename_call_shadowed_by_nested_async_function(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     assert "    async def get_data():\n        return 2\n    return await get_data()\n" in file_content
@@ -600,7 +602,7 @@ def test_apply_fix_does_not_rename_call_shadowed_by_nested_assignment(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     assert "        get_data = compute()\n        return get_data\n" in file_content
@@ -624,7 +626,7 @@ def test_apply_fix_renames_reference_inside_non_shadowing_async_function(
     )
 
     suggestion = _suggestion_for(test_file, "get_data")
-    assert apply_fix(test_file, suggestion)
+    assert apply_fix(test_file, suggestion) is FixOutcome.APPLIED
 
     file_content = test_file.read_text()
     new_name = suggestion.suggested_name
@@ -720,7 +722,32 @@ def test_apply_fix_refuses(
     filepath, suggestion = make_case(tmp_path)
     original = filepath.read_text() if filepath.exists() else None
 
-    assert apply_fix(filepath, suggestion) is False
+    assert apply_fix(filepath, suggestion) is not FixOutcome.APPLIED
 
     if check_unchanged:
         assert filepath.read_text() == original
+
+
+@pytest.mark.parametrize(
+    ("outcome", "failure"),
+    [
+        (FixOutcome.REJECTED, lambda filepath: FixValidationError(filepath, SyntaxError("invalid output"))),
+        (FixOutcome.ABORTED, ConcurrentModificationError),
+    ],
+)
+def test_apply_fix_reports_write_outcomes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: FixOutcome,
+    failure: Callable[[Path], Exception],
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text('def get_data():\n    f = open("f.txt")\n    return f.read()\n')
+    suggestion = _suggestion_for(filepath, "get_data")
+
+    def fail_write(path: Path, *_args: object) -> None:
+        raise failure(path)
+
+    monkeypatch.setattr(autofix_module, "atomic_write_text", fail_write)
+
+    assert apply_fix(filepath, suggestion) is outcome

--- a/tests/validate_function_name/test_autofix.py
+++ b/tests/validate_function_name/test_autofix.py
@@ -60,9 +60,9 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
 @pytest.mark.parametrize(
     ("make_case", "expected"),
     [
-        (_from_fixture("safe_small.py", "get_config"), True),
-        (_from_fixture("safe_small.py", "get_active"), True),
-        (_from_fixture("safe_small.py", "get_items"), True),
+        (_from_fixture("safe_small.py", "get_config"), FixOutcome.APPLIED),
+        (_from_fixture("safe_small.py", "get_active"), FixOutcome.APPLIED),
+        (_from_fixture("safe_small.py", "get_items"), FixOutcome.APPLIED),
         # Neither function matches a naming heuristic strongly enough for
         # process_file to suggest a rename, so should_autofix is exercised
         # directly with a hand-built Suggestion instead.
@@ -74,7 +74,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="renamed_get_value",
                 reason="test",
             ),
-            False,
+            FixOutcome.FAILED,
         ),
         (
             _with_suggestion(
@@ -84,9 +84,9 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="renamed_get_result",
                 reason="test",
             ),
-            False,
+            FixOutcome.FAILED,
         ),
-        (_from_fixture("unsafe_large.py", "get_user_data"), False),
+        (_from_fixture("unsafe_large.py", "get_user_data"), FixOutcome.DECLINED),
         # apply_fix can only find self.x/cls.x call sites within the same
         # class body, not external calls through a differently-named
         # receiver (e.g. reader.get_report() in a free function elsewhere
@@ -98,7 +98,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 'class Reader:\n    def get_data(self):\n        f = open("f.txt")\n        return f.read()\n\n\n'
                 "def helper(reader):\n    return reader.get_data()\n"
             ),
-            False,
+            FixOutcome.DECLINED,
         ),
         (
             _with_suggestion(
@@ -108,7 +108,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="get_data",
                 reason="no confident suggestion",
             ),
-            False,
+            FixOutcome.DECLINED,
         ),
         (
             _with_suggestion(
@@ -118,7 +118,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="load_data",
                 reason="reads data from disk",
             ),
-            False,
+            FixOutcome.FAILED,
         ),
         (
             _with_suggestion(
@@ -128,7 +128,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="load_missing",
                 reason="reads data from disk",
             ),
-            False,
+            FixOutcome.DECLINED,
         ),
         # A function with 20+ lines of code (excluding docstring) is too
         # large to safely auto-fix.
@@ -140,7 +140,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="fetch_data",
                 reason="test",
             ),
-            False,
+            FixOutcome.DECLINED,
         ),
         # A function with control-flow nesting depth > 1 is too complex to
         # safely auto-fix.
@@ -157,7 +157,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 suggested_name="find_data",
                 reason="test",
             ),
-            False,
+            FixOutcome.DECLINED,
         ),
         # A docstring's own lines don't count against the size limit.
         (
@@ -165,7 +165,7 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
                 'def get_data():\n    """A short docstring\n    spanning two lines.\n    """\n'
                 '    f = open("f.txt")\n    return f.read()\n'
             ),
-            True,
+            FixOutcome.APPLIED,
         ),
     ],
     ids=[
@@ -185,10 +185,10 @@ def _with_suggestion(source: str | None, **suggestion_kwargs: object) -> Callabl
     ],
 )
 def test_should_autofix(
-    tmp_path: Path, make_case: Callable[[Path], tuple[Path, Suggestion]], *, expected: bool
+    tmp_path: Path, make_case: Callable[[Path], tuple[Path, Suggestion]], *, expected: FixOutcome
 ) -> None:
     filepath, suggestion = make_case(tmp_path)
-    assert (should_autofix(filepath, suggestion) is FixOutcome.APPLIED) is expected
+    assert should_autofix(filepath, suggestion) is expected
 
 
 def test_apply_fix_does_not_corrupt_unrelated_string_literal(tmp_path: Path) -> None:

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import pre_commit_hooks.ast_checks.validate_function_name as module
-from pre_commit_hooks.ast_checks._base import FixValidationError, is_fix_errored, is_fix_rejected
+from pre_commit_hooks.ast_checks._base import FixOutcome, FixValidationError
 from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck, autofix
 from tests._helpers import raises, restricted_permissions
 from tests.factories import ViolationFactory
@@ -69,12 +69,12 @@ def test_get_prefilter_pattern() -> None:
     assert ValidateFunctionNameCheck().get_prefilter_pattern() == ["def get_"]
 
 
-def test_fix_with_no_violations_returns_false(tmp_path: Path) -> None:
+def test_fix_with_no_violations_declines(tmp_path: Path) -> None:
     filepath = tmp_path / "mod.py"
     filepath.write_text("x = 1\n")
 
     check = ValidateFunctionNameCheck()
-    assert check.fix(filepath, [], "x = 1\n", ast.parse("x = 1\n")) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, [], "x = 1\n", ast.parse("x = 1\n")).outcomes
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ def test_fix_skips_violation_missing_suggestion(fix_data: dict[str, int] | None,
     violation = ViolationFactory.build(check_id="validate-function-name", error_code="TR4", fix_data=fix_data)
 
     check = ValidateFunctionNameCheck()
-    assert check.fix(filepath, [violation], "x = 1\n", ast.parse("x = 1\n")) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, [violation], "x = 1\n", ast.parse("x = 1\n")).outcomes
 
 
 def test_fix_applies_safe_suggestion(tmp_path: Path) -> None:
@@ -105,7 +105,7 @@ def test_fix_applies_safe_suggestion(tmp_path: Path) -> None:
     # Marking a violation "fixed" is the orchestrator's responsibility
     # (CheckOrchestrator._apply_fixes), not this check's own fix() — calling
     # fix() directly, as this test does, never sets it.
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
     assert violations[0].fix_data is not None
     assert "def is_data() -> bool:" in filepath.read_text()
 
@@ -131,7 +131,7 @@ def test_fix_applies_context_manager_rename(tmp_path: Path) -> None:
 
     assert len(violations) == 1
     assert violations[0].fixable is True
-    assert check.fix(filepath, violations, source, tree) is True
+    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
     assert "async def tempfile_session()" in filepath.read_text()
     assert "async with tempfile_session() as session:" in filepath.read_text()
 
@@ -156,7 +156,7 @@ def test_sync_lazy_accessor_property_suggestion_is_not_fixable(tmp_path: Path) -
     assert violations[0].message == (
         "Function 'get_connection' should use @property 'connection' (synchronous lazy accessor)"
     )
-    assert check.fix(filepath, violations, source, tree) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
     assert filepath.read_text() == source
 
 
@@ -171,7 +171,7 @@ def test_fix_skips_unsafe_suggestion(tmp_path: Path) -> None:
     violations = check.check(filepath, tree, source)
     assert len(violations) == 1
 
-    assert check.fix(filepath, violations, source, tree) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
     assert filepath.read_text() == source
 
 
@@ -267,7 +267,7 @@ def test_fix_refuses_a_rename_referenced_by_another_repository_file(tmp_path: Pa
 
     assert len(violations) == 1
     assert violations[0].fixable is False
-    assert check.fix(filepath, violations, source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, ast.parse(source)).outcomes
     assert filepath.read_text() == source
 
 
@@ -281,15 +281,15 @@ def test_fix_rechecks_repository_references_before_writing(tmp_path: Path) -> No
 
     _add_external_reference(filepath, git)
 
-    assert check.fix(filepath, violations, source, ast.parse(source)) is False
+    assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, ast.parse(source)).outcomes
     assert filepath.read_text() == source
 
 
-def test_fix_returns_false_when_apply_fix_fails_without_raising(
+def test_fix_returns_a_failure_outcome_when_apply_fix_fails_without_raising(
     tmp_path: Path,
 ) -> None:
     # apply_fix() can fail internally (e.g. a write error) and simply
-    # return False rather than raising; that must not be reported as
+    # return a declined outcome rather than raising; that must not be reported as
     # fixed. The write goes through atomic_write_text's
     # temp-file-then-rename, which only needs the parent directory to be
     # writable (not the target file itself, since rename() doesn't check
@@ -305,16 +305,16 @@ def test_fix_returns_false_when_apply_fix_fails_without_raising(
     assert len(violations) == 1
 
     with restricted_permissions(tmp_path, 0o555, restore=0o755):
-        assert check.fix(filepath, violations, source, tree) is False
+        assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
 
-    assert not (violations[0].fix_data and violations[0].fix_data.get("fixed"))
+    assert filepath.read_text() == source
 
 
 def test_fix_marks_violation_errored_and_continues_when_apply_fix_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     # A rename that raises something other than FixValidationError is a bug
-    # in apply_fix() itself. Must be marked distinctly (mark_fix_errored)
+    # in apply_fix() itself. It must be reported distinctly
     # so main() reports [FIX ERRORED] with a "this is a bug" hint rather
     # than the ordinary [FIXABLE]/"Run with --fix" — CheckOrchestrator's own
     # equivalent handling in _apply_fixes never even sees this, since it
@@ -331,14 +331,9 @@ def test_fix_marks_violation_errored_and_continues_when_apply_fix_raises(
     monkeypatch.setattr(module, "apply_fix", raises(RuntimeError, "simulated apply_fix failure"))
 
     with caplog.at_level("DEBUG"):
-        assert check.fix(filepath, violations, source, tree) is False
-    assert is_fix_errored(violations[0])
-    assert not is_fix_rejected(violations[0])
+        fix_result = check.fix(filepath, violations, source, tree)
+    assert fix_result.outcomes == (FixOutcome.ERRORED,)
     assert filepath.read_text() == source
-    # mark_fix_errored() above already reports this cleanly; a raw
-    # traceback on stderr by default would just be redundant noise (ch. 7:
-    # "MUST NOT emit uncontrolled human-oriented text into a
-    # machine-readable output stream").
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -357,13 +352,13 @@ def test_fix_marks_violation_rejected_when_apply_fix_raises_fix_validation_error
     violations = check.check(filepath, tree, source)
     assert len(violations) == 1
 
-    def raise_fix_validation_error(*_args: object, **_kws: object) -> bool:
+    def raise_fix_validation_error(*_args: object, **_kws: object) -> FixOutcome:
         raise FixValidationError(filepath, SyntaxError("simulated"))
 
     monkeypatch.setattr(module, "apply_fix", raise_fix_validation_error)
 
-    assert check.fix(filepath, violations, source, tree) is False
-    assert is_fix_rejected(violations[0])
+    fix_result = check.fix(filepath, violations, source, tree)
+    assert fix_result.outcomes == (FixOutcome.REJECTED,)
     assert filepath.read_text() == source
 
 
@@ -392,19 +387,18 @@ def test_fix_rejects_only_the_violation_whose_write_produces_invalid_syntax(
 
     original_apply_fix = module.apply_fix
 
-    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> bool:
+    def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             raise FixValidationError(fp, SyntaxError("simulated"))
         return original_apply_fix(fp, suggestion)
 
     monkeypatch.setattr(module, "apply_fix", flaky_apply_fix)
 
-    assert check.fix(filepath, violations, source, tree) is True
+    fix_result = check.fix(filepath, violations, source, tree)
+    assert FixOutcome.APPLIED in fix_result.outcomes
 
-    by_func_name = {v.fix_data["suggestion"].func_name: v for v in violations if v.fix_data}
     fixed_content = filepath.read_text()
 
     assert "def get_config" not in fixed_content
     assert 'def get_active(user: dict) -> bool:\n    return user.get("status") == "active"\n' in fixed_content
-    assert not is_fix_rejected(by_func_name["get_config"])
-    assert is_fix_rejected(by_func_name["get_active"])
+    assert fix_result.outcomes == (FixOutcome.APPLIED, FixOutcome.REJECTED)


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autofix results now distinguish applied, declined, rejected, interrupted, errored, failed, and indirectly resolved fixes.
  * Diagnostics provide clearer messages and safety guidance for declined fixes.
  * Fix outcomes are reported individually for each violation.

* **Documentation**
  * Added changelog details and clarified fix-outcome terminology.

* **Chores**
  * Updated the `ruff-extra-rules` pre-commit revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->