### PR TITLE
feat(ast-checks): report unused pytriage suppressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ This repo runs its own checks against itself, which creates three gotchas that d
 - **The `local-*-aggressive` hooks run live working-tree code, at `permissive` level, against `src/` and `tests/` on every commit.** They no longer pass `--fix` explicitly; it comes from `[tool.ruff-extra-rules] fix = true`. Widening any check's default detection can therefore fail your very next commit. It can also rewrite code you just wrote, mid-commit, but only through `local-ruff-extra-rules-aggressive` — `local-ruff-extra-rules-ty-aggressive` runs `redundant-type-conversion` alone, which reports violations and never fixes. Before widening a default, search `src/` and `tests/` for what it would newly catch and reconcile anything that has no auto-fix path.
 - **`ruff check`/`ruff format` above use the standalone binary, not the pinned `ruff-pre-commit` rev.** When the two drift, the standalone one can make edits the pinned one rejects — including stripping `# noqa` comments the pinned version still wants. Compare `ruff --version` against the `rev:` under `astral-sh/ruff-pre-commit` in `.pre-commit-config.yaml`; if they differ, use `prek run ruff-check --files <paths>` instead and tell the user about the drift.
 
+### Writing Commit Messages
+
+The commit body should communicate the "why," not just the "what." Include the rationale behind the changes, non-trivial decisions, and any other information that may be useful for future developers.
+
 ## Agent skills
 
 ### Issue tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ See [docs/adding-a-check.md](docs/adding-a-check.md) for the full walkthrough of
 - If a file is already bloated with prose that violates these rules, that is not an excuse to bypass them. Instead, signal that the code needs decluttering — retain any indispensable rationale as an ADR reference instead.
 - Immediately delete any pre-existing stale comments or prose that violates these rules.
 
+_Note that ignore comments that suppress false-positives (e.g., `# noqa`, `# type: ignore`, `# pragma`) are obviously out of scope of these guidelines._
+
 ## User-facing prose (README, program output)
 
 - **No internal implementation details.** Don't expose internal scoring/threshold numbers (e.g. "semantic value score ≤ 10", "score < 50") or other implementation-level mechanics in a README. A README is a short, high-level description for a regular user, not a spec for the internals — use a concrete illustrative example instead of a formula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Changed
 
 - `unused-pytriage` now retains cached suppression evidence through fix-mode refreshes and audits the final source with the complete active-check context.
-- Suppression tracking now covers TR5 markers on assignment lines, keeps TR6 normal and tracking analyses separate, and avoids repeated token and suggestion analysis when it is not needed.
+- Suppression tracking now covers TR5 markers on assignment lines, so TR8 reports reflect their actual use.
 - `--fix` reports whether each fix was applied, declined for safety, rejected, aborted, errored, or failed to write, so an operational failure is visible without being confused with a safety decision.
 - `meaningless-vars --fix` now renames enclosing references in class bodies and methods, assigns distinct names to related nested renames, and declines class scopes whose `global` or `nonlocal` declarations cannot be safely rewritten.
 - `meaningless-vars --fix` preserves type-alias peer type parameters referenced inside nested scopes while still renaming unrelated enclosing variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ### Changed
 
+- `unused-pytriage` now retains cached suppression evidence through fix-mode refreshes and audits the final source with the complete active-check context.
+- Suppression tracking now covers TR5 markers on assignment lines, keeps TR6 normal and tracking analyses separate, and avoids repeated token and suggestion analysis when it is not needed.
 - `--fix` reports whether each fix was applied, declined for safety, rejected, aborted, errored, or failed to write, so an operational failure is visible without being confused with a safety decision.
 - `meaningless-vars --fix` now renames enclosing references in class bodies and methods, assigns distinct names to related nested renames, and declines class scopes whose `global` or `nonlocal` declarations cannot be safely rewritten.
 - `meaningless-vars --fix` preserves type-alias peer type parameters referenced inside nested scopes while still renaming unrelated enclosing variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 - `meaningless-vars --fix` preserves type-alias peer type parameters referenced inside nested scopes while still renaming unrelated enclosing variables.
 - `meaningless-vars --fix` preserves peer type-parameter references inside nested generic bounds and signature annotations while still renaming unrelated enclosing variables.
 
+### Added
+
+- `unused-pytriage` (TR8) reports redundant known `# pytriage` suppression codes when explicitly selected; it is report-only and does not auto-fix comments.
+
 ## [0.1.0] - 2026-08-16
 
 ### Changed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: exclude — an excluded file is not checked by anything; a per-file ign
 A `# pytriage: TR1` comment, or a comma-separated list (`# pytriage: TR1,TR5`) to suppress more than one check's violation on the same line. Detected via `tokenize`, never text/regex matching, so a string or byte literal containing the same text can't be mistaken for one.
 _Avoid_: pragma — this repo's own suppression comment is distinct from the _third-party_ linter pragmas (`noqa`, `type: ignore`, `pylint:`, etc.) that `misplaced-comment` recognizes and refuses to ever move; don't conflate the two.
 
+**Suppression usage**:
+A record that a check found a candidate violation and an inline ignore comment suppressed it, retained separately from the violations that are reported or fixed. The `unused-pytriage` check uses these records to identify redundant known-code entries without rerunning each check's detection logic.
+_Avoid_: suppression — that is the comment's effect; suppression usage is the evidence that the effect occurred.
+
 **Format suppression**:
 `ruff format`'s own `# fmt: off`/`# fmt: on`, `# fmt: skip`, and YAPF's equivalent `# yapf: disable`/`# yapf: enable` pragmas, honored by every check with the same standing as an inline ignore comment: a line they cover is never reported and never fixed. Unlike an inline ignore comment, these are third-party pragmas this tool recognizes rather than owns, detected via the same shared `tokenize`-based helpers (`find_ignored_lines`, `ignored_lines_from_tokens`, `find_ignored_lines_and_classify_comments`), not a separate mechanism. See `docs/adr/0050-format-suppression-pragmas.md`.
 _Avoid_: fmt:off — spell it out; a bare "fmt:off" reads as the comment text itself rather than the general concept of every pragma this covers.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Individual checks are toggled with `--select`/`--ignore` (or the matching `pypro
 | [redundant-assignment](docs/rules/redundant-assignment.md)           | TR5  | Flags (and optionally inlines) variable assignments that add no clarity.                                                                                                          |
 | [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TR6  | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
 | [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
-| [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; opt in with `--select=unused-pytriage`.                                                             |
+| [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; select it alongside the checks being audited, e.g. `--select=meaningless-vars,unused-pytriage`.     |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Individual checks are toggled with `--select`/`--ignore` (or the matching `pypro
 | [redundant-assignment](docs/rules/redundant-assignment.md)           | TR5  | Flags (and optionally inlines) variable assignments that add no clarity.                                                                                                          |
 | [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TR6  | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
 | [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
+| [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; opt in with `--select=unused-pytriage`.                                                             |
 
 ## Installation
 

--- a/docs/adr/0057-explicit-suppression-usage-results.md
+++ b/docs/adr/0057-explicit-suppression-usage-results.md
@@ -1,0 +1,5 @@
+# Preserve suppression usage as explicit check-result metadata
+
+`unused-pytriage` needs to distinguish an inline comment that suppressed a real candidate from one that no longer does anything, but existing checks discard suppressed candidates before the orchestrator sees them. Checks therefore expose suppression-usage records as explicit per-file result metadata, which the orchestrator caches and passes to the opt-in audit; the design avoids hidden shared ledgers and shared token streams, preserves each check's own suppression semantics, and lets the audit recompute against the final source after fixes.
+
+The audit uses only checks that actually ran for the file, ignores unknown codes and format-suppressed comments, reports duplicate entries independently, and never lets `TR8` self-suppress an unused entry.

--- a/docs/rules/unused-pytriage.md
+++ b/docs/rules/unused-pytriage.md
@@ -1,0 +1,13 @@
+# unused-pytriage (TR8)
+
+Reports `# pytriage` codes that no longer suppress a matching violation from an active check.
+
+Enable it explicitly with `--select=unused-pytriage` or alongside the checks you want to audit:
+
+```python
+result = 42  # pytriage: TR1
+```
+
+If `meaningless-vars` is active and does not report this line, `unused-pytriage` reports the redundant `TR1` entry. Codes are evaluated independently, so a valid entry in a comma-separated list remains untouched. Unknown codes are retained because they may belong to another or future check.
+
+This check only reports; it never changes files, including when `--fix` is used.

--- a/docs/rules/unused-pytriage.md
+++ b/docs/rules/unused-pytriage.md
@@ -2,7 +2,7 @@
 
 Reports `# pytriage` codes that no longer suppress a matching violation from an active check.
 
-Enable it explicitly with `--select=unused-pytriage` or alongside the checks you want to audit:
+Select it alongside the checks you want to audit:
 
 ```python
 result = 42  # pytriage: TR1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ ignore = [
 "tests/performance/**" = ["S603"]
 "src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py" = ["S603"]
 "tests/validate_function_name/test_check.py" = ["S603"]
+"tests/test_orchestrator.py" = ["ANN401", "FBT002", "S102", "S603"]
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ignore = [
 "tests/performance/**" = ["S603"]
 "src/pre_commit_hooks/ast_checks/validate_function_name/autofix.py" = ["S603"]
 "tests/validate_function_name/test_check.py" = ["S603"]
-"tests/test_orchestrator.py" = ["ANN401", "FBT002", "S102", "S603"]
+"tests/test_orchestrator.py" = ["S102", "S603"]
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip"

--- a/src/pre_commit_hooks/ast_checks/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/__init__.py
@@ -35,6 +35,7 @@ from .misplaced_comment import MisplacedCommentCheck
 from .redundant_assignment import RedundantAssignmentCheck
 from .redundant_super_init import RedundantSuperInitCheck
 from .redundant_type_conversion import RedundantTypeConversionCheck
+from .unused_pytriage import UnusedPytriageCheck
 from .validate_function_name import ValidateFunctionNameCheck
 
 if TYPE_CHECKING:
@@ -52,4 +53,5 @@ ALL_CHECKS: list[type[ASTCheck]] = [
     RedundantAssignmentCheck,
     MisplacedCommentCheck,
     RedundantTypeConversionCheck,
+    UnusedPytriageCheck,
 ]

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -523,11 +523,13 @@ class _FormatSuppressionScanner:
         return set(range(self._suppressed_from, self._last_line + 1))
 
 
-def ignored_lines_and_pytriage_comments_from_tokens(
+def _scan_token_stream(
     tokens: Iterable[tokenize.TokenInfo], *patterns: re.Pattern[str]
-) -> tuple[set[int], set[int], tuple[PytriageComment, ...]]:
+) -> tuple[set[int], set[int], set[int], set[int], tuple[PytriageComment, ...]]:
     ignored: set[int] = set()
     format_suppressed: set[int] = set()
+    comment_lines: set[int] = set()
+    code_lines: set[int] = set()
     comments: list[PytriageComment] = []
     scanner = _FormatSuppressionScanner()
 
@@ -537,22 +539,38 @@ def ignored_lines_and_pytriage_comments_from_tokens(
             ignored |= newly_ignored
             format_suppressed |= newly_ignored
         if tok.type == tokenize.COMMENT:
+            comment_lines.add(tok.start[0])
             parsed = _parse_pytriage_comment(tok)
             if parsed is not None:
                 comments.append(parsed)
             if any(pattern.search(tok.string) for pattern in patterns):
                 ignored.add(tok.start[0])
+        elif tok.type not in _NON_CODE_TOKEN_TYPES:
+            code_lines.update(range(tok.start[0], tok.end[0] + 1))
 
     finalized = scanner.finalize()
     ignored |= finalized
     format_suppressed |= finalized
-    return ignored, format_suppressed, tuple(comments)
+    return ignored, comment_lines - code_lines, comment_lines & code_lines, format_suppressed, tuple(comments)
+
+
+def ignored_lines_and_pytriage_comments_from_tokens(
+    tokens: Iterable[tokenize.TokenInfo], *patterns: re.Pattern[str]
+) -> tuple[set[int], set[int], tuple[PytriageComment, ...]]:
+    ignored, _comment_only, _trailing, format_suppressed, comments = _scan_token_stream(tokens, *patterns)
+    return ignored, format_suppressed, comments
 
 
 def find_ignored_lines_and_pytriage_comments(
     source: str, *patterns: re.Pattern[str]
 ) -> tuple[set[int], set[int], tuple[PytriageComment, ...]]:
     return ignored_lines_and_pytriage_comments_from_tokens(tokenize_source(source), *patterns)
+
+
+def find_ignored_lines_and_classify_comments_and_pytriage(
+    source: str, *patterns: re.Pattern[str]
+) -> tuple[set[int], set[int], set[int], set[int], tuple[PytriageComment, ...]]:
+    return _scan_token_stream(tokenize_source(source), *patterns)
 
 
 def find_suppression_usage(
@@ -681,35 +699,7 @@ def classify_comment_lines(source: str) -> tuple[set[int], set[int]]:
 def find_ignored_lines_and_classify_comments(
     source: str, *patterns: re.Pattern[str]
 ) -> tuple[set[int], set[int], set[int]]:
-    """Tokenize `source` exactly once, returning (ignored_lines,
-    comment_only_lines, trailing_comment_lines) — the same results
-    `find_ignored_lines`/`classify_comment_lines` would each compute from
-    their own separate tokenize pass, fused into one. `ignored_lines` also
-    includes every line suppressed by a ruff/Black-style format-suppression
-    pragma, same as `ignored_lines_from_tokens` — see that function's own
-    docstring and `docs/adr/0050-format-suppression-pragmas.md`.
-
-    `RedundantAssignmentCheck.check()` needs both, and streams this single
-    combined pass over `tokenize_source`'s lazy `Iterator` (rather than
-    materializing the whole token stream once and feeding it to each
-    helper) so a large file's token count never inflates peak memory — only
-    the resulting line-number sets are retained, one token at a time.
-    """
-    ignored_lines: set[int] = set()
-    comment_lines: set[int] = set()
-    code_lines: set[int] = set()
-    scanner = _FormatSuppressionScanner()
-
-    for tok in tokenize_source(source):
-        newly_ignored = scanner.observe(tok)
-        if newly_ignored:
-            ignored_lines |= newly_ignored
-        if tok.type == tokenize.COMMENT:
-            comment_lines.add(tok.start[0])
-            if any(p.search(tok.string) for p in patterns):
-                ignored_lines.add(tok.start[0])
-        elif tok.type not in _NON_CODE_TOKEN_TYPES:
-            code_lines.update(range(tok.start[0], tok.end[0] + 1))
-
-    ignored_lines |= scanner.finalize()
-    return ignored_lines, comment_lines - code_lines, comment_lines & code_lines
+    ignored, comment_only, trailing, _format_suppressed, _comments = _scan_token_stream(
+        tokenize_source(source), *patterns
+    )
+    return ignored, comment_only, trailing

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -101,6 +101,9 @@ class ASTCheck(Protocol):
         ...
 
     @property
+    def default_enabled(self) -> bool: ...
+
+    @property
     def cacheable(self) -> bool:
         """Whether `CheckOrchestrator` may store/reuse this check's own
         violations in the shared per-file cache. `True` for almost every
@@ -143,6 +146,8 @@ class ASTCheck(Protocol):
         ...
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]: ...
+
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]: ...
 
     def fix(
         self,
@@ -565,6 +570,24 @@ def find_suppression_usage(
     return None
 
 
+def record_suppression_usage_if_ignored(
+    suppression_usages: list[SuppressionUsage],
+    ignored_lines: set[int],
+    comments: Iterable[PytriageComment],
+    format_suppressed: set[int],
+    *,
+    check_id: str,
+    error_code: str,
+    candidate_lines: Collection[int],
+) -> bool:
+    if not any(line in ignored_lines for line in candidate_lines):
+        return False
+    usage = find_suppression_usage(comments, format_suppressed, check_id, error_code, candidate_lines)
+    if usage is not None:
+        suppression_usages.append(usage)
+    return True
+
+
 def tokenize_source(source: str) -> Iterator[tokenize.TokenInfo]:
     """Tokenize `source`, normalizing line endings first (see
     `normalize_for_tokenize`) — the one `tokenize`-invocation boilerplate
@@ -588,15 +611,7 @@ def ignored_lines_from_tokens(tokens: Iterable[tokenize.TokenInfo], *patterns: r
     `misplaced_comment`, which would otherwise tokenize the same source a
     second time just to check for suppression comments).
     """
-    ignored: set[int] = set()
-    scanner = _FormatSuppressionScanner()
-    for tok in tokens:
-        newly_ignored = scanner.observe(tok)
-        if newly_ignored:
-            ignored |= newly_ignored
-        if tok.type == tokenize.COMMENT and any(p.search(tok.string) for p in patterns):
-            ignored.add(tok.start[0])
-    ignored |= scanner.finalize()
+    ignored, _format_suppressed, _comments = ignored_lines_and_pytriage_comments_from_tokens(tokens, *patterns)
     return ignored
 
 

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -582,7 +582,10 @@ def record_suppression_usage_if_ignored(
 ) -> bool:
     if not any(line in ignored_lines for line in candidate_lines):
         return False
-    usage = find_suppression_usage(comments, format_suppressed, check_id, error_code, candidate_lines)
+    non_format_candidate_lines = tuple(line for line in candidate_lines if line not in format_suppressed)
+    if len(non_format_candidate_lines) != len(candidate_lines):
+        return True
+    usage = find_suppression_usage(comments, format_suppressed, check_id, error_code, non_format_candidate_lines)
     if usage is not None:
         suppression_usages.append(usage)
     return True

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -74,7 +74,7 @@ class CheckResult(list[Violation]):
         suppression_usages: Iterable[SuppressionUsage] = (),
     ) -> None:
         super().__init__(violations)
-        self.suppression_usages = tuple(suppression_usages)  # pytriage: TR6 -- retain immutable result metadata
+        self.suppression_usages = tuple(suppression_usages)  # pytriage: TR6
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -572,10 +572,10 @@ def find_suppression_usage(
 
 def record_suppression_usage_if_ignored(
     suppression_usages: list[SuppressionUsage],
-    ignored_lines: set[int],
     comments: Iterable[PytriageComment],
-    format_suppressed: set[int],
     *,
+    ignored_lines: set[int],
+    format_suppressed: set[int],
     check_id: str,
     error_code: str,
     candidate_lines: Collection[int],

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -147,7 +147,7 @@ class ASTCheck(Protocol):
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]: ...
 
-    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]: ...
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult: ...
 
     def fix(
         self,
@@ -196,8 +196,9 @@ class BaseCheck:
     def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> list[Violation]:
         raise NotImplementedError
 
-    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
-        return self.check(filepath, tree, source)
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        check_result = self.check(filepath, tree, source)
+        return check_result if isinstance(check_result, CheckResult) else CheckResult(check_result)
 
 
 class CheckUnavailableError(Exception):

--- a/src/pre_commit_hooks/ast_checks/_base.py
+++ b/src/pre_commit_hooks/ast_checks/_base.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Collection, Iterable, Iterator
 
     from ._options import CheckOption
 
@@ -56,6 +56,32 @@ class Violation:
     fixable: bool
     fix_data: dict[str, Any] | None = None
     fix_outcome: FixOutcome | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SuppressionUsage:
+    check_id: str
+    error_code: str
+    line: int
+
+
+class CheckResult(list[Violation]):
+    __slots__ = ("suppression_usages",)
+
+    def __init__(
+        self,
+        violations: Iterable[Violation] = (),
+        suppression_usages: Iterable[SuppressionUsage] = (),
+    ) -> None:
+        super().__init__(violations)
+        self.suppression_usages = tuple(suppression_usages)  # pytriage: TR6 -- retain immutable result metadata
+
+
+@dataclass(frozen=True, slots=True)
+class PytriageComment:
+    line: int
+    col: int
+    codes: tuple[str, ...]
 
 
 class ASTCheck(Protocol):
@@ -149,6 +175,10 @@ class BaseCheck:
         return True
 
     @property
+    def default_enabled(self) -> bool:
+        return True
+
+    @property
     def tracks_direct_inputs(self) -> bool:
         return False
 
@@ -157,6 +187,12 @@ class BaseCheck:
 
     def reconcile_direct_inputs(self, _direct_inputs: list[Path]) -> list[Path]:
         return []
+
+    def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> list[Violation]:
+        raise NotImplementedError
+
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+        return self.check(filepath, tree, source)
 
 
 class CheckUnavailableError(Exception):
@@ -382,6 +418,23 @@ def ignore_pattern_for(error_code: str) -> re.Pattern[str]:
     return re.compile(rf"#\s*pytriage:\s*(?:[^,\s]+\s*,\s*)*{escaped}(?!\w)", re.IGNORECASE)
 
 
+_PYTRIAGE_COMMENT_PATTERN = re.compile(r"#\s*pytriage\s*:\s*(.*)", re.IGNORECASE)
+
+
+def _parse_pytriage_comment(tok: tokenize.TokenInfo) -> PytriageComment | None:
+    match = _PYTRIAGE_COMMENT_PATTERN.search(tok.string)
+    if match is None:
+        return None
+    codes = tuple(
+        code.upper()
+        for segment in match.group(1).split(",")
+        if (code := segment.strip().split(maxsplit=1)[0] if segment.strip() else "")
+    )
+    if not codes:
+        return None
+    return PytriageComment(line=tok.start[0], col=tok.start[1], codes=codes)
+
+
 _FMT_OFF_PATTERN = re.compile(r"#\s*fmt:\s*off")
 _FMT_ON_PATTERN = re.compile(r"#\s*fmt:\s*on")
 _YAPF_DISABLE_PATTERN = re.compile(r"#\s*yapf:\s*disable")
@@ -462,6 +515,54 @@ class _FormatSuppressionScanner:
         if self._suppressed_from is None:
             return set()
         return set(range(self._suppressed_from, self._last_line + 1))
+
+
+def ignored_lines_and_pytriage_comments_from_tokens(
+    tokens: Iterable[tokenize.TokenInfo], *patterns: re.Pattern[str]
+) -> tuple[set[int], set[int], tuple[PytriageComment, ...]]:
+    ignored: set[int] = set()
+    format_suppressed: set[int] = set()
+    comments: list[PytriageComment] = []
+    scanner = _FormatSuppressionScanner()
+
+    for tok in tokens:
+        newly_ignored = scanner.observe(tok)
+        if newly_ignored:
+            ignored |= newly_ignored
+            format_suppressed |= newly_ignored
+        if tok.type == tokenize.COMMENT:
+            parsed = _parse_pytriage_comment(tok)
+            if parsed is not None:
+                comments.append(parsed)
+            if any(pattern.search(tok.string) for pattern in patterns):
+                ignored.add(tok.start[0])
+
+    finalized = scanner.finalize()
+    ignored |= finalized
+    format_suppressed |= finalized
+    return ignored, format_suppressed, tuple(comments)
+
+
+def find_ignored_lines_and_pytriage_comments(
+    source: str, *patterns: re.Pattern[str]
+) -> tuple[set[int], set[int], tuple[PytriageComment, ...]]:
+    return ignored_lines_and_pytriage_comments_from_tokens(tokenize_source(source), *patterns)
+
+
+def find_suppression_usage(
+    comments: Iterable[PytriageComment],
+    format_suppressed: set[int],
+    check_id: str,
+    error_code: str,
+    candidate_lines: Collection[int],
+) -> SuppressionUsage | None:
+    normalized_code = error_code.upper()
+    for comment in comments:
+        if comment.line in format_suppressed:
+            continue
+        if comment.line in candidate_lines and normalized_code in comment.codes:
+            return SuppressionUsage(check_id=check_id, error_code=normalized_code, line=comment.line)
+    return None
 
 
 def tokenize_source(source: str) -> Iterator[tokenize.TokenInfo]:

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -1,7 +1,3 @@
-"""The linting application itself: running the enabled checks over a set of
-files, caching their results, and applying fixes.
-"""
-
 from __future__ import annotations
 
 import ast
@@ -40,14 +36,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("ast_checks")
 
-# src/pre_commit_hooks/ — the tree CacheManager.compute_tree_hash() hashes to
-# invalidate every cached result whenever any check's own code, or shared
-# code it depends on, changes.
+
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 
-# Matches a pre-fix Violation against a fresh check() re-run's own new
-# Violation objects, which can never share object identity with it.
-type ViolationKey = tuple[int, int, str]  # (line, col, message)
+
+type ViolationKey = tuple[int, int, str]
 
 
 def _as_check_result(result: list[Violation]) -> CheckResult:
@@ -88,12 +81,7 @@ def _has_terminal_fix_state(violation: Violation) -> bool:
 def _replace_check_violations(
     all_violations: dict[str, list[Violation]], key: str, check_id: str, new_violations: list[Violation]
 ) -> None:
-    """Replaces whatever `check_id` previously reported for `key` in `all_violations` with
-    `new_violations`, preserving any other check's own violations for that same file (ADR-0041: a
-    drained candidate is re-checked with only the one check that flagged it, never every check, so a
-    stale result must be replaced rather than appended to -- otherwise an unchanged violation would be
-    reported twice, and one that's now clean would still show its own, no-longer-true earlier report).
-    """
+
     kept = [violation for violation in all_violations.get(key, []) if violation.check_id != check_id]
     combined = kept + new_violations
     if combined:
@@ -121,7 +109,7 @@ def _unmatched_by_message(dropped: list[Violation], replacements: list[Violation
 
 
 def _record_indirect_resolutions(violations: list[Violation], initial_violations: dict[str, list[Violation]]) -> None:
-    """See `docs/adr/0053-indirect-resolution-outcome.md`."""
+
     final_by_check = _group_by_check_id(violations)
     surviving = {id(violation) for violation in violations}
     for check_id, initial in initial_violations.items():
@@ -144,34 +132,14 @@ def _set_fix_outcomes(violations: list[Violation], fix_result: FixResult) -> Non
 
 
 def _fingerprint_default(value: object) -> object:
-    """`json.dumps(..., default=...)` handler for the value shapes a check's
-    own instance state (see `_instance_state`) can contain but that `json`
-    can't natively serialize: a `set`'s iteration order depends on
-    PYTHONHASHSEED (randomized per process by default), so it's sorted
-    first rather than dumped as-is — otherwise the same config would
-    fingerprint differently across process runs, making the cache key (and
-    so the cache itself) useless. Anything else falls back to repr() rather
-    than raising, since instance state can pick up values this generic and
-    unopinionated (e.g. a test's monkeypatched instance attribute) that
-    were never meant to be "config" in the first place — the fingerprint
-    just needs to not crash construction, not be meaningful for every
-    possible value a check instance could ever hold.
-    """
+
     if isinstance(value, (set, frozenset)):
         return sorted(value)
     return repr(value)
 
 
 def _instance_state(check: ASTCheck) -> dict[str, object]:
-    """Every attribute making up `check`'s own instance state — effectively
-    its constructor arguments, so two instances of the same check with
-    different configuration wouldn't share a cache entry. Checks with no
-    `__init__` override (most of them) have no instance state at all, so
-    this deliberately walks both `__slots__` (across the whole MRO, since a
-    subclass's own `__slots__` doesn't include an ancestor's) and any
-    `__dict__` a check might still have, rather than something every check
-    must opt into.
-    """
+
     state: dict[str, object] = {}
     for cls in type(check).__mro__:
         for slot in cls.__dict__.get("__slots__", ()):
@@ -183,37 +151,18 @@ def _instance_state(check: ASTCheck) -> dict[str, object]:
 
 
 def _fingerprint_check(check: ASTCheck) -> str:
-    """Stable fingerprint of a check instance's own state (see
-    `_instance_state`).
-    """
+
     return json.dumps(_instance_state(check), default=_fingerprint_default, sort_keys=True)
 
 
 @dataclass(frozen=True, slots=True)
 class _FileChecks:
-    """One file's share of a run: the checks to run against it, the checks
-    `per-file-ignores` switched off for it that must still be handed its
-    content (see `ASTCheck.tracks_direct_inputs`), and the cache identity of
-    what running that set produces. See
-    `docs/adr/0049-per-file-ignores.md`.
-    """
-
     run: tuple[ASTCheck, ...]
     record_only: tuple[ASTCheck, ...]
     hook_name: str
 
 
 class CheckOrchestrator:
-    """Orchestrates running multiple AST checks on Python files.
-
-    This class manages the workflow of:
-    1. Pre-filtering files per-check, against each check's own pattern
-    2. Caching check results
-    3. Parsing files once and running each file's applicable checks
-    4. Applying fixes when requested
-    5. Reporting violations
-    """
-
     __slots__ = (
         "_cacheable_check_ids",
         "_cacheable_fingerprints",
@@ -252,50 +201,19 @@ class CheckOrchestrator:
             hook_name=self._hook_name_for(self._cacheable_check_ids),
             cache_version=self._generate_cache_version(),
         )
-        # Populated by process_files() with every candidate file _check_file()
-        # returned None for (couldn't be read/decoded or failed to parse) —
-        # reset at the start of each call, so main() can report them instead
-        # of letting them vanish silently from all_violations with no trace.
+
         self.unprocessable_files: list[str] = []
-        # (filepath, check_id) pairs where a check's own check() or fix()
-        # raised unexpectedly (in _check_file or _apply_fixes respectively)
-        # — reset at the start of each process_files() call, same as
-        # unprocessable_files. Without this, a check that crashes on every
-        # file it sees would make the whole run look clean (zero
-        # violations, exit code 0) whenever no other check reports
-        # anything for the same files; and a fix() that raises after
-        # already resolving every violation it was given would otherwise
-        # leave no trace at all once every one of them gets marked fixed.
+
         self.rule_failures: list[tuple[str, str]] = []
-        # (check_id, message) pairs, one per check_id, where a check raised
-        # CheckUnavailableError -- see that exception's own docstring for
-        # why this is recorded once here instead of aborting the whole run.
-        # Reset at the start of each process_files() call, same as the two
-        # above.
+
         self.unavailable_checks: list[tuple[str, str]] = []
-        # check_ids already recorded in unavailable_checks this run -- once
-        # a check_id lands here, _check_file skips calling that check
-        # entirely, rather than paying its own failure cost again (and
-        # recording a duplicate entry) on every remaining file.
+
         self._unavailable_check_ids: set[str] = set()
-        # Set by _apply_fixes() for the file it was just called on -- read
-        # back by _process_single_file() right after its own full-checks
-        # _check_file() call returns, to decide whether that file's result
-        # is safe to cache (see _apply_fixes' own docstring for why a
-        # changed file's cacheable results aren't).
+
         self._fix_changed_file = False
 
     def process_files(self, filepaths: list[str]) -> dict[str, list[Violation]]:
-        """A file that couldn't be read or parsed has no entry in the
-        returned dict (indistinguishable from "processed, zero
-        violations") — check `self.unprocessable_files` for those. A file
-        where one check crashed while others ran fine can still have an
-        entry here (the other checks' violations), but its results are
-        incomplete — check `self.rule_failures` for those. A check that
-        raised `CheckUnavailableError` contributes no violations for the
-        rest of this run, for any file — check `self.unavailable_checks`
-        for those; every other check's results are unaffected.
-        """
+
         self.unprocessable_files = []
         self.rule_failures = []
         self.unavailable_checks = []
@@ -309,12 +227,8 @@ class CheckOrchestrator:
         if not checks_by_file:
             return {}
 
-        # self.cache's own cache_version and hook_name (set at construction
-        # from _generate_cache_version()/_generate_hook_name()) already gate
-        # staleness and config identity — no separate per-file cache_key
-        # needed here.
         all_violations: dict[str, list[Violation]] = {}
-        # Lets a reconciled file that is also a direct input retain the caller's original key.
+
         resolved_to_key: dict[Path, str] = {}
         for filepath_str in checks_by_file:
             try:
@@ -327,8 +241,6 @@ class CheckOrchestrator:
             violations = self._process_single_file(filepath, file_checks)
 
             if violations is None:
-                # Unreadable, undecodable, or unparseable — _check_file
-                # already logged the specific cause.
                 self.unprocessable_files.append(filepath_str)
             elif violations:
                 all_violations[filepath_str] = violations
@@ -378,28 +290,10 @@ class CheckOrchestrator:
                     _replace_check_violations(all_violations, extra_file_str, check.check_id, violations)
 
     def _process_single_file(self, filepath: Path, file_checks: _FileChecks) -> list[Violation] | None:
-        """Runs `file_checks.run` against a single file, honoring each
-        check's own `cacheable` flag: a cacheable check's violations may
-        come from (and be written to) the shared per-file cache; a
-        non-cacheable check (see `ASTCheck.cacheable`) is always re-run
-        fresh, on every call, regardless of what the cache holds for this
-        file.
 
-        `file_checks.record_only` rides along with whichever pass below
-        already reads the file, since a check switched off for it by
-        `per-file-ignores` still has to be handed its content (ADR-0049).
-        Only a clean cache hit with nothing to re-run pays for its own read,
-        being the one path that would otherwise never open the file.
-
-        Returns `None` if the file couldn't be read/parsed (mirrors
-        `_check_file`'s own contract).
-        """
         record_only = file_checks.record_only
         checks = file_checks.run
         if not checks:
-            # Nothing left to run, but reading and parsing the file is what
-            # turns an unreadable or unparseable input into a report rather
-            # than a silent skip (ch. 13).
             return self._check_file(filepath, (), record_only=record_only)
 
         hook_name = file_checks.hook_name
@@ -410,26 +304,12 @@ class CheckOrchestrator:
         if cacheable_checks:
             cached_violations = self._get_cached_violations(filepath, hook_name)
 
-        # A cache hit is only trustworthy in fix mode when it reports zero
-        # violations: fix_data is never cached (see _cache_violations), so
-        # a hit that shows a violation can't be used to actually fix it --
-        # that case falls through to the full recompute-and-fix path below,
-        # same as a genuine cache miss. See ADR-0044.
         if cached_violations is not None and (not self.fix_mode or not cached_violations):
             if not always_rerun_checks:
-                # The one path that returns without opening the file, so a
-                # check owed its content gets a pass of its own here.
                 if record_only and not self._record_direct_inputs(filepath, record_only):
                     return None
                 return cached_violations
-            # The cacheable group's cache entry is still valid, but a
-            # non-cacheable check must run fresh against this file's
-            # current, real content every single call — its own result is
-            # never read from or written to the cache. In fix mode, this
-            # already fixes any violation it finds: _check_file_locked
-            # calls _apply_fixes with exactly the violations this call
-            # produced, so it never touches the (already-clean) cacheable
-            # group.
+
             self._fix_changed_file = False
             rule_failures_before = len(self.rule_failures)
             fresh = self._check_file(
@@ -445,17 +325,7 @@ class CheckOrchestrator:
                 return None
             if not self._fix_changed_file:
                 return _merge_check_results(cached_violations, fresh)
-            # The always-rerun group's own fix changed the file, so the
-            # cached "clean" cacheable-group result is no longer known to
-            # be accurate for the file's new content. Re-verify (and fix,
-            # if needed) just the cacheable group fresh against that new
-            # content, merging in `fresh` as-is rather than re-running the
-            # already-fixed always-rerun group a second time: a second
-            # check() there would find it clean and silently lose its own
-            # [FIXED] outcome, since the violation is already gone.
-            # cacheable_checks is guaranteed non-empty here: cached_violations
-            # is only ever not None when it was, since that's the only branch
-            # that sets it.
+
             rerun_checks = [*cacheable_checks, *(check for check in checks if isinstance(check, UnusedPytriageCheck))]
             audit_check_ids = {check.check_id for check in rerun_checks if isinstance(check, UnusedPytriageCheck)}
             fresh_regular_result = CheckResult(
@@ -495,17 +365,7 @@ class CheckOrchestrator:
         prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
         prior_active_error_codes: frozenset[str] = frozenset(),
     ) -> list[Violation] | None:
-        """Runs `checks` fresh against `filepath` (fixing, in fix mode),
-        then caches whatever cacheable subset of `checks` is complete and
-        accurate this run. `extra_violations`, if given, is merged into the
-        return value without being cached itself — e.g. an always-rerun
-        group's own already-resolved result from an earlier pass this same
-        `_process_single_file()` call, which must still be reported even
-        though it's never eligible for caching either way (ADR-0034).
 
-        Returns `None` if the file couldn't be read/parsed (mirrors
-        `_check_file`'s own contract).
-        """
         rule_failures_before = len(self.rule_failures)
         self._fix_changed_file = False
         if prior_suppression_usages or prior_active_error_codes:
@@ -524,27 +384,11 @@ class CheckOrchestrator:
             return None
 
         cacheable_ids = {check.check_id for check in checks if check.cacheable}
-        # incomplete_ids covers a cacheable check that crashed this file
-        # (new_failure_ids), one that's globally unavailable this run
-        # (_unavailable_check_ids, e.g. a missing prerequisite), and — in
-        # fix mode — one that hit a rejected/errored/aborted fix outcome
-        # this run (terminal_negative_ids). All three mean this check's own
-        # results for this file are missing or unverified: caching the rest
-        # of the group as if it were complete would let a future cache hit
-        # keep serving that gap, or serve stale positions _refresh_stale_
-        # positions() deliberately left unrefreshed for the same check_id
-        # (see its own docstring), until the file or cache version changes.
+
         terminal_negative_ids = {v.check_id for v in violations if _has_terminal_fix_state(v)}
         incomplete_ids = new_failure_ids | self._unavailable_check_ids | terminal_negative_ids
-        # self._fix_changed_file (set by _apply_fixes, see its own
-        # docstring): a check with zero violations here is never
-        # re-verified against the file's final content once some other
-        # check's fix actually changed it, so nothing in this group can be
-        # cached as complete and accurate this run — it converges to a
-        # cache hit on its own next (unchanged) run instead.
+
         if cacheable_ids and not (incomplete_ids & cacheable_ids) and not self._fix_changed_file:
-            # A violation marked fixed no longer exists in the file's
-            # current content, so it must never be cached as still present.
             cacheable_violations = [
                 v for v in violations if v.check_id in cacheable_ids and v.fix_outcome is not FixOutcome.APPLIED
             ]
@@ -556,33 +400,7 @@ class CheckOrchestrator:
         return _merge_check_results(violations, extra_result) if extra_result else violations
 
     def _checks_by_file(self, filepaths: list[str]) -> dict[str, _FileChecks]:
-        """Applies each check's own prefilter pattern independently, rather
-        than combining every enabled check's pattern into one OR'd filter --
-        the combined filter dropped a file for every check whenever it
-        matched none of them, even a check whose own get_prefilter_pattern()
-        returns None specifically to see every file. Preserves `self.checks`
-        order per file, since `_apply_fixes` depends on it.
 
-        A check's prefilter is never asked about a file `per-file-ignores`
-        switched it off for -- the answer could not change what runs, and
-        the scan is the expensive half of deciding it. A check tracking
-        direct inputs is the exception, since it still has to be handed
-        those files (ADR-0049).
-
-        The cache identity is decided from the `per-file-ignores` outcome
-        alone, never from the prefilter: a prefiltered-out check genuinely
-        has nothing to report for that file, so its absence is already part
-        of what a cache entry means (ADR-0049).
-
-        A file matched by no enabled check's prefilter and not named by
-        `per-file-ignores` either gets no entry at all, so it is never read
-        or parsed and a syntax error in it is never reported -- an accepted
-        scope boundary, not an oversight (ADR-0052).
-        """
-        # Intersected with this run's own checks: one table serves both
-        # published hooks (ADR-0045), so an entry naming only the other one's
-        # check has switched nothing off here and must not change what this
-        # run reads or reports.
         ignored_by_file = {
             filepath_str: self._per_file_ignores.ignored_check_ids(filepath_str) & self._check_ids
             for filepath_str in filepaths
@@ -611,11 +429,7 @@ class CheckOrchestrator:
             record_only = tuple(
                 check for check in applicable if check.check_id in ignored and check.tracks_direct_inputs
             )
-            # A file `per-file-ignores` emptied out is still an input the
-            # user named, and dropping it here is what would make an
-            # unreadable one vanish without a word (ch. 13). A file with
-            # neither -- no enabled check's prefilter matched it, nothing
-            # ignored it -- is dropped on purpose (ADR-0052).
+
             if applicable or ignored:
                 checks_by_file[filepath_str] = _FileChecks(
                     run=run,
@@ -626,13 +440,7 @@ class CheckOrchestrator:
         return checks_by_file
 
     def _hook_name_for(self, check_ids: frozenset[str]) -> str:
-        """Identity of *what produced* a cached result: a short hash of
-        `check_ids` (a subset of the enabled cacheable checks, since
-        `per-file-ignores` can switch some of them off for one file) and
-        their own config. See ADR-0044 and ADR-0005 for why this is split
-        from `_generate_cache_version()`, and ADR-0049 for why it is decided
-        per file.
-        """
+
         hook_name = self._hook_names.get(check_ids)
         if hook_name is None:
             fingerprints = sorted(self._cacheable_fingerprints[check_id] for check_id in check_ids)
@@ -641,20 +449,13 @@ class CheckOrchestrator:
         return hook_name
 
     def _generate_cache_version(self) -> str:
-        """Whether a cached result can be trusted *at all*: this package's
-        own source-tree hash, and the running interpreter's major.minor
-        (`ast.parse()`'s output isn't guaranteed identical across Python
-        minor versions). See ADR-0044 and ADR-0005.
-        """
+
         tree_hash = CacheManager.compute_tree_hash(_PACKAGE_ROOT)
         python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         return f"{tree_hash}|{python_version}"
 
     def _get_cached_violations(self, filepath: Path, hook_name: str) -> CheckResult | None:
         try:
-            # self.cache's own cache_version already rejects a stale entry,
-            # and `hook_name` a mismatched-config one, before this ever sees
-            # it.
             cached = self.cache.get_cached_result(filepath, hook_name)
             if cached is None:
                 return None
@@ -697,7 +498,6 @@ class CheckOrchestrator:
                     "col": v.col,
                     "message": v.message,
                     "fixable": v.fixable,
-                    # Note: fix_data is NOT cached as it may contain AST nodes
                 }
                 for v in check_result
             ]
@@ -720,19 +520,7 @@ class CheckOrchestrator:
             logger.warning("Cache serialization failed: %s", repr(error))
 
     def _read_source(self, filepath: Path) -> tuple[str, str] | None:
-        """Thin error-handling wrapper around read_source_with_encoding: logs
-        and returns None on any failure instead of raising, since every
-        caller here treats "file couldn't be processed" the same way.
 
-        Debug-only logging: every caller already turns a None return into
-        its own clean, user-facing diagnostic (_check_file's own caller
-        reports it via unprocessable_files; _apply_fixes's own caller
-        reports it via rule_failures) — an ERROR-level .exception() call
-        here would just leak a redundant raw traceback onto the user's
-        stderr by default (nothing in this codebase configures logging, so
-        Python's own lastResort handler prints WARNING+ straight to
-        stderr).
-        """
         try:
             return read_source_with_encoding(filepath)
         except OSError:
@@ -815,12 +603,7 @@ class CheckOrchestrator:
             return None
 
     def _parsed_source(self, filepath: Path) -> tuple[str, ast.Module] | None:
-        """`None` if the file couldn't be read, decoded, or parsed — every
-        caller here turns that into the same "unprocessable file" outcome.
 
-        Debug-only logging: see `_read_source`'s own docstring for why an
-        ERROR-level `.exception()` call here would just be redundant noise.
-        """
         read_result = self._read_source(filepath)
         if read_result is None:
             return None
@@ -852,10 +635,6 @@ class CheckOrchestrator:
         audit_checks = [check for check in checks if isinstance(check, UnusedPytriageCheck)]
         for check in regular_checks:
             if check.check_id in self._unavailable_check_ids:
-                # Already recorded in unavailable_checks for an earlier
-                # file this run -- a missing/misbehaving prerequisite
-                # doesn't get better on the next file, so this check is
-                # never worth retrying (or re-recording) again this run.
                 continue
             try:
                 if audit_checks:
@@ -863,16 +642,9 @@ class CheckOrchestrator:
                 else:
                     violations = check.check(filepath, tree, source)
             except CheckUnavailableError as error:
-                # Recorded once here rather than per file: see
-                # CheckUnavailableError's own docstring for why this must
-                # not abort every other check's results for the rest of
-                # this run.
                 logger.debug("Check %s is unavailable: %s", check.check_id, error, exc_info=True)
                 self._record_unavailable_check(check, error)
             except Exception:
-                # Debug-only: reported cleanly via rule_failures below — see
-                # _read_source's own docstring for why ERROR-level
-                # .exception() logging here would just be redundant noise.
                 logger.debug("Check %s failed on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
             else:
@@ -963,10 +735,7 @@ class CheckOrchestrator:
         violations_result.suppression_usages = tuple(usages)
 
     def _record_direct_inputs(self, filepath: Path, checks: Sequence[ASTCheck]) -> bool:
-        """Reads and parses `filepath` for its own sake, for the one caller
-        with nothing else to read it. `False` if it couldn't be, which is that
-        caller's cue to report the file unprocessable.
-        """
+
         parsed = self._parsed_source(filepath)
         if parsed is None:
             return False
@@ -992,58 +761,20 @@ class CheckOrchestrator:
         filepath: Path,
         violations: list[Violation],
     ) -> None:
-        """`violations` holds all violations found in the file so far this
-        run, and is mutated in place: each fixable check's own stale entries
-        (collected once, before any fix ran) are replaced with a freshly
-        recomputed list, each marked fixed/rejected/errored/left alone
-        against the file's actual post-fix state. The pre-fix entries are
-        kept aside for `_record_indirect_resolutions`. Matching a stale entry
-        back to "is this the same violation, now fixed" by identity isn't
-        reliable — an earlier check's own fix can shift line/col numbers,
-        and two distinct violations can share an identical message (e.g. a
-        same-named free function and method both suggesting the same
-        rename) — so the stale entries for this check_id are discarded
-        outright rather than matched.
 
-        Sets `self._fix_changed_file` for `_process_single_file` to read
-        back: a check with zero violations this run is never re-verified
-        here or by `_refresh_stale_positions()` below (neither one has any
-        reason to look at a check_id with no entries in `violations`), so
-        if some *other* check's fix changed the file, that zero-violation
-        check's result is no longer known to be accurate against the file's
-        final content — a fresh check() next run might disagree. See
-        ADR-0044.
-        """
         initial_violations = _group_by_check_id(violations)
         fixable_check_ids = {v.check_id for v in violations if v.fixable}
 
-        # Whether any check's fix() actually resolved at least one violation
-        # this call — the only case where a later check's own recompute (or
-        # a non-participating check's stale entries) can possibly be
-        # pointing at shifted line numbers, so the final pass below is worth
-        # its own extra read+parse+recheck.
         file_changed = False
-        # Once somebody else has written to the file, a violation that
-        # disappeared can no longer be attributed to a fix of this run's
-        # own. See ADR-0053.
+
         externally_modified = False
 
         for check in self.checks:
             if check.check_id not in fixable_check_ids:
                 continue
             try:
-                # Re-read source in case a previous check's fix in this same
-                # loop already modified the file
                 read_result = self._read_source(filepath)
                 if read_result is None:
-                    # The file was readable moments ago (this run's own
-                    # initial check pass succeeded on it) — a failure here
-                    # means something changed concurrently, or an earlier
-                    # check's own fix in this same loop left it in a bad
-                    # state. Without a rule_failure + marking, this check's
-                    # violations would silently keep their stale pre-fix
-                    # snapshot and be reported as ordinary [FIXABLE], as if
-                    # --fix had never even been attempted for them.
                     self.rule_failures.append((str(filepath), check.check_id))
                     for v in violations:
                         if v.check_id == check.check_id and v.fixable:
@@ -1052,11 +783,6 @@ class CheckOrchestrator:
                 current_source, encoding = read_result
                 current_tree = ast.parse(current_source, filename=filepath)
 
-                # Recompute violations against the current file state rather
-                # than reusing the stale ones collected before any fixes ran:
-                # an earlier check's fix can shift line/col numbers (removing
-                # or inserting lines), which would otherwise make this
-                # check's fix() edit the wrong location.
                 fresh_violations = [v for v in check.check(filepath, current_tree, current_source) if v.fixable]
                 if not fresh_violations:
                     continue
@@ -1122,41 +848,7 @@ class CheckOrchestrator:
         filepath: Path,
         violations: list[Violation],
     ) -> None:
-        """Re-check `filepath`'s final on-disk state and refresh the
-        position of every still-*open* violation (no fixed/rejected/
-        errored/failed/aborted outcome yet this call) — covers both a check that
-        never got as far as calling its own `fix()` this run (e.g. a check
-        that's never fixable at all, like redundant-super-init) *and* a
-        check that did run but left some of its own violations open (e.g.
-        `validate-function-name`'s `should_autofix` guard skipping a method
-        while renaming a different, unrelated function in the same `fix()`
-        call — the per-check loop above only recomputes that check's own
-        positions once, immediately before its own `fix()` call, not again
-        afterward). Either way, if some *other* check's fix in the same run
-        removed or inserted lines after that point, the still-open
-        violation's position silently points at the wrong place — ch. 7:
-        "MUST report line and column information accurately when
-        available". Only called when `_apply_fixes` already confirmed the
-        file's content actually changed this call.
 
-        A violation already marked fixed this call is left completely
-        untouched rather than recomputed: it's genuinely gone from the file,
-        so a fresh `check()` call would never find it again (silently
-        losing its `[FIXED]` confirmation). A check_id with any
-        rejected/errored/failed/aborted entry is skipped *entirely* this
-        pass, including its own still-open entries (if any): a fresh
-        `check()` call would rediscover the still-present rejected/errored/
-        failed/aborted violation too, and there's no reliable way to tell
-        that rediscovery
-        apart from a different, unrelated violation that merely happens to
-        share the same message text (e.g. two identically-named functions
-        in different scopes) without a stable per-violation identity this
-        codebase doesn't have — silently dropping a real, unrelated
-        violation would be worse than leaving its position stale (ch. 34:
-        "MUST prefer a visible failure over a silent incorrect result").
-
-        `violations` is the same list `_apply_fixes` mutates in place.
-        """
         final_read = self._read_source(filepath)
         if final_read is None:
             return
@@ -1168,9 +860,6 @@ class CheckOrchestrator:
 
         for check in self.checks:
             if check.check_id in self._unavailable_check_ids:
-                # Already recorded in unavailable_checks -- see _check_file's
-                # own matching guard for why this check is never worth
-                # retrying again this run.
                 continue
             check_entries = [v for v in violations if v.check_id == check.check_id]
             if not check_entries or any(_has_terminal_fix_state(v) for v in check_entries):
@@ -1183,9 +872,6 @@ class CheckOrchestrator:
             try:
                 fresh = check.check(filepath, final_tree, final_source)
             except Exception:
-                # Debug-only: reported cleanly via rule_failures below — see
-                # _read_source's own docstring for why ERROR-level
-                # .exception() logging here would just be redundant noise.
                 logger.debug("Check %s failed on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
                 continue
@@ -1232,10 +918,7 @@ def load_checks(
     check_args: dict[str, Any] | None = None,
     check_classes: Sequence[type[ASTCheck]] | None = None,
 ) -> list[ASTCheck]:
-    """Mirrors `ruff check --select`/`--ignore`: `select` narrows the
-    candidate set (None = all checks), and `ignore` always subtracts from
-    whatever that candidate set is, whether or not `select` was given.
-    """
+
     if check_args is None:
         check_args = {}
 
@@ -1257,7 +940,6 @@ def load_checks(
         if select is None and not check.default_enabled:
             continue
 
-        # Re-instantiate with check-specific arguments, if any were given.
         args = check_args.get(check_id, {})
         if args:
             try:

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -328,21 +328,29 @@ class CheckOrchestrator:
 
             rerun_checks = [*cacheable_checks, *(check for check in checks if isinstance(check, UnusedPytriageCheck))]
             audit_check_ids = {check.check_id for check in rerun_checks if isinstance(check, UnusedPytriageCheck)}
-            fresh_regular_result = CheckResult(
-                (violation for violation in fresh if violation.check_id not in audit_check_ids),
-                fresh.suppression_usages,
-            )
             fresh_failure_ids = {
                 check_id
                 for _filepath, check_id in self.rule_failures[rule_failures_before:]
                 if Path(_filepath) == filepath
             }
+            successful_always_rerun_ids = {
+                check.check_id
+                for check in always_rerun_checks
+                if check.check_id not in self._unavailable_check_ids and check.check_id not in fresh_failure_ids
+            }
+            fresh_suppression_usages = tuple(
+                usage for usage in fresh.suppression_usages if usage.check_id in successful_always_rerun_ids
+            )
+            fresh_regular_result = CheckResult(
+                (violation for violation in fresh if violation.check_id not in audit_check_ids),
+                fresh_suppression_usages,
+            )
             return self._check_and_cache(
                 filepath,
                 rerun_checks,
                 hook_name,
                 extra_result=fresh_regular_result,
-                prior_suppression_usages=fresh.suppression_usages,
+                prior_suppression_usages=fresh_suppression_usages,
                 prior_active_error_codes=frozenset(
                     check.error_code
                     for check in [*cacheable_checks, *always_rerun_checks]

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -431,6 +431,7 @@ class CheckOrchestrator:
             # produced, so it never touches the (already-clean) cacheable
             # group.
             self._fix_changed_file = False
+            rule_failures_before = len(self.rule_failures)
             fresh = self._check_file(
                 filepath,
                 [*always_rerun_checks],
@@ -456,7 +457,25 @@ class CheckOrchestrator:
             # is only ever not None when it was, since that's the only branch
             # that sets it.
             rerun_checks = [*cacheable_checks, *(check for check in checks if isinstance(check, UnusedPytriageCheck))]
-            return self._check_and_cache(filepath, rerun_checks, hook_name, extra_result=fresh)
+            fresh_failure_ids = {
+                check_id
+                for _filepath, check_id in self.rule_failures[rule_failures_before:]
+                if _filepath == str(filepath)  # pytriage: TR6
+            }
+            return self._check_and_cache(
+                filepath,
+                rerun_checks,
+                hook_name,
+                extra_result=fresh,
+                prior_suppression_usages=fresh.suppression_usages,
+                prior_active_error_codes=frozenset(
+                    check.error_code
+                    for check in [*cacheable_checks, *always_rerun_checks]
+                    if not isinstance(check, UnusedPytriageCheck)
+                    and check.check_id not in self._unavailable_check_ids
+                    and check.check_id not in fresh_failure_ids
+                ),
+            )
 
         return self._check_and_cache(filepath, checks, hook_name, record_only=record_only)
 
@@ -468,6 +487,8 @@ class CheckOrchestrator:
         *,
         extra_result: CheckResult | None = None,
         record_only: Sequence[ASTCheck] = (),
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
     ) -> list[Violation] | None:
         """Runs `checks` fresh against `filepath` (fixing, in fix mode),
         then caches whatever cacheable subset of `checks` is complete and
@@ -482,7 +503,16 @@ class CheckOrchestrator:
         """
         rule_failures_before = len(self.rule_failures)
         self._fix_changed_file = False
-        violations = self._check_file(filepath, checks, record_only=record_only)
+        if prior_suppression_usages or prior_active_error_codes:
+            violations = self._check_file(
+                filepath,
+                checks,
+                record_only=record_only,
+                prior_suppression_usages=prior_suppression_usages,
+                prior_active_error_codes=prior_active_error_codes,
+            )
+        else:
+            violations = self._check_file(filepath, checks, record_only=record_only)
         new_failure_ids = {check_id for _fp, check_id in self.rule_failures[rule_failures_before:]}
 
         if violations is None:
@@ -908,9 +938,13 @@ class CheckOrchestrator:
 
         fresh_audits = CheckResult()
         for check in audit_checks:
-            fresh_audits.extend(
-                check.check_with_suppression_usage(source, tuple(usages), frozenset(active_error_codes))
-            )
+            try:
+                fresh_audits.extend(
+                    check.check_with_suppression_usage(source, tuple(usages), frozenset(active_error_codes))
+                )
+            except Exception:
+                logger.debug("Check %s failed while refreshing unused suppressions", check.check_id, exc_info=True)
+                self.rule_failures.append((str(filepath), check.check_id))
 
         violations_result[:] = [
             violation

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -63,10 +63,7 @@ def _merge_check_results(*results: CheckResult) -> CheckResult:
 
 
 def _check_with_suppression_tracking(check: ASTCheck, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
-    tracking_check = getattr(check, "check_with_suppression_tracking", None)
-    if tracking_check is None:
-        return check.check(filepath, tree, source)
-    return tracking_check(filepath, tree, source)
+    return check.check_with_suppression_tracking(filepath, tree, source)
 
 
 _FIX_LOCK_TIMEOUT_SECONDS = 30.0
@@ -869,7 +866,14 @@ class CheckOrchestrator:
         if self.fix_mode and all_violations:
             self._apply_fixes(filepath, all_violations)
             if self._fix_changed_file and audit_checks:
-                self._refresh_unused_pytriage(filepath, regular_checks, audit_checks, all_violations)
+                self._refresh_unused_pytriage(
+                    filepath,
+                    regular_checks,
+                    audit_checks,
+                    all_violations,
+                    prior_suppression_usages=prior_suppression_usages,
+                    prior_active_error_codes=prior_active_error_codes,
+                )
 
         return all_violations
 
@@ -879,13 +883,16 @@ class CheckOrchestrator:
         regular_checks: Sequence[ASTCheck],
         audit_checks: Sequence[UnusedPytriageCheck],
         violations_result: CheckResult,
+        *,
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
     ) -> None:
         parsed = self._parsed_source(filepath)
         if parsed is None:
             return
         source, tree = parsed
-        usages: list[SuppressionUsage] = []
-        active_error_codes: set[str] = set()
+        usages = list(prior_suppression_usages)
+        active_error_codes = set(prior_active_error_codes)
         for check in regular_checks:
             if check.check_id in self._unavailable_check_ids:
                 continue
@@ -1205,7 +1212,7 @@ def load_checks(
             continue
         if ignore is not None and check_id in ignore:
             continue
-        if select is None and not getattr(check, "default_enabled", True):
+        if select is None and not check.default_enabled:
             continue
 
         # Re-instantiate with check-specific arguments, if any were given.

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -457,16 +457,21 @@ class CheckOrchestrator:
             # is only ever not None when it was, since that's the only branch
             # that sets it.
             rerun_checks = [*cacheable_checks, *(check for check in checks if isinstance(check, UnusedPytriageCheck))]
+            audit_check_ids = {check.check_id for check in rerun_checks if isinstance(check, UnusedPytriageCheck)}
+            fresh_regular_result = CheckResult(
+                (violation for violation in fresh if violation.check_id not in audit_check_ids),
+                fresh.suppression_usages,
+            )
             fresh_failure_ids = {
                 check_id
                 for _filepath, check_id in self.rule_failures[rule_failures_before:]
-                if _filepath == str(filepath)  # pytriage: TR6
+                if Path(_filepath) == filepath
             }
             return self._check_and_cache(
                 filepath,
                 rerun_checks,
                 hook_name,
-                extra_result=fresh,
+                extra_result=fresh_regular_result,
                 prior_suppression_usages=fresh.suppression_usages,
                 prior_active_error_codes=frozenset(
                     check.error_code
@@ -928,6 +933,9 @@ class CheckOrchestrator:
                 continue
             try:
                 fresh = _check_with_suppression_tracking(check, filepath, tree, source)
+            except CheckUnavailableError as error:
+                logger.debug("Check %s is unavailable while refreshing unused suppressions: %s", check.check_id, error)
+                self._record_unavailable_check(check, error)
             except Exception:
                 logger.debug("Check %s failed while refreshing unused suppressions", check.check_id, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -22,15 +22,18 @@ from pre_commit_hooks._prefilter import batch_filter_files
 from . import ALL_CHECKS
 from ._base import (
     ASTCheck,
+    CheckResult,
     CheckUnavailableError,
     ConcurrentModificationError,
     FixOutcome,
     FixResult,
     FixValidationError,
+    SuppressionUsage,
     Violation,
     read_source_with_encoding,
 )
 from ._per_file_ignores import PerFileIgnoreList
+from .unused_pytriage import UnusedPytriageCheck
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -45,6 +48,26 @@ _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 # Matches a pre-fix Violation against a fresh check() re-run's own new
 # Violation objects, which can never share object identity with it.
 type ViolationKey = tuple[int, int, str]  # (line, col, message)
+
+
+def _as_check_result(result: list[Violation]) -> CheckResult:
+    return result if isinstance(result, CheckResult) else CheckResult(result)
+
+
+def _merge_check_results(*results: CheckResult) -> CheckResult:
+    merged = CheckResult()
+    for result in results:
+        merged.extend(result)
+        merged.suppression_usages += result.suppression_usages
+    return merged
+
+
+def _check_with_suppression_tracking(check: ASTCheck, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    tracking_check = getattr(check, "check_with_suppression_tracking", None)
+    if tracking_check is None:
+        return check.check(filepath, tree, source)
+    return tracking_check(filepath, tree, source)
+
 
 _FIX_LOCK_TIMEOUT_SECONDS = 30.0
 _FIX_LOCK_POLL_INTERVAL_SECONDS = 0.05
@@ -386,7 +409,7 @@ class CheckOrchestrator:
         cacheable_checks = [check for check in checks if check.cacheable]
         always_rerun_checks = [check for check in checks if not check.cacheable]
 
-        cached_violations: list[Violation] | None = None
+        cached_violations: CheckResult | None = None
         if cacheable_checks:
             cached_violations = self._get_cached_violations(filepath, hook_name)
 
@@ -411,11 +434,19 @@ class CheckOrchestrator:
             # produced, so it never touches the (already-clean) cacheable
             # group.
             self._fix_changed_file = False
-            fresh = self._check_file(filepath, always_rerun_checks, record_only=record_only)
+            fresh = self._check_file(
+                filepath,
+                [*always_rerun_checks],
+                record_only=record_only,
+                prior_suppression_usages=cached_violations.suppression_usages,
+                prior_active_error_codes=frozenset(
+                    check.error_code for check in cacheable_checks if not isinstance(check, UnusedPytriageCheck)
+                ),
+            )
             if fresh is None:
                 return None
             if not self._fix_changed_file:
-                return cached_violations + fresh
+                return _merge_check_results(cached_violations, fresh)
             # The always-rerun group's own fix changed the file, so the
             # cached "clean" cacheable-group result is no longer known to
             # be accurate for the file's new content. Re-verify (and fix,
@@ -427,7 +458,8 @@ class CheckOrchestrator:
             # cacheable_checks is guaranteed non-empty here: cached_violations
             # is only ever not None when it was, since that's the only branch
             # that sets it.
-            return self._check_and_cache(filepath, cacheable_checks, hook_name, extra_violations=fresh)
+            rerun_checks = [*cacheable_checks, *(check for check in checks if isinstance(check, UnusedPytriageCheck))]
+            return self._check_and_cache(filepath, rerun_checks, hook_name, extra_result=fresh)
 
         return self._check_and_cache(filepath, checks, hook_name, record_only=record_only)
 
@@ -437,7 +469,7 @@ class CheckOrchestrator:
         checks: Sequence[ASTCheck],
         hook_name: str,
         *,
-        extra_violations: list[Violation] | None = None,
+        extra_result: CheckResult | None = None,
         record_only: Sequence[ASTCheck] = (),
     ) -> list[Violation] | None:
         """Runs `checks` fresh against `filepath` (fixing, in fix mode),
@@ -484,9 +516,12 @@ class CheckOrchestrator:
             cacheable_violations = [
                 v for v in violations if v.check_id in cacheable_ids and v.fix_outcome is not FixOutcome.APPLIED
             ]
-            self._cache_violations(filepath, hook_name, cacheable_violations)
+            cacheable_usages = tuple(
+                usage for usage in violations.suppression_usages if usage.check_id in cacheable_ids
+            )
+            self._cache_violations(filepath, hook_name, CheckResult(cacheable_violations, cacheable_usages))
 
-        return violations + extra_violations if extra_violations else violations
+        return _merge_check_results(violations, extra_result) if extra_result else violations
 
     def _checks_by_file(self, filepaths: list[str]) -> dict[str, _FileChecks]:
         """Applies each check's own prefilter pattern independently, rather
@@ -583,13 +618,15 @@ class CheckOrchestrator:
         python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         return f"{tree_hash}|{python_version}"
 
-    def _get_cached_violations(self, filepath: Path, hook_name: str) -> list[Violation] | None:
+    def _get_cached_violations(self, filepath: Path, hook_name: str) -> CheckResult | None:
         try:
             # self.cache's own cache_version already rejects a stale entry,
             # and `hook_name` a mismatched-config one, before this ever sees
             # it.
             cached = self.cache.get_cached_result(filepath, hook_name)
             if cached is None:
+                return None
+            if "suppression_usages" not in cached:
                 return None
 
             violations = [
@@ -604,13 +641,21 @@ class CheckOrchestrator:
                 )
                 for v_dict in cached.get("violations", [])
             ]
+            suppression_usages = tuple(
+                SuppressionUsage(
+                    check_id=usage_dict["check_id"],
+                    error_code=usage_dict["error_code"],
+                    line=usage_dict["line"],
+                )
+                for usage_dict in cached.get("suppression_usages", [])
+            )
         except (KeyError, TypeError, ValueError) as error:
             logger.debug("Cache deserialization failed: %s", repr(error))
             return None
         else:
-            return violations
+            return CheckResult(violations, suppression_usages)
 
-    def _cache_violations(self, filepath: Path, hook_name: str, violations: list[Violation]) -> None:
+    def _cache_violations(self, filepath: Path, hook_name: str, check_result: CheckResult) -> None:
         try:
             serialized = [
                 {
@@ -622,10 +667,23 @@ class CheckOrchestrator:
                     "fixable": v.fixable,
                     # Note: fix_data is NOT cached as it may contain AST nodes
                 }
-                for v in violations
+                for v in check_result
             ]
-
-            self.cache.set_cached_result(filepath, hook_name, {"violations": serialized})
+            self.cache.set_cached_result(
+                filepath,
+                hook_name,
+                {
+                    "violations": serialized,
+                    "suppression_usages": [
+                        {
+                            "check_id": usage.check_id,
+                            "error_code": usage.error_code,
+                            "line": usage.line,
+                        }
+                        for usage in check_result.suppression_usages
+                    ],
+                },
+            )
         except (TypeError, ValueError) as error:
             logger.warning("Cache serialization failed: %s", repr(error))
 
@@ -656,18 +714,45 @@ class CheckOrchestrator:
             return None
 
     def _check_file(
-        self, filepath: Path, checks: Sequence[ASTCheck], *, record_only: Sequence[ASTCheck] = ()
-    ) -> list[Violation] | None:
-        return self._check_file_with_lifecycle(filepath, checks, direct=True, record_only=record_only)
+        self,
+        filepath: Path,
+        checks: Sequence[ASTCheck],
+        *,
+        record_only: Sequence[ASTCheck] = (),
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
+    ) -> CheckResult | None:
+        return self._check_file_with_lifecycle(
+            filepath,
+            checks,
+            direct=True,
+            record_only=record_only,
+            prior_suppression_usages=prior_suppression_usages,
+            prior_active_error_codes=prior_active_error_codes,
+        )
 
-    def _check_derived_file(self, filepath: Path, checks: Sequence[ASTCheck]) -> list[Violation] | None:
+    def _check_derived_file(self, filepath: Path, checks: Sequence[ASTCheck]) -> CheckResult | None:
         return self._check_file_with_lifecycle(filepath, checks, direct=False)
 
     def _check_file_with_lifecycle(
-        self, filepath: Path, checks: Sequence[ASTCheck], *, direct: bool, record_only: Sequence[ASTCheck] = ()
-    ) -> list[Violation] | None:
+        self,
+        filepath: Path,
+        checks: Sequence[ASTCheck],
+        *,
+        direct: bool,
+        record_only: Sequence[ASTCheck] = (),
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
+    ) -> CheckResult | None:
         if not self.fix_mode or not locking_is_available():
-            return self._check_file_locked(filepath, checks, direct=direct, record_only=record_only)
+            return self._check_file_locked(
+                filepath,
+                checks,
+                direct=direct,
+                record_only=record_only,
+                prior_suppression_usages=prior_suppression_usages,
+                prior_active_error_codes=prior_active_error_codes,
+            )
 
         try:
             lock_path = _fix_lock_path(filepath)
@@ -677,7 +762,14 @@ class CheckOrchestrator:
                 timeout_seconds=_FIX_LOCK_TIMEOUT_SECONDS,
                 poll_interval_seconds=_FIX_LOCK_POLL_INTERVAL_SECONDS,
             ):
-                return self._check_file_locked(filepath, checks, direct=direct, record_only=record_only)
+                return self._check_file_locked(
+                    filepath,
+                    checks,
+                    direct=direct,
+                    record_only=record_only,
+                    prior_suppression_usages=prior_suppression_usages,
+                    prior_active_error_codes=prior_active_error_codes,
+                )
         except TimeoutError:
             logger.debug(
                 "Could not acquire the fix lock for %s within %ss -- another process may be fixing it",
@@ -708,15 +800,25 @@ class CheckOrchestrator:
             return None
 
     def _check_file_locked(
-        self, filepath: Path, checks: Sequence[ASTCheck], *, direct: bool, record_only: Sequence[ASTCheck] = ()
-    ) -> list[Violation] | None:
+        self,
+        filepath: Path,
+        checks: Sequence[ASTCheck],
+        *,
+        direct: bool,
+        record_only: Sequence[ASTCheck] = (),
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
+    ) -> CheckResult | None:
         parsed = self._parsed_source(filepath)
         if parsed is None:
             return None
         source, tree = parsed
 
-        all_violations: list[Violation] = []
-        for check in checks:
+        all_violations = CheckResult(suppression_usages=prior_suppression_usages)
+        active_error_codes = set(prior_active_error_codes)
+        regular_checks = [check for check in checks if not isinstance(check, UnusedPytriageCheck)]
+        audit_checks = [check for check in checks if isinstance(check, UnusedPytriageCheck)]
+        for check in regular_checks:
             if check.check_id in self._unavailable_check_ids:
                 # Already recorded in unavailable_checks for an earlier
                 # file this run -- a missing/misbehaving prerequisite
@@ -724,7 +826,10 @@ class CheckOrchestrator:
                 # never worth retrying (or re-recording) again this run.
                 continue
             try:
-                violations = check.check(filepath, tree, source)
+                if audit_checks:
+                    violations = _check_with_suppression_tracking(check, filepath, tree, source)
+                else:
+                    violations = check.check(filepath, tree, source)
             except CheckUnavailableError as error:
                 # Recorded once here rather than per file: see
                 # CheckUnavailableError's own docstring for why this must
@@ -739,9 +844,23 @@ class CheckOrchestrator:
                 logger.debug("Check %s failed on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
             else:
-                all_violations.extend(violations)
+                check_result = _as_check_result(violations)
+                all_violations.extend(check_result)
+                all_violations.suppression_usages += check_result.suppression_usages
+                active_error_codes.add(check.error_code)
                 if direct:
                     self._record_direct_input(check, filepath, source)
+
+        for check in audit_checks:
+            try:
+                audit_result = check.check_with_suppression_usage(
+                    source, all_violations.suppression_usages, frozenset(active_error_codes)
+                )
+            except Exception:
+                logger.debug("Check %s failed on %s", check.check_id, filepath, exc_info=True)
+                self.rule_failures.append((str(filepath), check.check_id))
+            else:
+                all_violations.extend(audit_result)
 
         if direct:
             for check in record_only:
@@ -749,8 +868,50 @@ class CheckOrchestrator:
 
         if self.fix_mode and all_violations:
             self._apply_fixes(filepath, all_violations)
+            if self._fix_changed_file and audit_checks:
+                self._refresh_unused_pytriage(filepath, regular_checks, audit_checks, all_violations)
 
         return all_violations
+
+    def _refresh_unused_pytriage(
+        self,
+        filepath: Path,
+        regular_checks: Sequence[ASTCheck],
+        audit_checks: Sequence[UnusedPytriageCheck],
+        violations_result: CheckResult,
+    ) -> None:
+        parsed = self._parsed_source(filepath)
+        if parsed is None:
+            return
+        source, tree = parsed
+        usages: list[SuppressionUsage] = []
+        active_error_codes: set[str] = set()
+        for check in regular_checks:
+            if check.check_id in self._unavailable_check_ids:
+                continue
+            try:
+                fresh = _check_with_suppression_tracking(check, filepath, tree, source)
+            except Exception:
+                logger.debug("Check %s failed while refreshing unused suppressions", check.check_id, exc_info=True)
+                self.rule_failures.append((str(filepath), check.check_id))
+            else:
+                fresh_result = _as_check_result(fresh)
+                usages.extend(fresh_result.suppression_usages)
+                active_error_codes.add(check.error_code)
+
+        fresh_audits = CheckResult()
+        for check in audit_checks:
+            fresh_audits.extend(
+                check.check_with_suppression_usage(source, tuple(usages), frozenset(active_error_codes))
+            )
+
+        violations_result[:] = [
+            violation
+            for violation in violations_result
+            if violation.check_id not in {check.check_id for check in audit_checks}
+        ]
+        violations_result.extend(fresh_audits)
+        violations_result.suppression_usages = tuple(usages)
 
     def _record_direct_inputs(self, filepath: Path, checks: Sequence[ASTCheck]) -> bool:
         """Reads and parses `filepath` for its own sake, for the one caller
@@ -1043,6 +1204,8 @@ def load_checks(
         if select is not None and check_id not in select:
             continue
         if ignore is not None and check_id in ignore:
+            continue
+        if select is None and not getattr(check, "default_enabled", True):
             continue
 
         # Re-instantiate with check-specific arguments, if any were given.

--- a/src/pre_commit_hooks/ast_checks/_orchestrator.py
+++ b/src/pre_commit_hooks/ast_checks/_orchestrator.py
@@ -55,10 +55,6 @@ def _merge_check_results(*results: CheckResult) -> CheckResult:
     return merged
 
 
-def _check_with_suppression_tracking(check: ASTCheck, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
-    return check.check_with_suppression_tracking(filepath, tree, source)
-
-
 _FIX_LOCK_TIMEOUT_SECONDS = 30.0
 _FIX_LOCK_POLL_INTERVAL_SECONDS = 0.05
 
@@ -376,16 +372,13 @@ class CheckOrchestrator:
 
         rule_failures_before = len(self.rule_failures)
         self._fix_changed_file = False
-        if prior_suppression_usages or prior_active_error_codes:
-            violations = self._check_file(
-                filepath,
-                checks,
-                record_only=record_only,
-                prior_suppression_usages=prior_suppression_usages,
-                prior_active_error_codes=prior_active_error_codes,
-            )
-        else:
-            violations = self._check_file(filepath, checks, record_only=record_only)
+        violations = self._check_file(
+            filepath,
+            checks,
+            record_only=record_only,
+            prior_suppression_usages=prior_suppression_usages,
+            prior_active_error_codes=prior_active_error_codes,
+        )
         new_failure_ids = {check_id for _fp, check_id in self.rule_failures[rule_failures_before:]}
 
         if violations is None:
@@ -646,9 +639,9 @@ class CheckOrchestrator:
                 continue
             try:
                 if audit_checks:
-                    violations = _check_with_suppression_tracking(check, filepath, tree, source)
+                    check_result = check.check_with_suppression_tracking(filepath, tree, source)
                 else:
-                    violations = check.check(filepath, tree, source)
+                    check_result = _as_check_result(check.check(filepath, tree, source))
             except CheckUnavailableError as error:
                 logger.debug("Check %s is unavailable: %s", check.check_id, error, exc_info=True)
                 self._record_unavailable_check(check, error)
@@ -656,7 +649,6 @@ class CheckOrchestrator:
                 logger.debug("Check %s failed on %s", check.check_id, filepath, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
             else:
-                check_result = _as_check_result(violations)
                 all_violations.extend(check_result)
                 all_violations.suppression_usages += check_result.suppression_usages
                 active_error_codes.add(check.error_code)
@@ -712,7 +704,7 @@ class CheckOrchestrator:
             if check.check_id in self._unavailable_check_ids:
                 continue
             try:
-                fresh = _check_with_suppression_tracking(check, filepath, tree, source)
+                fresh_result = check.check_with_suppression_tracking(filepath, tree, source)
             except CheckUnavailableError as error:
                 logger.debug("Check %s is unavailable while refreshing unused suppressions: %s", check.check_id, error)
                 self._record_unavailable_check(check, error)
@@ -720,7 +712,6 @@ class CheckOrchestrator:
                 logger.debug("Check %s failed while refreshing unused suppressions", check.check_id, exc_info=True)
                 self.rule_failures.append((str(filepath), check.check_id))
             else:
-                fresh_result = _as_check_result(fresh)
                 usages.extend(fresh_result.suppression_usages)
                 active_error_codes.add(check.error_code)
 

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -20,12 +20,13 @@ from ._base import (
     CheckResult,
     FixOutcome,
     FixResult,
+    SuppressionUsage,
     Violation,
     atomic_write_text,
     find_ignored_lines,
     find_ignored_lines_and_pytriage_comments,
-    find_suppression_usage,
     ignore_pattern_for,
+    record_suppression_usage_if_ignored,
 )
 
 if TYPE_CHECKING:
@@ -222,14 +223,17 @@ class ExcessiveBlankLinesCheck(BaseCheck):
 
         ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
         violations = []
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
         for fv in file_violations:
-            if fv.anchor_line in ignored_lines:
-                usage = find_suppression_usage(
-                    comments, format_suppressed, self.check_id, self.error_code, (fv.anchor_line,)
-                )
-                if usage is not None:
-                    suppression_usages.append(usage)
+            if record_suppression_usage_if_ignored(
+                suppression_usages,
+                ignored_lines,
+                comments,
+                format_suppressed,
+                check_id=self.check_id,
+                error_code=self.error_code,
+                candidate_lines=(fv.anchor_line,),
+            ):
                 continue
             violations.append(
                 Violation(

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -17,11 +17,14 @@ from typing import TYPE_CHECKING
 
 from ._base import (
     BaseCheck,
+    CheckResult,
     FixOutcome,
     FixResult,
     Violation,
     atomic_write_text,
     find_ignored_lines,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
 )
 
@@ -212,15 +215,21 @@ class ExcessiveBlankLinesCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return None
 
-    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         file_violations = check_file_violations(source, tree)
         if not file_violations:
-            return []
+            return CheckResult()
 
-        ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+        ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
         violations = []
+        suppression_usages = []
         for fv in file_violations:
             if fv.anchor_line in ignored_lines:
+                usage = find_suppression_usage(
+                    comments, format_suppressed, self.check_id, self.error_code, (fv.anchor_line,)
+                )
+                if usage is not None:
+                    suppression_usages.append(usage)
                 continue
             violations.append(
                 Violation(
@@ -233,7 +242,7 @@ class ExcessiveBlankLinesCheck(BaseCheck):
                 )
             )
 
-        return violations
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
+++ b/src/pre_commit_hooks/ast_checks/excessive_blank_lines.py
@@ -227,9 +227,9 @@ class ExcessiveBlankLinesCheck(BaseCheck):
         for fv in file_violations:
             if record_suppression_usage_if_ignored(
                 suppression_usages,
-                ignored_lines,
                 comments,
-                format_suppressed,
+                ignored_lines=ignored_lines,
+                format_suppressed=format_suppressed,
                 check_id=self.check_id,
                 error_code=self.error_code,
                 candidate_lines=(fv.anchor_line,),

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -18,13 +18,14 @@ from ._base import (
     CheckResult,
     FixOutcome,
     FixResult,
+    SuppressionUsage,
     Violation,
     atomic_write_text,
     byte_col_to_char_col,
     find_ignored_lines,
     find_ignored_lines_and_pytriage_comments,
-    find_suppression_usage,
     ignore_pattern_for,
+    record_suppression_usage_if_ignored,
     split_lines_like_ast,
 )
 from ._options import EnumOption
@@ -912,33 +913,42 @@ class MeaninglessVarsCheck(BaseCheck):
         return sorted(self.meaningless_names)
 
     def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(tree, source, collect_suppression_usage=False)
+
+    def check_with_suppression_tracking(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(tree, source, collect_suppression_usage=True)
+
+    def _check(self, tree: ast.Module, source: str, *, collect_suppression_usage: bool) -> CheckResult:
         visitor = MeaninglessNameVisitor(self.meaningless_names, source)
         visitor.visit(tree)
 
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
         if visitor.violations:
-            ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
-                source, IGNORE_PATTERN
-            )
+            if collect_suppression_usage:
+                ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
+                    source, IGNORE_PATTERN
+                )
+            else:
+                ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
             raw_violations = [v for v in visitor.violations if v["line"] not in ignored_lines]
             suggestions = plan_suggestions(tree, self.meaningless_names, ignored_lines)
 
             suppressed_candidates = [v for v in visitor.violations if v["line"] in ignored_lines]
-            if suppressed_candidates:
+            if collect_suppression_usage and suppressed_candidates:
                 all_suggestions = plan_suggestions(tree, self.meaningless_names, set())
                 for candidate in suppressed_candidates:
                     proposal = all_suggestions.get((candidate["line"], candidate["byte_col"]))
                     if self._level is MeaninglessVarsLevel.CONSERVATIVE and proposal is None:
                         continue
-                    usage = find_suppression_usage(
+                    record_suppression_usage_if_ignored(
+                        suppression_usages,
+                        ignored_lines,
                         comments,
                         format_suppressed,
-                        self.check_id,
-                        self.error_code,
-                        (candidate["line"],),
+                        check_id=self.check_id,
+                        error_code=self.error_code,
+                        candidate_lines=(candidate["line"],),
                     )
-                    if usage is not None:
-                        suppression_usages.append(usage)
         else:
             raw_violations = []
             suggestions = {}

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -942,9 +942,9 @@ class MeaninglessVarsCheck(BaseCheck):
                         continue
                     record_suppression_usage_if_ignored(
                         suppression_usages,
-                        ignored_lines,
                         comments,
-                        format_suppressed,
+                        ignored_lines=ignored_lines,
+                        format_suppressed=format_suppressed,
                         check_id=self.check_id,
                         error_code=self.error_code,
                         candidate_lines=(candidate["line"],),

--- a/src/pre_commit_hooks/ast_checks/meaningless_vars.py
+++ b/src/pre_commit_hooks/ast_checks/meaningless_vars.py
@@ -15,12 +15,15 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from ._base import (
     BaseCheck,
+    CheckResult,
     FixOutcome,
     FixResult,
     Violation,
     atomic_write_text,
     byte_col_to_char_col,
     find_ignored_lines,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
     split_lines_like_ast,
 )
@@ -908,14 +911,34 @@ class MeaninglessVarsCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return sorted(self.meaningless_names)
 
-    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         visitor = MeaninglessNameVisitor(self.meaningless_names, source)
         visitor.visit(tree)
 
+        suppression_usages = []
         if visitor.violations:
-            ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+            ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
+                source, IGNORE_PATTERN
+            )
             raw_violations = [v for v in visitor.violations if v["line"] not in ignored_lines]
             suggestions = plan_suggestions(tree, self.meaningless_names, ignored_lines)
+
+            suppressed_candidates = [v for v in visitor.violations if v["line"] in ignored_lines]
+            if suppressed_candidates:
+                all_suggestions = plan_suggestions(tree, self.meaningless_names, set())
+                for candidate in suppressed_candidates:
+                    proposal = all_suggestions.get((candidate["line"], candidate["byte_col"]))
+                    if self._level is MeaninglessVarsLevel.CONSERVATIVE and proposal is None:
+                        continue
+                    usage = find_suppression_usage(
+                        comments,
+                        format_suppressed,
+                        self.check_id,
+                        self.error_code,
+                        (candidate["line"],),
+                    )
+                    if usage is not None:
+                        suppression_usages.append(usage)
         else:
             raw_violations = []
             suggestions = {}
@@ -949,7 +972,7 @@ class MeaninglessVarsCheck(BaseCheck):
                 )
             )
 
-        return violations
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -20,11 +20,14 @@ from typing import TYPE_CHECKING
 
 from ._base import (
     BaseCheck,
+    CheckResult,
     FixOutcome,
     FixResult,
     Violation,
     atomic_write_text,
+    find_suppression_usage,
     ignore_pattern_for,
+    ignored_lines_and_pytriage_comments_from_tokens,
     ignored_lines_from_tokens,
     line_terminator,
     tokenize_source,
@@ -163,29 +166,40 @@ class MisplacedCommentCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["#"]
 
-    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         tokens = tuple(tokenize_source(source))
         found = _scan_misplaced_comments(tokens, tree)
         if not found:
-            return []
+            return CheckResult()
 
-        ignored_lines = ignored_lines_from_tokens(tokens, IGNORE_PATTERN)
-        return [
-            Violation(
-                check_id=self.check_id,
-                error_code=self.error_code,
-                line=item.bracket_line,
-                col=item.comment_col,
-                message=(
-                    f"Comment on line {item.comment_line} should not be on "
-                    "closing bracket line. Or add "
-                    "'# pytriage: TR7' to suppress."
-                ),
-                fixable=True,
+        ignored_lines, format_suppressed, comments = ignored_lines_and_pytriage_comments_from_tokens(
+            tokens, IGNORE_PATTERN
+        )
+        violations = []
+        suppression_usages = []
+        for item in found:
+            if item.bracket_line in ignored_lines:
+                usage = find_suppression_usage(
+                    comments, format_suppressed, self.check_id, self.error_code, (item.bracket_line,)
+                )
+                if usage is not None:
+                    suppression_usages.append(usage)
+                continue
+            violations.append(
+                Violation(
+                    check_id=self.check_id,
+                    error_code=self.error_code,
+                    line=item.bracket_line,
+                    col=item.comment_col,
+                    message=(
+                        f"Comment on line {item.comment_line} should not be on "
+                        "closing bracket line. Or add "
+                        "'# pytriage: TR7' to suppress."
+                    ),
+                    fixable=True,
+                )
             )
-            for item in found
-            if item.bracket_line not in ignored_lines
-        ]
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -23,13 +23,14 @@ from ._base import (
     CheckResult,
     FixOutcome,
     FixResult,
+    SuppressionUsage,
     Violation,
     atomic_write_text,
-    find_suppression_usage,
     ignore_pattern_for,
     ignored_lines_and_pytriage_comments_from_tokens,
     ignored_lines_from_tokens,
     line_terminator,
+    record_suppression_usage_if_ignored,
     tokenize_source,
 )
 
@@ -176,14 +177,17 @@ class MisplacedCommentCheck(BaseCheck):
             tokens, IGNORE_PATTERN
         )
         violations = []
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
         for item in found:
-            if item.bracket_line in ignored_lines:
-                usage = find_suppression_usage(
-                    comments, format_suppressed, self.check_id, self.error_code, (item.bracket_line,)
-                )
-                if usage is not None:
-                    suppression_usages.append(usage)
+            if record_suppression_usage_if_ignored(
+                suppression_usages,
+                ignored_lines,
+                comments,
+                format_suppressed,
+                check_id=self.check_id,
+                error_code=self.error_code,
+                candidate_lines=(item.bracket_line,),
+            ):
                 continue
             violations.append(
                 Violation(

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -181,9 +181,9 @@ class MisplacedCommentCheck(BaseCheck):
         for item in found:
             if record_suppression_usage_if_ignored(
                 suppression_usages,
-                ignored_lines,
                 comments,
-                format_suppressed,
+                ignored_lines=ignored_lines,
+                format_suppressed=format_suppressed,
                 check_id=self.check_id,
                 error_code=self.error_code,
                 candidate_lines=(item.bracket_line,),

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -12,6 +12,7 @@ from pre_commit_hooks.ast_checks._base import (
     byte_col_to_char_col,
     find_ignored_lines_and_classify_comments,
     find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
     record_suppression_usage_if_ignored,
 )
@@ -136,19 +137,19 @@ class RedundantAssignmentCheck(BaseCheck):
                 continue
 
             candidate_lines = (lifecycle.assignment.line, *(use.line for use in lifecycle.uses))
-            if lifecycle.assignment.line in ignored_lines:
-                record_suppression_usage_if_ignored(
-                    suppression_usages,
-                    ignored_lines,
-                    comments,
-                    format_suppressed,
-                    check_id=self.check_id,
-                    error_code=self.error_code,
-                    candidate_lines=candidate_lines,
-                )
-                continue
-
-            if not should_report_violation(lifecycle, pattern, level=self._level):
+            assignment_suppression = find_suppression_usage(
+                comments,
+                format_suppressed,
+                self.check_id,
+                self.error_code,
+                (lifecycle.assignment.line,),
+            )
+            if not should_report_violation(
+                lifecycle,
+                pattern,
+                level=self._level,
+                allow_inline_suppression=assignment_suppression is not None,
+            ):
                 continue
 
             if record_suppression_usage_if_ignored(

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -5,10 +5,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
+    CheckResult,
     FixResult,
     Violation,
     byte_col_to_char_col,
     find_ignored_lines_and_classify_comments,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
 )
 from pre_commit_hooks.ast_checks._options import EnumOption
@@ -85,10 +88,11 @@ class RedundantAssignmentCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return [" = "]
 
-    def check(self, _filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         ignored_lines, comment_only_lines, trailing_comment_lines = find_ignored_lines_and_classify_comments(
             source, IGNORE_PATTERN
         )
+        _ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
 
         tracker = VariableTracker(source, comment_only_lines, trailing_comment_lines)
         tracker.visit(tree)
@@ -113,6 +117,7 @@ class RedundantAssignmentCheck(BaseCheck):
         }
 
         violations: list[Violation] = []
+        suppression_usages = []
 
         for lifecycle in lifecycles:
             key = (lifecycle.assignment.scope_id, lifecycle.assignment.var_name)
@@ -129,10 +134,16 @@ class RedundantAssignmentCheck(BaseCheck):
             if pattern is None:
                 continue
 
-            if lifecycle.assignment.line in ignored_lines or any(use.line in ignored_lines for use in lifecycle.uses):
+            if not should_report_violation(lifecycle, pattern, level=self._level):
                 continue
 
-            if not should_report_violation(lifecycle, pattern, level=self._level):
+            candidate_lines = (lifecycle.assignment.line, *(use.line for use in lifecycle.uses))
+            if any(line in ignored_lines for line in candidate_lines):
+                usage = find_suppression_usage(
+                    comments, format_suppressed, self.check_id, self.error_code, candidate_lines
+                )
+                if usage is not None:
+                    suppression_usages.append(usage)
                 continue
 
             fixable = should_autofix(lifecycle, source_lines=tracker.source_lines)
@@ -165,7 +176,7 @@ class RedundantAssignmentCheck(BaseCheck):
             )
             violations.append(violation)
 
-        return violations
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -10,8 +10,7 @@ from pre_commit_hooks.ast_checks._base import (
     SuppressionUsage,
     Violation,
     byte_col_to_char_col,
-    find_ignored_lines_and_classify_comments,
-    find_ignored_lines_and_pytriage_comments,
+    find_ignored_lines_and_classify_comments_and_pytriage,
     find_suppression_usage,
     ignore_pattern_for,
     record_suppression_usage_if_ignored,
@@ -91,10 +90,13 @@ class RedundantAssignmentCheck(BaseCheck):
         return [" = "]
 
     def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
-        ignored_lines, comment_only_lines, trailing_comment_lines = find_ignored_lines_and_classify_comments(
-            source, IGNORE_PATTERN
-        )
-        _ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
+        (
+            ignored_lines,
+            comment_only_lines,
+            trailing_comment_lines,
+            format_suppressed,
+            comments,
+        ) = find_ignored_lines_and_classify_comments_and_pytriage(source, IGNORE_PATTERN)
 
         tracker = VariableTracker(source, comment_only_lines, trailing_comment_lines)
         tracker.visit(tree)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -7,12 +7,13 @@ from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
     CheckResult,
     FixResult,
+    SuppressionUsage,
     Violation,
     byte_col_to_char_col,
     find_ignored_lines_and_classify_comments,
     find_ignored_lines_and_pytriage_comments,
-    find_suppression_usage,
     ignore_pattern_for,
+    record_suppression_usage_if_ignored,
 )
 from pre_commit_hooks.ast_checks._options import EnumOption
 
@@ -117,7 +118,7 @@ class RedundantAssignmentCheck(BaseCheck):
         }
 
         violations: list[Violation] = []
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
 
         for lifecycle in lifecycles:
             key = (lifecycle.assignment.scope_id, lifecycle.assignment.var_name)
@@ -134,16 +135,31 @@ class RedundantAssignmentCheck(BaseCheck):
             if pattern is None:
                 continue
 
+            candidate_lines = (lifecycle.assignment.line, *(use.line for use in lifecycle.uses))
+            if lifecycle.assignment.line in ignored_lines:
+                record_suppression_usage_if_ignored(
+                    suppression_usages,
+                    ignored_lines,
+                    comments,
+                    format_suppressed,
+                    check_id=self.check_id,
+                    error_code=self.error_code,
+                    candidate_lines=candidate_lines,
+                )
+                continue
+
             if not should_report_violation(lifecycle, pattern, level=self._level):
                 continue
 
-            candidate_lines = (lifecycle.assignment.line, *(use.line for use in lifecycle.uses))
-            if any(line in ignored_lines for line in candidate_lines):
-                usage = find_suppression_usage(
-                    comments, format_suppressed, self.check_id, self.error_code, candidate_lines
-                )
-                if usage is not None:
-                    suppression_usages.append(usage)
+            if record_suppression_usage_if_ignored(
+                suppression_usages,
+                ignored_lines,
+                comments,
+                format_suppressed,
+                check_id=self.check_id,
+                error_code=self.error_code,
+                candidate_lines=candidate_lines,
+            ):
                 continue
 
             fixable = should_autofix(lifecycle, source_lines=tracker.source_lines)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -154,9 +154,9 @@ class RedundantAssignmentCheck(BaseCheck):
 
             if record_suppression_usage_if_ignored(
                 suppression_usages,
-                ignored_lines,
                 comments,
-                format_suppressed,
+                ignored_lines=ignored_lines,
+                format_suppressed=format_suppressed,
                 check_id=self.check_id,
                 error_code=self.error_code,
                 candidate_lines=candidate_lines,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -482,6 +482,8 @@ def should_report_violation(
     lifecycle: VariableLifecycle,
     pattern: PatternType,
     level: AggressivenessLevel = AggressivenessLevel.CONSERVATIVE,
+    *,
+    allow_inline_suppression: bool = False,
 ) -> bool:
     assignment = lifecycle.assignment
     is_keyword_argument_echo = _is_keyword_argument_echo(lifecycle)
@@ -501,7 +503,7 @@ def should_report_violation(
 
     # Skip if there's an inline comment on the assignment line
     # Inline comments (e.g., type: ignore) indicate intentional code
-    if assignment.has_inline_comment:
+    if assignment.has_inline_comment and not allow_inline_suppression:
         return False
 
     # Rule 1: Don't report global scope variables unless prefixed with `_`

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -13,7 +13,16 @@ import ast
 import logging
 from typing import TYPE_CHECKING
 
-from ._base import BaseCheck, FixOutcome, FixResult, Violation, find_ignored_lines, ignore_pattern_for
+from ._base import (
+    BaseCheck,
+    CheckResult,
+    FixOutcome,
+    FixResult,
+    Violation,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
+    ignore_pattern_for,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -137,17 +146,21 @@ class RedundantSuperInitCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["super().__init__"]
 
-    def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         checker = SuperInitChecker(str(filepath))
         checker.visit(tree)
 
         if not checker.violations:
-            return []
+            return CheckResult()
 
-        ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+        ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
         violations = []
+        suppression_usages = []
         for line_num, message in checker.violations:
             if line_num in ignored_lines:
+                usage = find_suppression_usage(comments, format_suppressed, self.check_id, self.error_code, (line_num,))
+                if usage is not None:
+                    suppression_usages.append(usage)
                 continue
             violations.append(
                 Violation(
@@ -160,7 +173,7 @@ class RedundantSuperInitCheck(BaseCheck):
                 )
             )
 
-        return violations
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -18,10 +18,11 @@ from ._base import (
     CheckResult,
     FixOutcome,
     FixResult,
+    SuppressionUsage,
     Violation,
     find_ignored_lines_and_pytriage_comments,
-    find_suppression_usage,
     ignore_pattern_for,
+    record_suppression_usage_if_ignored,
 )
 
 if TYPE_CHECKING:
@@ -155,12 +156,17 @@ class RedundantSuperInitCheck(BaseCheck):
 
         ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
         violations = []
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
         for line_num, message in checker.violations:
-            if line_num in ignored_lines:
-                usage = find_suppression_usage(comments, format_suppressed, self.check_id, self.error_code, (line_num,))
-                if usage is not None:
-                    suppression_usages.append(usage)
+            if record_suppression_usage_if_ignored(
+                suppression_usages,
+                ignored_lines,
+                comments,
+                format_suppressed,
+                check_id=self.check_id,
+                error_code=self.error_code,
+                candidate_lines=(line_num,),
+            ):
                 continue
             violations.append(
                 Violation(

--- a/src/pre_commit_hooks/ast_checks/redundant_super_init.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_super_init.py
@@ -160,9 +160,9 @@ class RedundantSuperInitCheck(BaseCheck):
         for line_num, message in checker.violations:
             if record_suppression_usage_if_ignored(
                 suppression_usages,
-                ignored_lines,
                 comments,
-                format_suppressed,
+                ignored_lines=ignored_lines,
+                format_suppressed=format_suppressed,
                 check_id=self.check_id,
                 error_code=self.error_code,
                 candidate_lines=(line_num,),

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -10,10 +10,13 @@ from typing import TYPE_CHECKING, ClassVar
 
 from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
+    CheckResult,
     FixOutcome,
     FixResult,
     Violation,
     find_ignored_lines,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
 )
 from pre_commit_hooks.ast_checks._options import EnumOption
@@ -113,36 +116,65 @@ class RedundantTypeConversionCheck(BaseCheck):
             return None
         return [f"{name}(" for name in eligible_constructors(self._level)]
 
-    def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(filepath, tree, source, collect_suppression_usage=False)
+
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(filepath, tree, source, collect_suppression_usage=True)
+
+    def _check(self, filepath: Path, tree: ast.Module, source: str, *, collect_suppression_usage: bool) -> CheckResult:
         candidates = find_candidates(tree, eligible_constructors(self._level))
         if not candidates:
-            return []
+            return CheckResult()
 
-        ignored_lines = find_ignored_lines(source, IGNORE_PATTERN, THIRD_PARTY_IGNORE_PATTERN)
-        if not any(candidate.line not in ignored_lines for candidate in candidates):
-            return []
+        if collect_suppression_usage:
+            ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
+                source, IGNORE_PATTERN, THIRD_PARTY_IGNORE_PATTERN
+            )
+            pytriage_lines = {
+                comment.line
+                for comment in comments
+                if self.error_code in comment.codes and comment.line not in format_suppressed
+            }
+            analysis_ignored_lines = ignored_lines - pytriage_lines
+        else:
+            ignored_lines = find_ignored_lines(source, IGNORE_PATTERN, THIRD_PARTY_IGNORE_PATTERN)
+            format_suppressed = set()
+            comments = ()
+            analysis_ignored_lines = ignored_lines
+        if not any(candidate.line not in analysis_ignored_lines for candidate in candidates):
+            return CheckResult()
 
         session = get_session()
         cache_key = self._level.name
         redundancies = session.cached_redundancies(filepath, source, cache_key)
         if redundancies is None:
             redundant = decide_candidates(
-                session, filepath, candidates, source, level=self._level, ignored_lines=ignored_lines
+                session, filepath, candidates, source, level=self._level, ignored_lines=analysis_ignored_lines
             )
             redundancies = [(item.candidate.constructor, item.line, item.col, item.argument_type) for item in redundant]
             session.cache_redundancies(filepath, source, cache_key, redundancies)
 
-        return [
-            Violation(
-                check_id=CHECK_ID,
-                error_code=ERROR_CODE,
-                line=line,
-                col=col,
-                message=_format_message(constructor, argument_type),
-                fixable=False,
+        violations = []
+        suppression_usages = []
+        for constructor, line, col, argument_type in redundancies:
+            if line in ignored_lines:
+                if collect_suppression_usage:
+                    usage = find_suppression_usage(comments, format_suppressed, self.check_id, self.error_code, (line,))
+                    if usage is not None:
+                        suppression_usages.append(usage)
+                continue
+            violations.append(
+                Violation(
+                    check_id=CHECK_ID,
+                    error_code=ERROR_CODE,
+                    line=line,
+                    col=col,
+                    message=_format_message(constructor, argument_type),
+                    fixable=False,
+                )
             )
-            for constructor, line, col, argument_type in redundancies
-        ]
+        return CheckResult(violations, suppression_usages)
 
     def record_direct_input(self, filepath: Path, source: str) -> None:
         record_direct_input_if_session_active(filepath, source)

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -41,6 +41,10 @@ ERROR_CODE = "TR6"
 CHECK_ID = "redundant-type-conversion"
 
 
+def _cache_key(level: ConfidenceLevel, *, collect_suppression_usage: bool) -> str:
+    return f"{level.name}:{'tracking' if collect_suppression_usage else 'normal'}"
+
+
 def _format_message(constructor: str, argument_type: str) -> str:
     if is_exact_match(argument_type, constructor):
         return (
@@ -146,7 +150,7 @@ class RedundantTypeConversionCheck(BaseCheck):
             return CheckResult()
 
         session = get_session()
-        cache_key = f"{self._level.name}:{'tracking' if collect_suppression_usage else 'normal'}"
+        cache_key = _cache_key(self._level, collect_suppression_usage=collect_suppression_usage)
         redundancies = session.cached_redundancies(filepath, source, cache_key)
         if redundancies is None:
             redundant = decide_candidates(

--- a/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_type_conversion/__init__.py
@@ -146,7 +146,7 @@ class RedundantTypeConversionCheck(BaseCheck):
             return CheckResult()
 
         session = get_session()
-        cache_key = self._level.name
+        cache_key = f"{self._level.name}:{'tracking' if collect_suppression_usage else 'normal'}"
         redundancies = session.cached_redundancies(filepath, source, cache_key)
         if redundancies is None:
             redundant = decide_candidates(

--- a/src/pre_commit_hooks/ast_checks/unused_pytriage.py
+++ b/src/pre_commit_hooks/ast_checks/unused_pytriage.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._base import (
+    BaseCheck,
+    CheckResult,
+    FixOutcome,
+    FixResult,
+    SuppressionUsage,
+    Violation,
+    find_ignored_lines_and_pytriage_comments,
+)
+
+if TYPE_CHECKING:
+    import ast
+    from pathlib import Path
+
+CHECK_ID = "unused-pytriage"
+ERROR_CODE = "TR8"
+
+
+class UnusedPytriageCheck(BaseCheck):
+    __slots__ = ()
+
+    @property
+    def check_id(self) -> str:
+        return CHECK_ID
+
+    @property
+    def error_code(self) -> str:
+        return ERROR_CODE
+
+    @property
+    def cacheable(self) -> bool:
+        return False
+
+    @property
+    def default_enabled(self) -> bool:
+        return False
+
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return ["# pytriage:"]
+
+    def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> CheckResult:
+        return CheckResult()
+
+    def check_with_suppression_usage(
+        self,
+        source: str,
+        usages: tuple[SuppressionUsage, ...],
+        active_error_codes: frozenset[str],
+    ) -> CheckResult:
+        _ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source)
+        used = {(usage.error_code, usage.line) for usage in usages if usage.error_code in active_error_codes}
+        violations: list[Violation] = []
+
+        for comment in comments:
+            if comment.line in format_suppressed:
+                continue
+
+            remaining_usage = {(code, comment.line) for code in active_error_codes if (code, comment.line) in used}
+            unused_codes: list[str] = []
+            for code in comment.codes:
+                if code not in active_error_codes or code == ERROR_CODE:
+                    continue
+                key = (code, comment.line)
+                if key in remaining_usage:
+                    remaining_usage.remove(key)
+                else:
+                    unused_codes.append(code)
+
+            if unused_codes:
+                listed_codes = ", ".join(unused_codes)
+                violations.append(
+                    Violation(
+                        check_id=CHECK_ID,
+                        error_code=ERROR_CODE,
+                        line=comment.line,
+                        col=comment.col,
+                        message=f"Unused '# pytriage' suppression code(s): {listed_codes}.",
+                        fixable=False,
+                    )
+                )
+
+        return CheckResult(violations)
+
+    def fix(
+        self,
+        _filepath: Path,
+        violations: list[Violation],
+        _source: str,
+        _tree: ast.Module,
+        _encoding: str = "utf-8",
+    ) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -45,7 +45,7 @@ from pre_commit_hooks.ast_checks._base import (
     Violation,
     find_ignored_lines,
     find_ignored_lines_and_pytriage_comments,
-    find_suppression_usage,
+    record_suppression_usage_if_ignored,
 )
 
 from .analysis import IGNORE_PATTERN, Suggestion, collect_suggestions
@@ -118,12 +118,15 @@ class ValidateFunctionNameCheck(BaseCheck):
         suppression_usages = []
         if collect_suppression_usage:
             for suggestion in all_suggestions:
-                if suggestion.lineno in ignored_lines:
-                    usage = find_suppression_usage(
-                        comments, format_suppressed, self.check_id, self.error_code, (suggestion.lineno,)
-                    )
-                    if usage is not None:
-                        suppression_usages.append(usage)
+                record_suppression_usage_if_ignored(
+                    suppression_usages,
+                    ignored_lines,
+                    comments,
+                    format_suppressed,
+                    check_id=self.check_id,
+                    error_code=self.error_code,
+                    candidate_lines=(suggestion.lineno,),
+                )
         for suggestion in suggestions:
             auto_fixable = not suggestion.requires_property and is_autofix_safe(function_index, suggestion)
             reference_status = _repository_reference_status(filepath, suggestion.func_name) if auto_fixable else "safe"

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -42,6 +42,7 @@ from pre_commit_hooks.ast_checks._base import (
     FixOutcome,
     FixResult,
     FixValidationError,
+    SuppressionUsage,
     Violation,
     find_ignored_lines,
     find_ignored_lines_and_pytriage_comments,
@@ -115,7 +116,7 @@ class ValidateFunctionNameCheck(BaseCheck):
         function_index = index_function_nodes(tree)
 
         violations = []
-        suppression_usages = []
+        suppression_usages: list[SuppressionUsage] = []
         if collect_suppression_usage:
             for suggestion in all_suggestions:
                 record_suppression_usage_if_ignored(

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -43,6 +43,7 @@ from pre_commit_hooks.ast_checks._base import (
     FixResult,
     FixValidationError,
     Violation,
+    find_ignored_lines,
     find_ignored_lines_and_pytriage_comments,
     find_suppression_usage,
 )
@@ -88,23 +89,41 @@ class ValidateFunctionNameCheck(BaseCheck):
         return ["def get_"]
 
     def check(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(filepath, tree, source, collect_suppression_usage=False)
+
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(filepath, tree, source, collect_suppression_usage=True)
+
+    def _check(self, filepath: Path, tree: ast.Module, source: str, *, collect_suppression_usage: bool) -> CheckResult:
         # Reuse the orchestrator's already-parsed tree/source instead of
         # re-reading and re-parsing the file (see analysis.process_file for
         # the standalone equivalent used by tests).
-        ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
+        if collect_suppression_usage:
+            ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
+                source, IGNORE_PATTERN
+            )
+        else:
+            ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+            format_suppressed = set()
+            comments = ()
         suggestions = collect_suggestions(filepath, tree, source, ignored_lines)
-        all_suggestions = collect_suggestions(filepath, tree, source, set()) if ignored_lines else suggestions
+        all_suggestions = (
+            collect_suggestions(filepath, tree, source, set())
+            if collect_suppression_usage and ignored_lines
+            else suggestions
+        )
         function_index = index_function_nodes(tree)
 
         violations = []
         suppression_usages = []
-        for suggestion in all_suggestions:
-            if suggestion.lineno in ignored_lines:
-                usage = find_suppression_usage(
-                    comments, format_suppressed, self.check_id, self.error_code, (suggestion.lineno,)
-                )
-                if usage is not None:
-                    suppression_usages.append(usage)
+        if collect_suppression_usage:
+            for suggestion in all_suggestions:
+                if suggestion.lineno in ignored_lines:
+                    usage = find_suppression_usage(
+                        comments, format_suppressed, self.check_id, self.error_code, (suggestion.lineno,)
+                    )
+                    if usage is not None:
+                        suppression_usages.append(usage)
         for suggestion in suggestions:
             auto_fixable = not suggestion.requires_property and is_autofix_safe(function_index, suggestion)
             reference_status = _repository_reference_status(filepath, suggestion.func_name) if auto_fixable else "safe"

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -96,9 +96,6 @@ class ValidateFunctionNameCheck(BaseCheck):
         return self._check(filepath, tree, source, collect_suppression_usage=True)
 
     def _check(self, filepath: Path, tree: ast.Module, source: str, *, collect_suppression_usage: bool) -> CheckResult:
-        # Reuse the orchestrator's already-parsed tree/source instead of
-        # re-reading and re-parsing the file (see analysis.process_file for
-        # the standalone equivalent used by tests).
         if collect_suppression_usage:
             ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
                 source, IGNORE_PATTERN
@@ -121,9 +118,9 @@ class ValidateFunctionNameCheck(BaseCheck):
             for suggestion in all_suggestions:
                 record_suppression_usage_if_ignored(
                     suppression_usages,
-                    ignored_lines,
                     comments,
-                    format_suppressed,
+                    ignored_lines=ignored_lines,
+                    format_suppressed=format_suppressed,
                     check_id=self.check_id,
                     error_code=self.error_code,
                     candidate_lines=(suggestion.lineno,),

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -37,14 +37,17 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from pre_commit_hooks.ast_checks._base import (
     BaseCheck,
+    CheckResult,
     ConcurrentModificationError,
     FixOutcome,
     FixResult,
     FixValidationError,
     Violation,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
 )
 
-from .analysis import Suggestion, collect_suggestions
+from .analysis import IGNORE_PATTERN, Suggestion, collect_suggestions
 from .autofix import (
     _repository_reference_status,
     apply_fix,
@@ -84,14 +87,24 @@ class ValidateFunctionNameCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["def get_"]
 
-    def check(self, filepath: Path, tree: ast.Module, source: str) -> list[Violation]:
+    def check(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         # Reuse the orchestrator's already-parsed tree/source instead of
         # re-reading and re-parsing the file (see analysis.process_file for
         # the standalone equivalent used by tests).
-        suggestions = collect_suggestions(filepath, tree, source)
+        ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
+        suggestions = collect_suggestions(filepath, tree, source, ignored_lines)
+        all_suggestions = collect_suggestions(filepath, tree, source, set())
         function_index = index_function_nodes(tree)
 
         violations = []
+        suppression_usages = []
+        for suggestion in all_suggestions:
+            if suggestion.lineno in ignored_lines:
+                usage = find_suppression_usage(
+                    comments, format_suppressed, self.check_id, self.error_code, (suggestion.lineno,)
+                )
+                if usage is not None:
+                    suppression_usages.append(usage)
         for suggestion in suggestions:
             auto_fixable = not suggestion.requires_property and is_autofix_safe(function_index, suggestion)
             reference_status = _repository_reference_status(filepath, suggestion.func_name) if auto_fixable else "safe"
@@ -126,7 +139,7 @@ class ValidateFunctionNameCheck(BaseCheck):
                 )
             )
 
-        return violations
+        return CheckResult(violations, suppression_usages)
 
     def fix(
         self,

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/__init__.py
@@ -93,7 +93,7 @@ class ValidateFunctionNameCheck(BaseCheck):
         # the standalone equivalent used by tests).
         ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
         suggestions = collect_suggestions(filepath, tree, source, ignored_lines)
-        all_suggestions = collect_suggestions(filepath, tree, source, set())
+        all_suggestions = collect_suggestions(filepath, tree, source, set()) if ignored_lines else suggestions
         function_index = index_function_nodes(tree)
 
         violations = []

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
@@ -677,7 +677,9 @@ def process_file(filepath: Path) -> list[Suggestion]:
     return collect_suggestions(filepath, tree, source)
 
 
-def collect_suggestions(filepath: Path, tree: ast.Module, source: str) -> list[Suggestion]:
+def collect_suggestions(
+    filepath: Path, tree: ast.Module, source: str, ignored_lines: set[int] | None = None
+) -> list[Suggestion]:
     """`filepath` is used only to tag returned Suggestions; `tree` must already be parsed from `source`."""
     attach_parents(tree)
 
@@ -693,7 +695,8 @@ def collect_suggestions(filepath: Path, tree: ast.Module, source: str) -> list[S
         # See ADR-0040.
         return []
 
-    ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+    if ignored_lines is None:
+        ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
     suggestions: list[Suggestion] = []
 
     for node in candidates:

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -85,6 +85,15 @@ def test_check_records_a_pytriage_usage() -> None:
     ]
 
 
+def test_check_records_a_pytriage_usage_on_the_assignment_line() -> None:
+    source = 'def example():\n    x = "foo"  # pytriage: TR5\n    func(x=x)\n'
+
+    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [2]
+
+
 def test_check_records_each_suppressed_pytriage_usage() -> None:
     source = (
         'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # pytriage: TR5\n'

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import ast
+from pathlib import Path
 
 import pytest
 
@@ -8,9 +9,6 @@ from pre_commit_hooks.ast_checks._orchestrator import CheckOrchestrator
 from pre_commit_hooks.ast_checks.redundant_assignment import RedundantAssignmentCheck
 from pre_commit_hooks.ast_checks.redundant_assignment.semantic import AggressivenessLevel
 from tests.redundant_assignment._helpers import _check
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_check_id_and_error_code() -> None:
@@ -74,6 +72,39 @@ def load_config():
 )
 def test_check_does_not_report_assignments_protected_by_try_handlers(source: str) -> None:
     assert _check(source, level=AggressivenessLevel.PERMISSIVE) == []
+
+
+def test_check_records_a_pytriage_usage() -> None:
+    source = 'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n'
+
+    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("redundant-assignment", "TR5", 3)
+    ]
+
+
+def test_check_records_each_suppressed_pytriage_usage() -> None:
+    source = (
+        'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # pytriage: TR5\n'
+    )
+
+    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3, 5]
+
+
+def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
+    source = (
+        'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # fmt: skip\n'
+    )
+
+    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3]
 
 
 @pytest.mark.parametrize(

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -106,26 +106,23 @@ async def example():
     assert check_result.suppression_usages == ()
 
 
-def test_check_records_each_suppressed_pytriage_usage() -> None:
+@pytest.mark.parametrize(
+    ("second_comment", "expected_lines"),
+    [("# pytriage: TR5", [3, 5]), ("# fmt: skip", [3])],
+    ids=["pytriage", "format-suppressed"],
+)
+def test_check_records_suppression_usage_for_each_reportable_candidate(
+    second_comment: str, expected_lines: list[int]
+) -> None:
     source = (
-        'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # pytriage: TR5\n'
+        'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n'
+        f'    y = "bar"\n    func(y=y)  {second_comment}\n'
     )
 
     check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
 
     assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3, 5]
-
-
-def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
-    source = (
-        'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # fmt: skip\n'
-    )
-
-    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3]
+    assert [usage.line for usage in check_result.suppression_usages] == expected_lines
 
 
 @pytest.mark.parametrize(

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -91,6 +91,21 @@ def test_check_records_a_pytriage_usage(source: str, expected_line: int) -> None
     ]
 
 
+def test_check_does_not_record_a_non_reportable_assignment_suppression() -> None:
+    source = """
+async def example():
+    value = await get_value()  # pytriage: TR5
+    return value
+"""
+
+    check_result = RedundantAssignmentCheck(level=AggressivenessLevel.PERMISSIVE).check(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert check_result == []
+    assert check_result.suppression_usages == ()
+
+
 def test_check_records_each_suppressed_pytriage_usage() -> None:
     source = (
         'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n    y = "bar"\n    func(y=y)  # pytriage: TR5\n'

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -125,6 +125,21 @@ def test_check_records_suppression_usage_for_each_reportable_candidate(
     assert [usage.line for usage in check_result.suppression_usages] == expected_lines
 
 
+def test_check_does_not_record_assignment_suppression_for_a_format_suppressed_use() -> None:
+    source = """
+def example():
+    value = "foo"  # pytriage: TR5
+    # fmt: off
+    func(value=value)
+    # fmt: on
+"""
+
+    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert check_result.suppression_usages == ()
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -74,24 +74,21 @@ def test_check_does_not_report_assignments_protected_by_try_handlers(source: str
     assert _check(source, level=AggressivenessLevel.PERMISSIVE) == []
 
 
-def test_check_records_a_pytriage_usage() -> None:
-    source = 'def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n'
-
+@pytest.mark.parametrize(
+    ("source", "expected_line"),
+    [
+        ('def example():\n    x = "foo"\n    func(x=x)  # pytriage: TR5\n', 3),
+        ('def example():\n    x = "foo"  # pytriage: TR5\n    func(x=x)\n', 2),
+    ],
+    ids=["use", "assignment"],
+)
+def test_check_records_a_pytriage_usage(source: str, expected_line: int) -> None:
     check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
 
     assert check_result == []
     assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
-        ("redundant-assignment", "TR5", 3)
+        ("redundant-assignment", "TR5", expected_line)
     ]
-
-
-def test_check_records_a_pytriage_usage_on_the_assignment_line() -> None:
-    source = 'def example():\n    x = "foo"  # pytriage: TR5\n    func(x=x)\n'
-
-    check_result = RedundantAssignmentCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [2]
 
 
 def test_check_records_each_suppressed_pytriage_usage() -> None:

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -180,6 +180,62 @@ def test_check_honors_pytriage_inline_ignore(monkeypatch: pytest.MonkeyPatch) ->
     assert session.opened_content == []
 
 
+def test_tracking_check_records_a_pytriage_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = "y = str(x)  # pytriage: TR6\n"
+    session = FakeSession(
+        diagnostics_by_content={source: frozenset(), "y = x  # pytriage: TR6\n": frozenset()},
+        hover_by_position={(0, 8): "str"},
+    )
+    _patch_session(monkeypatch, session)
+
+    check_result = RedundantTypeConversionCheck().check_with_suppression_tracking(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert check_result == []
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("redundant-type-conversion", "TR6", 1)
+    ]
+
+
+def test_tracking_check_records_each_pytriage_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = "y = str(x)  # pytriage: TR6\nz = int(a)  # pytriage: TR6\n"
+    session = FakeSession(
+        diagnostics_by_content={
+            source: frozenset(),
+            "y = x  # pytriage: TR6\nz = int(a)  # pytriage: TR6\n": frozenset(),
+            "y = str(x)  # pytriage: TR6\nz = a  # pytriage: TR6\n": frozenset(),
+        },
+        hover_by_position={(0, 8): "str", (1, 8): "int"},
+    )
+    _patch_session(monkeypatch, session)
+
+    check_result = RedundantTypeConversionCheck().check_with_suppression_tracking(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [1, 2]
+
+
+def test_tracking_check_handles_cached_format_suppressed_redundancies(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = "y = str(x)  # pytriage: TR6\n# fmt: off\nz = int(a)\n# fmt: on\nw = bool(value)\n"
+    session = FakeSession(diagnostics_by_content={}, hover_by_position={})
+    session._redundancies_by_content[(source, "CONSERVATIVE")] = [
+        ("str", 1, 8, "str"),
+        ("int", 3, 8, "int"),
+        ("bool", 5, 8, "bool"),
+    ]
+    _patch_session(monkeypatch, session)
+    check = RedundantTypeConversionCheck()
+
+    tracked = check.check_with_suppression_tracking(Path("test.py"), ast.parse(source), source)
+    direct = check.check(Path("test.py"), ast.parse(source), source)
+
+    assert [usage.line for usage in tracked.suppression_usages] == [1]
+    assert [violation.line for violation in direct] == [5]
+
+
 @pytest.mark.parametrize(
     "comment",
     ["# type: ignore", "# pyright: ignore", "# pyright: ignore[reportArgumentType]", "# ty: ignore", "# TY: IGNORE"],

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 from typing import NoReturn
 
 import pytest
@@ -198,6 +199,41 @@ def test_tracking_check_records_a_pytriage_usage(monkeypatch: pytest.MonkeyPatch
     ]
 
 
+def test_tracking_check_does_not_reuse_normal_analysis_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = "y = str(x)  # pytriage: TR6\nz = int(value)\n"
+    session = FakeSession(diagnostics_by_content={}, hover_by_position={})
+    _patch_session(monkeypatch, session)
+    ignored_lines_seen: list[set[int]] = []
+
+    def decide(
+        _session: object,
+        _filepath: Path,
+        _candidates: object,
+        _source: str,
+        *,
+        level: object,
+        ignored_lines: set[int],
+    ) -> list[SimpleNamespace]:
+        assert level is not None
+        ignored_lines_seen.append(ignored_lines)
+        return [
+            SimpleNamespace(candidate=SimpleNamespace(constructor="str"), line=1, col=4, argument_type="str"),
+            SimpleNamespace(candidate=SimpleNamespace(constructor="int"), line=2, col=4, argument_type="int"),
+        ]
+
+    monkeypatch.setattr(tri006_module, "decide_candidates", decide)
+    check = RedundantTypeConversionCheck()
+
+    assert check.check(Path("test.py"), ast.parse(source), source)[0].line == 2
+    tracked = check.check_with_suppression_tracking(Path("test.py"), ast.parse(source), source)
+
+    assert ignored_lines_seen == [{1}, set()]
+    assert [usage.line for usage in tracked.suppression_usages] == [1]
+    assert [violation.line for violation in tracked] == [2]
+
+
 def test_tracking_check_records_each_pytriage_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     source = "y = str(x)  # pytriage: TR6\nz = int(a)  # pytriage: TR6\n"
     session = FakeSession(
@@ -221,11 +257,13 @@ def test_tracking_check_records_each_pytriage_usage(monkeypatch: pytest.MonkeyPa
 def test_tracking_check_handles_cached_format_suppressed_redundancies(monkeypatch: pytest.MonkeyPatch) -> None:
     source = "y = str(x)  # pytriage: TR6\n# fmt: off\nz = int(a)\n# fmt: on\nw = bool(value)\n"
     session = FakeSession(diagnostics_by_content={}, hover_by_position={})
-    session._redundancies_by_content[(source, "CONSERVATIVE")] = [
+    redundancies = [
         ("str", 1, 8, "str"),
         ("int", 3, 8, "int"),
         ("bool", 5, 8, "bool"),
     ]
+    session._redundancies_by_content[(source, "CONSERVATIVE:normal")] = redundancies
+    session._redundancies_by_content[(source, "CONSERVATIVE:tracking")] = redundancies
     _patch_session(monkeypatch, session)
     check = RedundantTypeConversionCheck()
 

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -262,13 +262,14 @@ def test_tracking_check_handles_cached_format_suppressed_redundancies(monkeypatc
         ("int", 3, 8, "int"),
         ("bool", 5, 8, "bool"),
     ]
-    session._redundancies_by_content[(source, "CONSERVATIVE:normal")] = redundancies
-    session._redundancies_by_content[(source, "CONSERVATIVE:tracking")] = redundancies
+    filepath = Path("test.py")
+    session.cache_redundancies(filepath, source, "CONSERVATIVE:normal", redundancies)
+    session.cache_redundancies(filepath, source, "CONSERVATIVE:tracking", redundancies)
     _patch_session(monkeypatch, session)
     check = RedundantTypeConversionCheck()
 
-    tracked = check.check_with_suppression_tracking(Path("test.py"), ast.parse(source), source)
-    direct = check.check(Path("test.py"), ast.parse(source), source)
+    tracked = check.check_with_suppression_tracking(filepath, ast.parse(source), source)
+    direct = check.check(filepath, ast.parse(source), source)
 
     assert [usage.line for usage in tracked.suppression_usages] == [1]
     assert [violation.line for violation in direct] == [5]

--- a/tests/redundant_type_conversion/test_check.py
+++ b/tests/redundant_type_conversion/test_check.py
@@ -213,10 +213,9 @@ def test_tracking_check_does_not_reuse_normal_analysis_cache(
         _candidates: object,
         _source: str,
         *,
-        level: object,
+        level: object,  # noqa: ARG001
         ignored_lines: set[int],
     ) -> list[SimpleNamespace]:
-        assert level is not None
         ignored_lines_seen.append(ignored_lines)
         return [
             SimpleNamespace(candidate=SimpleNamespace(constructor="str"), line=1, col=4, argument_type="str"),
@@ -263,8 +262,18 @@ def test_tracking_check_handles_cached_format_suppressed_redundancies(monkeypatc
         ("bool", 5, 8, "bool"),
     ]
     filepath = Path("test.py")
-    session.cache_redundancies(filepath, source, "CONSERVATIVE:normal", redundancies)
-    session.cache_redundancies(filepath, source, "CONSERVATIVE:tracking", redundancies)
+    session.cache_redundancies(
+        filepath,
+        source,
+        tri006_module._cache_key(ConfidenceLevel.CONSERVATIVE, collect_suppression_usage=False),
+        redundancies,
+    )
+    session.cache_redundancies(
+        filepath,
+        source,
+        tri006_module._cache_key(ConfidenceLevel.CONSERVATIVE, collect_suppression_usage=True),
+        redundancies,
+    )
     _patch_session(monkeypatch, session)
     check = RedundantTypeConversionCheck()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,6 +13,7 @@ from pre_commit_hooks.ast_checks._base import (
     FixResult,
     FixValidationError,
     PytriageComment,
+    SuppressionUsage,
     atomic_write_text,
     byte_col_to_char_col,
     classify_comment_lines,
@@ -238,7 +239,7 @@ def test_find_suppression_usage_excludes_format_suppressed_comments() -> None:
 
 
 def test_record_suppression_usage_skips_a_nonmatching_comment() -> None:
-    suppression_usages = []
+    suppression_usages: list[SuppressionUsage] = []
     comment = PytriageComment(line=2, col=0, codes=("TR1",))
 
     assert record_suppression_usage_if_ignored(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,6 +25,7 @@ from pre_commit_hooks.ast_checks._base import (
     ignored_lines_from_tokens,
     line_terminator,
     normalize_for_tokenize,
+    record_suppression_usage_if_ignored,
     split_lines_like_ast,
     tokenize_source,
 )
@@ -234,6 +235,22 @@ def test_find_suppression_usage_excludes_format_suppressed_comments() -> None:
     comment = PytriageComment(line=2, col=0, codes=("TR1",))
 
     assert find_suppression_usage((comment,), {2}, "meaningless-vars", "TR1", (2,)) is None
+
+
+def test_record_suppression_usage_skips_a_nonmatching_comment() -> None:
+    suppression_usages = []
+    comment = PytriageComment(line=2, col=0, codes=("TR1",))
+
+    assert record_suppression_usage_if_ignored(
+        suppression_usages,
+        (comment,),
+        ignored_lines={2},
+        format_suppressed=set(),
+        check_id="meaningless-vars",
+        error_code="TR2",
+        candidate_lines=(2,),
+    )
+    assert suppression_usages == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,12 +12,15 @@ from pre_commit_hooks.ast_checks._base import (
     FixOutcome,
     FixResult,
     FixValidationError,
+    PytriageComment,
     atomic_write_text,
     byte_col_to_char_col,
     classify_comment_lines,
     fast_get_source_segment,
     find_ignored_lines,
     find_ignored_lines_and_classify_comments,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
     ignore_pattern_for,
     ignored_lines_from_tokens,
     line_terminator,
@@ -217,6 +220,20 @@ def test_find_ignored_lines_on_cr_only_source() -> None:
 )
 def test_ignore_pattern_for_comma_separated_codes(comment: str, code: str, expected: bool) -> None:
     assert bool(find_ignored_lines(f"x = 1  {comment}\n", ignore_pattern_for(code))) is expected
+
+
+def test_pytriage_comment_parser_ignores_an_empty_comment() -> None:
+    ignored, format_suppressed, comments = find_ignored_lines_and_pytriage_comments("x = 1  # pytriage:\n")
+
+    assert ignored == set()
+    assert format_suppressed == set()
+    assert comments == ()
+
+
+def test_find_suppression_usage_excludes_format_suppressed_comments() -> None:
+    comment = PytriageComment(line=2, col=0, codes=("TR1",))
+
+    assert find_suppression_usage((comment,), {2}, "meaningless-vars", "TR1", (2,)) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
     from pre_commit_hooks.ast_checks import ASTCheck
-    from pre_commit_hooks.ast_checks._base import Violation
+    from pre_commit_hooks.ast_checks._base import SuppressionUsage, Violation
 
 
 @pytest.fixture(autouse=True)
@@ -108,10 +108,19 @@ def test_real_sigterm_mid_run_stops_gracefully_without_leftover_temp_files(
         checks: list[ASTCheck],
         *,
         record_only: Sequence[ASTCheck] = (),
+        prior_suppression_usages: tuple[SuppressionUsage, ...] = (),
+        prior_active_error_codes: frozenset[str] = frozenset(),
     ) -> list[Violation] | None:
         nonlocal calls
         calls += 1
-        violations = original_check_file(self, filepath, checks, record_only=record_only)
+        violations = original_check_file(
+            self,
+            filepath,
+            checks,
+            record_only=record_only,
+            prior_suppression_usages=prior_suppression_usages,
+            prior_active_error_codes=prior_active_error_codes,
+        )
         if calls == 3:
             os.kill(os.getpid(), signal.SIGTERM)
         return violations

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -421,12 +421,21 @@ def test_check_reports_violation_count(source: str, count: int) -> None:
     assert len(violations) == count
 
 
-def test_check_records_each_suppressed_pytriage_usage() -> None:
-    source = """
+@pytest.mark.parametrize(
+    ("second_fragment", "expected_lines"),
+    [
+        ("    result = None  # pytriage: TR1\n", [3, 4]),
+        ("    # fmt: off\n    result = None\n    # fmt: on\n", [3]),
+    ],
+    ids=["pytriage", "format-suppressed"],
+)
+def test_check_records_suppression_usage_for_each_reportable_candidate(
+    second_fragment: str, expected_lines: list[int]
+) -> None:
+    source = f"""
 def process():
-    data = {}  # pytriage: TR1
-    result = None  # pytriage: TR1
-    return data, result
+    data = {{}}  # pytriage: TR1
+{second_fragment}    return data, result
 """
 
     check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check_with_suppression_tracking(
@@ -434,25 +443,7 @@ def process():
     )
 
     assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3, 4]
-
-
-def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
-    source = """
-def process():
-    data = {}  # pytriage: TR1
-    # fmt: off
-    result = None
-    # fmt: on
-    return data, result
-"""
-
-    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check_with_suppression_tracking(
-        Path("test.py"), ast.parse(source), source
-    )
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3]
+    assert [usage.line for usage in check_result.suppression_usages] == expected_lines
 
 
 def test_multiple_meaningless_names() -> None:

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -429,7 +429,7 @@ def process():
     return data, result
 """
 
-    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check(
+    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check_with_suppression_tracking(
         Path("test.py"), ast.parse(source), source
     )
 
@@ -447,7 +447,7 @@ def process():
     return data, result
 """
 
-    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check(
+    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check_with_suppression_tracking(
         Path("test.py"), ast.parse(source), source
     )
 

--- a/tests/test_meaningless_vars.py
+++ b/tests/test_meaningless_vars.py
@@ -421,6 +421,40 @@ def test_check_reports_violation_count(source: str, count: int) -> None:
     assert len(violations) == count
 
 
+def test_check_records_each_suppressed_pytriage_usage() -> None:
+    source = """
+def process():
+    data = {}  # pytriage: TR1
+    result = None  # pytriage: TR1
+    return data, result
+"""
+
+    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3, 4]
+
+
+def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
+    source = """
+def process():
+    data = {}  # pytriage: TR1
+    # fmt: off
+    result = None
+    # fmt: on
+    return data, result
+"""
+
+    check_result = MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE).check(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3]
+
+
 def test_multiple_meaningless_names() -> None:
     source = """
 def process():

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -69,24 +69,23 @@ def test_check_records_a_pytriage_usage() -> None:
     ]
 
 
-def test_check_records_each_suppressed_pytriage_usage() -> None:
-    source = "first = func(\n    arg\n)  # pytriage: TR7\nsecond = func(\n    arg\n)  # pytriage: TR7\n"
+@pytest.mark.parametrize(
+    ("second_fragment", "expected_lines"),
+    [
+        ("second = func(\n    arg\n)  # pytriage: TR7\n", [3, 6]),
+        ("# fmt: off\nsecond = func(\n    arg\n)  # comment\n# fmt: on\n", [3]),
+    ],
+    ids=["pytriage", "format-suppressed"],
+)
+def test_check_records_suppression_usage_for_each_reportable_candidate(
+    second_fragment: str, expected_lines: list[int]
+) -> None:
+    source = f"first = func(\n    arg\n)  # pytriage: TR7\n{second_fragment}"
 
     check_result = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
 
     assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3, 6]
-
-
-def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
-    source = (
-        "first = func(\n    arg\n)  # pytriage: TR7\n# fmt: off\nsecond = func(\n    arg\n)  # comment\n# fmt: on\n"
-    )
-
-    check_result = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [3]
+    assert [usage.line for usage in check_result.suppression_usages] == expected_lines
 
 
 @pytest.mark.parametrize(

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -58,6 +58,37 @@ def test_check_returns_no_violations(source: str) -> None:
     assert MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source) == []
 
 
+def test_check_records_a_pytriage_usage() -> None:
+    source = "result = func(\n    arg\n)  # Comment  # pytriage: TR7\n"
+
+    check_result = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("misplaced-comment", "TR7", 3)
+    ]
+
+
+def test_check_records_each_suppressed_pytriage_usage() -> None:
+    source = "first = func(\n    arg\n)  # pytriage: TR7\nsecond = func(\n    arg\n)  # pytriage: TR7\n"
+
+    check_result = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3, 6]
+
+
+def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
+    source = (
+        "first = func(\n    arg\n)  # pytriage: TR7\n# fmt: off\nsecond = func(\n    arg\n)  # comment\n# fmt: on\n"
+    )
+
+    check_result = MisplacedCommentCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [3]
+
+
 @pytest.mark.parametrize(
     ("source", "expected_source", "expected_exit_code"),
     [

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -11,7 +11,7 @@ import time
 import types
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, cast
 from unittest import mock
 
 import pytest
@@ -329,9 +329,9 @@ def test_expand_directories_caps_gitignore_warning_at_a_bounded_number_of_paths(
 
 
 def _patch_status_popen(monkeypatch: pytest.MonkeyPatch, status_command: list[str] | None) -> None:
-    real_popen = subprocess.Popen
+    real_popen = cast("Callable[..., subprocess.Popen[bytes]]", subprocess.Popen)
 
-    def fake_popen(cmd: list[str], *args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
+    def fake_popen(cmd: list[str], *args: object, **kwargs: object) -> subprocess.Popen[bytes]:
         if "status" in cmd:
             if status_command is None:
                 raise FileNotFoundError("git not found")
@@ -1821,7 +1821,7 @@ def test_process_files_records_an_unavailable_direct_input_check(tmp_path: Path)
 def test_drain_cross_file_candidates_skips_an_unresolvable_extra_path(tmp_path: Path) -> None:
 
     class _UnresolvablePath(Path):
-        def resolve(self, _strict: bool = False) -> NoReturn:
+        def resolve(self, _strict: bool = False) -> NoReturn:  # noqa: FBT002 -- matches Path.resolve()'s own signature
             msg = "simulated resolve failure"
             raise OSError(msg)
 
@@ -1847,7 +1847,7 @@ def test_drain_cross_file_candidates_skips_an_unresolvable_direct_path(
     monkeypatch.setattr(CheckOrchestrator, "_process_single_file", lambda *_args: [])
     real_resolve = Path.resolve
 
-    def resolve(filepath: Path, strict: bool = False) -> Path:
+    def resolve(filepath: Path, strict: bool = False) -> Path:  # noqa: FBT002
         if filepath == main_file:
             msg = "simulated resolve failure"
             raise OSError(msg)
@@ -4090,14 +4090,14 @@ def test_main_handles_path_containing_spaces_and_unicode(
         encoding="utf-8",
     )
 
-    real_run = subprocess.run
+    real_run = cast("Callable[..., subprocess.CompletedProcess[str]]", subprocess.run)
 
     grep_commands: list[list[str]] = []
     grep_results: list[subprocess.CompletedProcess[str]] = []
 
-    def _spy_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def _spy_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         completed_process = real_run(*args, **kwargs)
-        grep_commands.append(args[0])
+        grep_commands.append(cast("list[str]", args[0]))
         grep_results.append(completed_process)
         return completed_process
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -24,6 +24,7 @@ from pre_commit_hooks._filelock import locked
 from pre_commit_hooks._lsp import LSPError
 from pre_commit_hooks.ast_checks import ALL_CHECKS, _cli, _discovery, _orchestrator
 from pre_commit_hooks.ast_checks._base import (
+    BaseCheck,
     CheckUnavailableError,
     FixOutcome,
     FixResult,
@@ -1633,7 +1634,7 @@ def test_process_files_a_sibling_hook_names_own_write_does_not_serve_a_stale_ent
     assert rechecked_a.process_files([str(filepath)]) == {}
 
 
-class _AlwaysRerunProbeCheck:
+class _AlwaysRerunProbeCheck(BaseCheck):
     """Minimal `ASTCheck` double with `cacheable = False`, for exercising
     `CheckOrchestrator`'s always-rerun split independent of any real
     check's own implementation (e.g. `redundant-type-conversion`, which

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3725,7 +3725,7 @@ def test_load_checks_ignore_set_skips_matching_check() -> None:
     checks = load_checks(ignore={"meaningless-vars"})
     check_ids = {c.check_id for c in checks}
     assert "meaningless-vars" not in check_ids
-    assert len(check_ids) == len(ALL_CHECKS) - 1
+    assert len(check_ids) == len(ALL_CHECKS) - 2
 
 
 def test_load_checks_ignore_composes_with_select() -> None:
@@ -3785,7 +3785,7 @@ def test_load_checks_skips_check_whose_init_raises(
 
     monkeypatch.setattr(_orchestrator, "ALL_CHECKS", [*ALL_CHECKS, BrokenCheck])
 
-    assert len(load_checks()) == len(ALL_CHECKS)
+    assert len(load_checks()) == len(ALL_CHECKS) - 1
 
 
 def test_load_checks_skips_check_when_custom_args_raise() -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -67,12 +67,10 @@ class _Response:
 
 def _exec_module(source: str) -> dict[str, Any]:
     namespace: dict[str, Any] = {}
-    exec(compile(source, "<orchestrator-fixture>", "exec", dont_inherit=True), namespace)  # noqa: S102
+    exec(compile(source, "<orchestrator-fixture>", "exec", dont_inherit=True), namespace)
     return namespace
 
 
-# Every expectation below was measured against `ruff 0.16.1`'s own
-# `exclude` handling before being written down; see ADR-0046.
 @pytest.mark.parametrize(
     ("files", "patterns", "expected"),
     [
@@ -130,8 +128,7 @@ def test_expand_directories_leaves_plain_files_untouched(tmp_path: Path) -> None
 
 
 def test_expand_directories_globs_python_files_outside_a_git_repo(tmp_path: Path) -> None:
-    # No git repo here, so this exercises the rglob fallback rather than
-    # `git ls-files`.
+
     (tmp_path / "pkg").mkdir()
     py_file = tmp_path / "pkg" / "module.py"
     py_file.write_text("x = 1\n")
@@ -141,45 +138,31 @@ def test_expand_directories_globs_python_files_outside_a_git_repo(tmp_path: Path
 
 
 def test_expand_directories_uses_git_ls_files_inside_a_git_repo(tmp_path: Path) -> None:
-    # A directory argument (e.g. `ruff-extra-rules src/`, the
-    # form this project's own dev docs use — see AGENTS.md) must not reach
-    # CheckOrchestrator.process_files() as a single unexpanded path.
-    # Inside a git repo, git grep's own directory pathspec support makes
-    # it recurse and match files *inside* that directory, but those
-    # resolved paths never match the literal directory path in
-    # git_grep_filter's own input map, so every result would be silently
-    # discarded as unresolvable — the run would report zero violations,
-    # exit code 0, having checked nothing.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         tracked = tmp_path / "tracked.py"
         tracked.write_text("x = 1\n")
-        subprocess.run([git, "add", "tracked.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "tracked.py"], check=True, cwd=tmp_path)
 
         assert expand_directories([str(tmp_path)]) == [str(tracked.resolve())]
 
 
 def test_expand_directories_includes_untracked_file_inside_a_git_repo(tmp_path: Path) -> None:
-    # A brand-new file that hasn't been `git add`ed yet must not be
-    # silently dropped from a directory-argument expansion, even though
-    # git_grep_filter already always searches that same file when it's
-    # named explicitly on the CLI instead (ADR 0024's
-    # `--untracked --no-exclude-standard`) — naming the containing
-    # directory must not produce a different, false-clean result for the
-    # identical file.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         tracked = tmp_path / "tracked.py"
         tracked.write_text("x = 1\n")
-        subprocess.run([git, "add", "tracked.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "tracked.py"], check=True, cwd=tmp_path)
 
         untracked = tmp_path / "untracked.py"
         untracked.write_text("y = 1\n")
@@ -190,16 +173,12 @@ def test_expand_directories_includes_untracked_file_inside_a_git_repo(tmp_path: 
 def test_expand_directories_excludes_gitignored_file_but_warns(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # A `.gitignore`d file is still excluded from a directory scan — ADR
-    # 0015's "avoid sweeping in .venv/build artifacts" rationale still
-    # applies — but its exclusion must now be visible (ch. 34/35) rather
-    # than the run silently reporting zero violations for a directory that
-    # actually contains an unexamined `.py` file (#67).
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         (tmp_path / ".gitignore").write_text("ignored.py\n")
         (tmp_path / "ignored.py").write_text("z = 1\n")
@@ -218,7 +197,7 @@ def test_expand_directories_warns_when_ignored_path_streaming_is_unavailable(
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
         monkeypatch.setattr(_discovery, "_CAN_STREAM_IGNORED_STATUS", False)
 
         with caplog.at_level("WARNING"):
@@ -231,15 +210,12 @@ def test_expand_directories_warns_when_ignored_path_streaming_is_unavailable(
 def test_expand_directories_warns_about_an_ignored_directory_with_an_unrecognized_name(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # `git status --ignored` collapses an entirely-ignored directory to one
-    # `!! path/` line without confirming it holds a `.py` file (ADR 0028) --
-    # an arbitrary directory name (not a known packaging/tooling artifact,
-    # ADR 0029) is still reported on that unconfirmed basis.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         (tmp_path / ".gitignore").write_text("vendored/\n")
         vendored = tmp_path / "vendored"
@@ -256,16 +232,12 @@ def test_expand_directories_warns_about_an_ignored_directory_with_an_unrecognize
 def test_expand_directories_does_not_warn_about_known_non_source_directories(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # __pycache__/, *.egg-info/, and .cache/ get created by this
-    # project's own routine `pytest`/`build`/`uv sync` commands (see ADR
-    # 0029), so warning about them unconditionally would fire on
-    # essentially every directory-argument run -- none of them is ever
-    # used for hand-written source, so all are excluded from this warning.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         (tmp_path / ".gitignore").write_text("__pycache__/\n*.egg-info/\n.cache/\n")
 
@@ -291,18 +263,12 @@ def test_expand_directories_does_not_warn_about_known_non_source_directories(
 def test_expand_directories_does_not_warn_about_ruff_cache_even_though_its_own_gitignore_is_nested(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Unlike __pycache__/.cache/etc. (see ADR 0029), `.ruff_cache`
-    # isn't named in a top-level .gitignore at all -- ruff writes its own
-    # nested `.ruff_cache/.gitignore` containing `*`, which is what makes
-    # `git status --ignored` collapse the directory to a single ignored-
-    # directory line. The denylist match is by directory name alone, so it
-    # must still apply here even though no top-level .gitignore rule names
-    # ".ruff_cache" directly.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         ruff_cache = tmp_path / ".ruff_cache"
         ruff_cache.mkdir()
@@ -319,18 +285,13 @@ def test_expand_directories_does_not_warn_about_ruff_cache_even_though_its_own_g
 def test_expand_directories_warns_about_ignored_file_regardless_of_status_showuntrackedfiles_config(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # `git status`'s own `--ignored` reporting is otherwise
-    # governed by the ambient `status.showUntrackedFiles` config -- "no"
-    # suppresses every `!!` record, silently defeating this warning's whole
-    # purpose for a user who's set that (a real, documented git setting),
-    # so the probe must pin `--untracked-files=normal` explicitly rather
-    # than trust git's own default.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
-        subprocess.run([git, "config", "status.showUntrackedFiles", "no"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
+        subprocess.run([git, "config", "status.showUntrackedFiles", "no"], check=True, cwd=tmp_path)
 
         (tmp_path / ".gitignore").write_text("ignored.py\n")
         (tmp_path / "ignored.py").write_text("z = 1\n")
@@ -345,20 +306,15 @@ def test_expand_directories_warns_about_ignored_file_regardless_of_status_showun
 def test_expand_directories_caps_gitignore_warning_at_a_bounded_number_of_paths(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # A directory that isn't *entirely* ignored (e.g. a
-    # generated/ subtree with one tracked file alongside many individually
-    # -ignored `.py` outputs) can't collapse to a single git-status line --
-    # each ignored path is reported separately. The warning must stay
-    # bounded rather than materializing, sorting, and printing an unbounded
-    # list for a large generated/vendored tree.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         (tmp_path / "README.md").write_text("keep this directory partially tracked\n")
-        subprocess.run([git, "add", "README.md"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "README.md"], check=True, cwd=tmp_path)
 
         num_ignored = 1_000
         (tmp_path / ".gitignore").write_text("".join(f"ignored{i}.py\n" for i in range(num_ignored)))
@@ -375,12 +331,12 @@ def test_expand_directories_caps_gitignore_warning_at_a_bounded_number_of_paths(
 def _patch_status_popen(monkeypatch: pytest.MonkeyPatch, status_command: list[str] | None) -> None:
     real_popen = subprocess.Popen
 
-    def fake_popen(cmd: list[str], *args: object, **kwargs: Any) -> subprocess.Popen[bytes]:  # noqa: ANN401
+    def fake_popen(cmd: list[str], *args: object, **kwargs: Any) -> subprocess.Popen[bytes]:
         if "status" in cmd:
             if status_command is None:
                 raise FileNotFoundError("git not found")
             return real_popen(status_command, **kwargs)
-        return real_popen(cmd, *args, **kwargs)  # type: ignore[call-overload]
+        return real_popen(cmd, *args, **kwargs)
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
 
@@ -389,7 +345,7 @@ def _patch_status_popen(monkeypatch: pytest.MonkeyPatch, status_command: list[st
 def git_repository(tmp_path: Path) -> str:
     git = shutil.which("git")
     assert git is not None
-    subprocess.run([git, "init", "-q"], check=True, cwd=tmp_path)  # noqa: S603
+    subprocess.run([git, "init", "-q"], check=True, cwd=tmp_path)
     return git
 
 
@@ -425,13 +381,7 @@ def test_expand_directories_skips_gitignore_warning_when_git_status_probe_is_unr
     monkeypatch: pytest.MonkeyPatch,
     status_failure: str,
 ) -> None:
-    # Self-healing: if the extra `git status --ignored` probe used to detect
-    # gitignored exclusions worth warning about is itself unreliable --
-    # missing entirely (e.g. git errors or times out), or succeeding with a
-    # per-path stderr error next to incomplete stdout (the same "don't trust
-    # a result alongside stderr" rule git_grep_filter and the primary git
-    # ls-files call both already follow) -- the directory listing must still
-    # succeed; only the warning is skipped, silently.
+
     if status_failure == "timeout":
         monkeypatch.setattr(_discovery, "_GIT_STATUS_TIMEOUT_SECONDS", 0.01)
         monkeypatch.setattr(_discovery, "_PROCESS_STOP_TIMEOUT_SECONDS", 0.01)
@@ -443,7 +393,7 @@ def test_expand_directories_skips_gitignore_warning_when_git_status_probe_is_unr
     with contextlib.chdir(tmp_path):
         tracked = tmp_path / "tracked.py"
         tracked.write_text("x = 1\n")
-        subprocess.run([git_repository, "add", "tracked.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git_repository, "add", "tracked.py"], check=True, cwd=tmp_path)
 
         scripts = {
             "malformed": "import os; os.write(1, b'!! ignored.py')",
@@ -473,7 +423,7 @@ def test_expand_directories_stops_ignored_status_at_the_reporting_threshold(
 ) -> None:
     with contextlib.chdir(tmp_path):
         (tmp_path / "tracked.py").write_text("x = 1\n")
-        subprocess.run([git_repository, "add", "tracked.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git_repository, "add", "tracked.py"], check=True, cwd=tmp_path)
 
         _patch_status_popen(
             monkeypatch, [sys.executable, "-c", "import os\nwhile True:\n os.write(1, b'!! ignored.py\\0')"]
@@ -501,21 +451,16 @@ def test_stop_ignored_status_process_escalates_after_termination_timeout() -> No
 
 
 def test_expand_directories_skips_tracked_file_deleted_from_working_tree(tmp_path: Path) -> None:
-    # `git ls-files` reports the *index*, not the working tree
-    # -- a tracked file removed from disk with a plain `rm` (not `git rm`)
-    # still shows up in its output even though it no longer exists. A
-    # directory scan isn't asking about that specific file by name, so a
-    # stale index entry must be dropped silently rather than surfacing a
-    # fake "could not be read" error for a file the user never named.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         deleted = tmp_path / "deleted.py"
         deleted.write_text("x = 1\n")
-        subprocess.run([git, "add", "deleted.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "deleted.py"], check=True, cwd=tmp_path)
         deleted.unlink()
 
         assert expand_directories([str(tmp_path)]) == []
@@ -524,9 +469,7 @@ def test_expand_directories_skips_tracked_file_deleted_from_working_tree(tmp_pat
 def test_expand_directories_falls_back_when_git_ls_files_fails(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Inside a git repo, but git itself fails (e.g. missing, or the
-    # subprocess times out) — falls back to the plain recursive glob
-    # instead of propagating the failure.
+
     (tmp_path / "pkg").mkdir()
     py_file = tmp_path / "pkg" / "module.py"
     py_file.write_text("x = 1\n")
@@ -536,27 +479,17 @@ def test_expand_directories_falls_back_when_git_ls_files_fails(
         matches = expand_directories([str(tmp_path)])
 
     assert matches == [str(py_file.resolve())]
-    # This is self-healing (falls back to an equivalent glob
-    # scan), so an ERROR-level .exception() call here would leak a raw
-    # traceback onto the user's stderr by default (nothing in this codebase
-    # configures logging, so Python's own lastResort handler prints
-    # WARNING+ straight to stderr) for a condition nothing actually failed
-    # at from the user's perspective.
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
 def test_expand_directories_includes_a_file_with_a_non_utf8_name(tmp_path: Path) -> None:
-    # `git ls-files -z`'s stdout is decoded via `text=True`. A
-    # filename that's a valid path on Linux (paths are just bytes, never
-    # required to be valid UTF-8) but isn't decodable as UTF-8 must not
-    # crash a directory scan that contains it -- `errors="surrogateescape"`
-    # (the same handler `os.fsdecode()` already uses for filesystem paths)
-    # round-trips it back to the identical file on disk instead.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         bad_path_bytes = str(tmp_path).encode() + b"/bad-\xff\xfe.py"
         with Path(os.fsdecode(bad_path_bytes)).open("wb") as f:
@@ -579,11 +512,11 @@ def test_main_directory_argument_checks_files_inside_it(tmp_path: Path, capsys: 
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         filepath = tmp_path / "module.py"
         filepath.write_text("data = 1\n")
-        subprocess.run([git, "add", "module.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "module.py"], check=True, cwd=tmp_path)
 
         exit_code = main([str(tmp_path), "--select", "meaningless-vars", "--meaningless-vars-level", "permissive"])
 
@@ -812,14 +745,12 @@ def test_main_fix_preserves_class_bindings_in_nested_class_headers_and_comprehen
 def test_main_directory_argument_matches_explicit_file_argument_for_untracked_file(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # An untracked file's violation must be reported the same way whether
-    # it's named explicitly or reached by expanding its containing
-    # directory.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         untracked = tmp_path / "untracked.py"
         untracked.write_text("result = 2\n")
@@ -832,17 +763,12 @@ def test_main_directory_argument_matches_explicit_file_argument_for_untracked_fi
 
 
 def test_main_directory_scan_does_not_crash_on_a_file_with_a_non_utf8_name(tmp_path: Path) -> None:
-    # expand_directories() safely includes a file whose name
-    # isn't valid UTF-8 (see test_expand_directories_includes_a_file_with_a_
-    # non_utf8_name), but that file still has to survive _prefilter.py's own
-    # git_grep_filter() call once meaningless-vars' prefilter pattern runs against
-    # it -- that call decodes git grep's stdout the same way, and would
-    # crash right there instead of reporting the violation.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         bad_path_bytes = str(tmp_path).encode() + b"/bad-\xff\xfe.py"
         with Path(os.fsdecode(bad_path_bytes)).open("wb") as f:
@@ -852,11 +778,7 @@ def test_main_directory_scan_does_not_crash_on_a_file_with_a_non_utf8_name(tmp_p
 
 
 def test_process_files_handles_utf8_bom(tmp_path: Path) -> None:
-    # A UTF-8 BOM must not make the orchestrator silently skip the file.
-    # filepath.read_text(encoding="utf-8") decodes a leading BOM as a
-    # literal U+FEFF character, which ast.parse rejects as a syntax error —
-    # reading with utf-8-sig strips it transparently instead (and is
-    # identical to utf-8 for files without one).
+
     filepath = tmp_path / "with_bom.py"
     filepath.write_bytes(b"\xef\xbb\xbfdata = 1\n")
 
@@ -868,10 +790,7 @@ def test_process_files_handles_utf8_bom(tmp_path: Path) -> None:
 
 
 def test_apply_fixes_handles_utf8_bom(tmp_path: Path) -> None:
-    # The re-read before each check's fix() call must also strip a BOM. The
-    # fixed file keeps its original BOM on write (detected encoding is
-    # "utf-8-sig", the same encoding used to write back) — reading it back
-    # with "utf-8-sig" strips it again, same as the original read.
+
     filepath = tmp_path / "with_bom.py"
     filepath.write_bytes(
         b"\xef\xbb\xbfimport requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
@@ -888,14 +807,7 @@ def test_apply_fixes_handles_utf8_bom(tmp_path: Path) -> None:
 
 
 def test_apply_fixes_recomputes_stale_positions(tmp_path: Path) -> None:
-    # A later check's fix() must not use line numbers from before an
-    # earlier check's fix already rewrote the file in the same --fix run.
-    # excessive-blank-lines runs (and fixes) before redundant-assignment in
-    # ALL_CHECKS order. Collapsing the 3 blank lines after the module
-    # docstring down to 2 removes one line, shifting `x = "foo"`/`print(x)`
-    # up by one — so if redundant-assignment's fix() were handed the
-    # violation positions collected before that collapse, it would edit
-    # the wrong (now-shifted) lines and silently fail to inline `x`.
+
     filepath = tmp_path / "stale_positions.py"
     filepath.write_text('"""Module docstring."""\n\n\n\ndef func_scope():\n    x = "foo"\n    print(x)\n')
 
@@ -915,16 +827,7 @@ def test_apply_fixes_recomputes_stale_positions(tmp_path: Path) -> None:
 
 
 def test_apply_fixes_refreshes_non_fixable_checks_position_too(tmp_path: Path) -> None:
-    # only checks that themselves had a fixable violation this
-    # run got their positions recomputed against the file's post-fix state.
-    # redundant-super-init is never fixable (RedundantSuperInitCheck.fix()
-    # always returns False), so it never participated in that loop -- its
-    # reported line stayed frozen at whatever _check_file's original,
-    # pre-fix pass saw. redundant-assignment's own fix deletes a whole
-    # line above it, shifting every subsequent line up by one; the
-    # non-fixable violation's reported line must reflect the file's real,
-    # final line, not the stale pre-fix one (ch. 7: "MUST report line and
-    # column information accurately when available").
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "def compute():\n"
@@ -956,11 +859,7 @@ def test_apply_fixes_refreshes_non_fixable_checks_position_too(tmp_path: Path) -
 def test_apply_fixes_refreshes_non_fixable_checks_position_after_an_aborted_fix(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Same requirement as the successful-fix case above, but the line shift
-    # comes from the external edit that aborts meaningless-vars' own fix,
-    # not from a fix this run itself applied -- the final refresh pass must
-    # not be gated on this run's own fix succeeding, since the file's
-    # content is known to have changed regardless of who changed it.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import requests\n\n\n"
@@ -980,9 +879,7 @@ def test_apply_fixes_refreshes_non_fixable_checks_position_after_an_aborted_fix(
     def racing_fix(
         _self: MeaninglessVarsCheck, fp: Path, _violations: object, source: str, *_args: object, **_kwargs: object
     ) -> None:
-        # Simulate a concurrent process deleting a blank line above the
-        # redundant-super-init violation while this fix was in flight,
-        # shifting it up by one line.
+
         edited = source.replace("return data.status_code\n\n\nclass Base:", "return data.status_code\n\nclass Base:", 1)
         fp.write_text(edited)
         atomic_write_text(
@@ -1008,18 +905,7 @@ def test_apply_fixes_refreshes_non_fixable_checks_position_after_an_aborted_fix(
 
 
 def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tmp_path: Path) -> None:
-    # a check that *did* participate in the fix loop (it had
-    # some fixable violation this run) only had its own positions
-    # recomputed once, immediately before its own fix() call -- a violation
-    # it left open that call (e.g. validate-function-name's should_autofix
-    # guard refusing to touch a method, while still renaming an unrelated
-    # free function in the same fix() call) never got revisited afterward.
-    # redundant-assignment runs *after* validate-function-name in
-    # ALL_CHECKS order and deletes a line above the still-open method
-    # violation, shifting it down by one -- the final reconciliation pass
-    # must catch this even though validate-function-name itself already
-    # ran its own fix() this call (ch. 7: "MUST report line and column
-    # information accurately when available").
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "def get_ready(user: dict) -> bool:\n"
@@ -1039,9 +925,7 @@ def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tm
     violations = orchestrator.process_files([str(filepath)])
 
     final_content = filepath.read_text()
-    # The free function was renamed; the method (never auto-fixed, per
-    # should_autofix's own "methods are never auto-fixed" rule) was left
-    # open, and the redundant assignment above it was inlined away.
+
     assert "is_ready" in final_content
     assert "def get_active(self)" in final_content
     assert "x = 1" not in final_content
@@ -1059,23 +943,12 @@ def test_apply_fixes_refreshes_a_participating_checks_own_left_open_violation(tm
 def test_refresh_stale_positions_never_drops_an_unrelated_open_violation_sharing_a_check_id_with_a_terminal_one(
     tmp_path: Path,
 ) -> None:
-    # a check_id with a rejected/errored/failed entry must be
-    # skipped entirely by the reconciliation pass, not just have that one
-    # terminal entry protected -- a fresh check() call has no reliable way
-    # to distinguish "this is the same still-present violation as the
-    # terminal one" from "this is a different, unrelated violation that
-    # merely happens to share message text with it" (e.g. two identically
-    # named functions in different scopes) without a stable per-violation
-    # identity this codebase doesn't have (ch. 34: "MUST prefer a visible
-    # failure over a silent incorrect result"). Filtering the fresh result
-    # by message alone would have silently dropped the unrelated one
-    # instead of just leaving its position stale.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = requests.get(url)\n")
 
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
-    # Same message on purpose -- e.g. two identically-named functions in
-    # different scopes would produce identical violation text.
+
     shared_message = "Meaningless variable name 'data' found. Consider renaming to 'response'."
     terminal = ViolationFactory.build(
         check_id="meaningless-vars", message=shared_message, fixable=True, fix_outcome=FixOutcome.FAILED
@@ -1087,15 +960,11 @@ def test_refresh_stale_positions_never_drops_an_unrelated_open_violation_sharing
 
     orchestrator._refresh_stale_positions(filepath, violations)
 
-    # Both entries survive untouched -- neither was silently dropped.
     assert violations == [terminal, open_violation]
 
 
 def test_refresh_stale_positions_returns_when_final_read_fails(tmp_path: Path) -> None:
-    # The file existed a moment ago (this same _apply_fixes call already
-    # read it successfully), so a failure here means something changed
-    # concurrently -- conservatively leave `violations` untouched rather
-    # than guess.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
@@ -1108,8 +977,7 @@ def test_refresh_stale_positions_returns_when_final_read_fails(tmp_path: Path) -
 
 
 def test_refresh_stale_positions_returns_when_final_parse_fails(tmp_path: Path) -> None:
-    # A syntax error in the file's final state (e.g. an external edit
-    # racing with this run) must not crash the reconciliation pass.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("def broken(:\n")
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
@@ -1123,17 +991,13 @@ def test_refresh_stale_positions_returns_when_final_parse_fails(tmp_path: Path) 
 def test_refresh_stale_positions_records_rule_failure_when_check_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A check crashing during this final reconciliation pass must be
-    # isolated (ch. 5) like every other check failure, not left to crash
-    # the whole run or silently leave the check's own stale entries in
-    # `violations`.
+
     monkeypatch.setattr(MeaninglessVarsCheck, "check", raises(RuntimeError, "simulated check failure"))
 
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
-    # A still-open (unmarked) violation for this check_id, so there's
-    # something for the reconciliation pass to actually attempt refreshing.
+
     stale_violation = ViolationFactory.build(
         check_id="meaningless-vars", fixable=True, fix_data=None, fix_outcome=FixOutcome.DECLINED
     )
@@ -1141,9 +1005,8 @@ def test_refresh_stale_positions_records_rule_failure_when_check_raises(
 
     orchestrator._refresh_stale_positions(filepath, violations)
 
-    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: TR6
-    # Left exactly as it was -- the check crashed before it could report
-    # anything current to replace it with.
+    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures
+
     assert violations == [stale_violation]
 
 
@@ -1188,8 +1051,7 @@ def test_post_fix_verification_declines_an_unconfirmed_applied_outcome(tmp_path:
 
 
 def test_fix_honors_pep263_encoding_declaration(tmp_path: Path) -> None:
-    # A file with a non-UTF-8 PEP 263 encoding cookie must be read, fixed,
-    # and written back in its declared encoding, not assumed to be UTF-8.
+
     source = "# -*- coding: latin-1 -*-\nresult = func(\n    x\n)  # caf\xe9\n"
     filepath = tmp_path / "latin1.py"
     filepath.write_bytes(source.encode("latin-1"))
@@ -1205,7 +1067,7 @@ def test_fix_honors_pep263_encoding_declaration(tmp_path: Path) -> None:
 
 
 def test_fix_preserves_crlf_line_endings(tmp_path: Path) -> None:
-    # Lines untouched by a fix must keep their original CRLF endings.
+
     filepath = tmp_path / "crlf.py"
     filepath.write_bytes(b"result = func(\r\n    x\r\n)  # comment\r\n\r\nother = 1\r\n")
 
@@ -1225,9 +1087,7 @@ def test_process_files_empty_filepaths_returns_empty() -> None:
 
 
 def test_process_files_no_prefilter_pattern_checks_all_files(tmp_path: Path) -> None:
-    # ExcessiveBlankLinesCheck has no prefilter pattern (checks
-    # everything), so with only it enabled, no git-grep pre-filtering
-    # happens at all.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("\n\n\nimport os\n")
 
@@ -1240,8 +1100,7 @@ def test_process_files_no_prefilter_pattern_checks_all_files(tmp_path: Path) -> 
 def test_process_files_no_candidates_after_prefilter_returns_empty(
     tmp_path: Path,
 ) -> None:
-    # A file that doesn't contain any check's prefilter pattern is dropped
-    # before parsing, and produces no entry in the result.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
@@ -1261,12 +1120,7 @@ def test_process_files_no_candidates_after_prefilter_returns_empty(
 def test_process_files_unprocessable_reporting_is_gated_by_prefilter_match(
     tmp_path: Path, check: ASTCheck, expect_unprocessable: bool
 ) -> None:
-    # ADR-0052: whether an invalid-syntax file even reaches _check_file()
-    # -- and so whether it's reported via unprocessable_files at all --
-    # depends on whether some enabled check's own prefilter pattern
-    # matches its content. RedundantSuperInitCheck's own pattern doesn't
-    # match this content; ExcessiveBlankLinesCheck's None pattern parses
-    # (and reports) any content.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("def foo(:\n")
 
@@ -1274,20 +1128,11 @@ def test_process_files_unprocessable_reporting_is_gated_by_prefilter_match(
     violations = orchestrator.process_files([str(filepath)])
 
     assert violations == {}
-    assert orchestrator.unprocessable_files == ([str(filepath)] if expect_unprocessable else [])  # pytriage: TR6
+    assert orchestrator.unprocessable_files == ([filepath.as_posix()] if expect_unprocessable else [])
 
 
 def test_process_files_none_pattern_check_still_sees_a_file_other_checks_patterns_miss(tmp_path: Path) -> None:
-    # Each enabled check's own prefilter pattern must gate that check
-    # individually -- combining them into one OR'd filter before running
-    # any check would drop a file for every check whenever it failed to
-    # match ANY enabled check's pattern, including excessive-blank-lines,
-    # whose own get_prefilter_pattern() returns None (see
-    # test_process_files_no_prefilter_pattern_checks_all_files) precisely
-    # so it sees every file regardless of what else is enabled. This file
-    # has a real excessive-blank-lines violation but contains none of
-    # meaningless-vars' own patterns ("data"/"result"), so a combined
-    # filter would drop it before it was ever parsed.
+
     filepath = tmp_path / "module.py"
     filepath.write_text('"""Doc."""\n\n\n\nclass Foo:\n    pass\n')
 
@@ -1300,12 +1145,7 @@ def test_process_files_none_pattern_check_still_sees_a_file_other_checks_pattern
 def test_process_files_applies_each_checks_prefilter_independently(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A file must only run through a check whose own
-    # prefilter pattern it actually matches -- not through every enabled
-    # check merely because some *other* check's pattern matched. This file
-    # contains meaningless-vars' own pattern ("data") but not
-    # redundant-super-init's ("super().__init__"), so redundant-super-init's
-    # check() must never even be called against it.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -1344,8 +1184,7 @@ def test_process_files_unreadable_file_is_skipped(tmp_path: Path, write_file: Ca
 
 
 def test_process_files_resets_unprocessable_files_between_calls(tmp_path: Path) -> None:
-    # A file that failed to parse on the first call must not keep showing up
-    # as unprocessable on a later call where it isn't even part of the input.
+
     bad_filepath = tmp_path / "bad.py"
     bad_filepath.write_text("def foo(:\n")
     good_filepath = tmp_path / "good.py"
@@ -1353,7 +1192,7 @@ def test_process_files_resets_unprocessable_files_between_calls(tmp_path: Path) 
 
     orchestrator = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck()])
     orchestrator.process_files([str(bad_filepath)])
-    assert orchestrator.unprocessable_files == [str(bad_filepath)]  # pytriage: TR6
+    assert orchestrator.unprocessable_files == [str(bad_filepath)]
 
     orchestrator.process_files([str(good_filepath)])
     assert orchestrator.unprocessable_files == []
@@ -1375,14 +1214,7 @@ def test_process_files_second_call_uses_cache(tmp_path: Path, monkeypatch: pytes
 
 
 def test_cache_hit_and_cache_miss_report_equivalent_violations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # ch. 9: "MUST ensure that cache hits and cache misses produce
-    # equivalent lint results." fix_data is deliberately dropped from the
-    # cached JSON blob (see _cache_violations' own comment, since it may
-    # hold AST nodes) -- report-only mode is the only mode that ever reads
-    # from the cache (fix mode always bypasses it), and report-only mode
-    # never touches fix_data, so every field a printed diagnostic actually
-    # depends on must still match exactly between a fresh check and a
-    # cached one.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("\n\n\ndata = 1\n")
     checks: list[ASTCheck] = [MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE), ExcessiveBlankLinesCheck()]
@@ -1404,8 +1236,7 @@ def test_cache_hit_and_cache_miss_report_equivalent_violations(tmp_path: Path, m
 
 
 def test_process_files_different_check_set_forces_recheck(tmp_path: Path) -> None:
-    # Changing which checks are enabled between runs must invalidate the
-    # cache entry from a previous run with a different check set.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("\n\n\ndata = 1\n")
 
@@ -1424,9 +1255,7 @@ def test_process_files_different_check_set_forces_recheck(tmp_path: Path) -> Non
 def test_generate_cache_version_changes_when_source_tree_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The cache version must change on its own when the hashed source tree
-    # changes, without a developer having to remember to hand-bump
-    # CACHE_VERSION whenever a check's own code changes.
+
     fake_root = tmp_path / "pre_commit_hooks"
     fake_root.mkdir()
     (fake_root / "module.py").write_text("x = 1\n")
@@ -1442,12 +1271,7 @@ def test_generate_cache_version_changes_when_source_tree_changes(
 
 
 def test_generate_cache_version_changes_when_python_version_changes(monkeypatch: pytest.MonkeyPatch) -> None:
-    # ast.parse()'s output for identical source isn't guaranteed stable
-    # across Python minor versions, so a .cache directory shared across an
-    # interpreter upgrade must not silently reuse the old interpreter's
-    # results. Patches the `sys` name binding inside the _orchestrator
-    # module (not the real global sys module) so only
-    # _generate_cache_version() sees a different version.
+
     orchestrator = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
     version_before = orchestrator._generate_cache_version()
 
@@ -1461,13 +1285,7 @@ def test_generate_cache_version_changes_when_python_version_changes(monkeypatch:
 
 
 def test_the_hook_name_changes_when_cacheable_check_config_changes() -> None:
-    # Two orchestrators enabling the same check with different config (e.g.
-    # this repo's own default vs. permissive --meaningless-vars-level hooks)
-    # must get distinct hook_names -- see ADR-0044's hook_name/cache_version
-    # split, which replaces folding the config fingerprint into
-    # cache_version (that approach made two such orchestrators collide on
-    # one file's cache blob, since a version mismatch wipes the whole blob,
-    # not just the mismatched hook_name's own entry).
+
     default = CheckOrchestrator(checks=[MeaninglessVarsCheck()])
     permissive = CheckOrchestrator(checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)])
 
@@ -1496,14 +1314,12 @@ def test_cache_violations_serialization_error_is_caught(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(CacheManager, "set_cached_result", raises(TypeError, "simulated cache backend failure"))
 
-    # Must not raise, just skip caching for this file.
     violations = orchestrator.process_files([str(filepath)])
     assert violations[str(filepath)][0].error_code == "TR1"
 
 
 def test_process_files_check_exception_is_logged_and_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A check that raises must not prevent other checks from running or
-    # crash the whole file's processing.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("\n\n\ndata = 1\n")
 
@@ -1517,11 +1333,7 @@ def test_process_files_check_exception_is_logged_and_skipped(tmp_path: Path, mon
 
 
 def test_process_files_check_exception_records_rule_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A check whose check() raises must not leave no trace at all outside
-    # a debug log line — that would be indistinguishable from that check
-    # having run cleanly and found nothing. If it's the only check
-    # enabled, that would make the whole file (and the whole run) look
-    # completely clean.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -1531,14 +1343,11 @@ def test_process_files_check_exception_records_rule_failure(tmp_path: Path, monk
     violations = orchestrator.process_files([str(filepath)])
 
     assert violations == {}
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]
 
 
 def test_process_files_rule_failure_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A result collected while a check crashed must never be cached: caching
-    # it would let a later run's cache hit keep serving the crash's "empty"
-    # result forever (until the tree hash changes), rather than actually
-    # retrying the check.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -1557,17 +1366,14 @@ def test_process_files_rule_failure_is_not_cached(tmp_path: Path, monkeypatch: p
     orchestrator = CheckOrchestrator(checks=[meaningless_vars])
     first = orchestrator.process_files([str(filepath)])
     assert first == {}
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]
 
     second = orchestrator.process_files([str(filepath)])
     assert second[str(filepath)][0].error_code == "TR1"
 
 
 def test_process_files_unavailable_checks_result_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A result collected while a cacheable check was unavailable must never
-    # be cached either -- otherwise a later run, after the prerequisite
-    # recovers, would keep serving the stale "clean" cached result instead
-    # of actually retrying the now-available check.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -1601,24 +1407,13 @@ _UNRELATED_LINE = "unrelated_call()\n"
 def test_process_files_a_sibling_hook_names_own_write_does_not_serve_a_stale_entry_after_content_changes(
     tmp_path: Path,
 ) -> None:
-    # See ADR-0044: several hook_names can now share one file's cache blob.
-    # `probe_a`'s own entry, cached against the file's original content,
-    # must not survive being served once `probe_b`'s own write updates the
-    # blob for content that changed since -- CacheManager.set_cached_
-    # result() must drop it rather than leave it paired with the blob's
-    # new, updated file_hash/mtime/size. The content change here comes from
-    # outside either orchestrator (e.g. a concurrent edit, or a separate
-    # tool) rather than from a fix in this same run, since CheckOrchestrator
-    # itself now never caches a run that changed the file on its own (see
-    # test_fix_mode_does_not_cache_a_run_that_actually_changed_the_file) --
-    # this is CacheManager's own general-purpose protection underneath
-    # that, independent of how the content came to change.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
     probe_a = CheckOrchestrator(checks=[_MarkerFixableCheck(check_id="probe-a")])
     first = probe_a.process_files([str(filepath)])
-    assert first[str(filepath)][0].check_id == "probe-a"  # pytriage: TR6
+    assert first[str(filepath)][0].check_id == "probe-a"
     assert probe_a.cache.get_cached_result(filepath, probe_a.cache.hook_name) is not None
 
     filepath.write_text(f"x = 1\n{_CLEAN_MARKER}")
@@ -1635,12 +1430,6 @@ def test_process_files_a_sibling_hook_names_own_write_does_not_serve_a_stale_ent
 
 
 class _AlwaysRerunProbeCheck(BaseCheck):
-    """Minimal `ASTCheck` double with `cacheable = False`, for exercising
-    `CheckOrchestrator`'s always-rerun split independent of any real
-    check's own implementation (e.g. `redundant-type-conversion`, which
-    needs a live `ty` process rather than a plain in-memory fixture).
-    """
-
     __slots__ = ("call_count", "message")
 
     check_id = "always-rerun-probe"
@@ -1682,16 +1471,6 @@ class _AlwaysRerunProbeCheck(BaseCheck):
 
 
 class _MarkerFixableCheck(_AlwaysRerunProbeCheck):
-    """A cacheable, fixable variant of `_AlwaysRerunProbeCheck`: flags a
-    violation whenever a fixed marker line is absent from the source, and
-    its own fix() appends that marker. Two instances with different
-    `check_id`s (and so different `hook_name`s, per ADR-0044) can share a
-    file's cache blob while each independently converges to clean once its
-    own fix runs -- lets a test deterministically change a file's content
-    via a real fix pass and observe what a *different* hook_name's own
-    cache entry does across that change.
-    """
-
     __slots__ = ("check_id",)
 
     error_code = "ZZZ003"
@@ -1718,12 +1497,6 @@ class _MarkerFixableCheck(_AlwaysRerunProbeCheck):
 
 
 class _MarkerRemovingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
-    """Non-cacheable `ASTCheck` double whose own fix() strips
-    `_MarkerFixableCheck`'s marker back out of the file -- lets a test
-    demonstrate that an always-rerun check's own fix can invalidate a
-    cacheable sibling's already-cached "clean" result for the same file.
-    """
-
     __slots__ = ()
 
     check_id = "marker-remover"
@@ -1752,52 +1525,30 @@ class _MarkerRemovingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
 def test_fix_mode_falls_through_when_an_always_rerun_fix_invalidates_a_cached_cacheable_result(
     tmp_path: Path,
 ) -> None:
-    # ADR-0044: a clean cacheable-group cache hit must not be trusted once
-    # an always-rerun sibling's own fix changes the file this run -- that
-    # fix can invalidate whatever made the cacheable group clean, so this
-    # must fall through to a full recompute rather than blindly returning
-    # the stale cached "clean" result merged with the always-rerun group's
-    # own fresh one.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(f"x = 1\n{_CLEAN_MARKER}")
 
     populate = CheckOrchestrator(checks=[_MarkerFixableCheck(check_id="c")])
-    populate.process_files([str(filepath)])  # marker present -> clean, populates the cache
+    populate.process_files([str(filepath)])
 
     combined = CheckOrchestrator(
         checks=[_MarkerFixableCheck(check_id="c"), _MarkerRemovingAlwaysRerunCheck()], fix_mode=True
     )
     violations = combined.process_files([str(filepath)])
 
-    # The stale cache hit for "c" must not be returned merged with only the
-    # always-rerun check's own result -- that would silently hide the
-    # violation the marker-remover's own fix just introduced for "c".
     by_check = {v.check_id: v for v in violations[str(filepath)]}
     assert "c" in by_check
 
-    # Re-running the always-rerun group a second time as part of the
-    # recompute must not happen: it would find the file already clean and
-    # silently lose its own [FIXED] outcome. The marker-remover's own fix
-    # must still be reported.
     assert by_check["marker-remover"].fix_outcome is FixOutcome.APPLIED
 
 
 def test_always_rerun_probe_check_fix_is_a_no_op(tmp_path: Path) -> None:
-    # _AlwaysRerunProbeCheck never marks a violation fixable, so its own
-    # fix() is never reached through CheckOrchestrator's own _apply_fixes
-    # path -- exercised directly here instead, matching this repo's own
-    # convention for a check with no autofix (e.g.
-    # RedundantTypeConversionCheck's own test_fix_never_applies_a_fix).
-    probe = _AlwaysRerunProbeCheck()
-    assert probe.fix(tmp_path / "module.py", [], "x = 1\n", ast.parse("x = 1\n")).outcomes == ()
+
+    assert _AlwaysRerunProbeCheck().fix(tmp_path / "module.py", [], "x = 1\n", ast.parse("x = 1\n")).outcomes == ()
 
 
 class _DrainingProbeCheck(_AlwaysRerunProbeCheck):
-    """An `_AlwaysRerunProbeCheck` that also reports extra cross-file candidates -- exercises
-    `CheckOrchestrator._reconcile_direct_inputs()` (ADR-0041) independent of
-    `redundant-type-conversion`'s own real implementation, which needs a live `ty` process.
-    """
-
     __slots__ = ("direct_inputs", "extra_files")
 
     check_id = "draining-probe"
@@ -1830,11 +1581,6 @@ class _OtherDrainingProbeCheck(_DrainingProbeCheck):
 
 
 class _CrossFileProbeCheck(_DrainingProbeCheck):
-    """A `_DrainingProbeCheck` declaring the direct-input lifecycle that
-    `per-file-ignores` must keep feeding even for a file it switched the
-    check off for; see ADR-0049.
-    """
-
     __slots__ = ()
 
     check_id = "cross-file-probe"
@@ -1905,17 +1651,12 @@ class _NeverConvergingDrainingCheck(_AlwaysRerunProbeCheck):
         self.drain_call_count = 0
 
     def reconcile_direct_inputs(self, _already_processed: list[Path]) -> list[Path]:
-        # Returns a fresh nonexistent path once, isolating reconciliation from direct-input processing.
+
         self.drain_call_count += 1
         return [Path(f"/nonexistent/never_converges_{self.drain_call_count}.py")]
 
 
 class _OrderDependentDrainingCheck(_AlwaysRerunProbeCheck):
-    """Reports `reported_file` as a cross-file candidate specifically once `trigger_file` has itself been
-    examined -- simulates a caller passed to the same run as its own callee, whose later examination is
-    what actually reveals the caller needs re-checking (ADR-0041's own processing-order regression).
-    """
-
     __slots__ = ("reported_file", "trigger_file")
 
     check_id = "order-dependent-draining-probe"
@@ -1932,11 +1673,6 @@ class _OrderDependentDrainingCheck(_AlwaysRerunProbeCheck):
 
 
 class _StaleThenCleanDrainingCheck(_AlwaysRerunProbeCheck):
-    """Flags `flagged_file` only the first time it's check()-ed, and reports it as a cross-file
-    candidate once `trigger_file` is examined -- proves a re-check that comes back clean replaces (not
-    merely fails to add to) that file's own earlier, now-stale violation instead of leaving it in place.
-    """
-
     __slots__ = ("flagged_file", "seen", "trigger_file")
 
     check_id = "stale-then-clean-draining-probe"
@@ -1977,11 +1713,6 @@ def test_order_dependent_draining_checks_do_not_report_before_their_trigger(tmp_
 
 
 class _SelectivelyViolatingDrainingCheck(_DrainingProbeCheck):
-    """Only flags a file named `flagged.py` -- unlike `_AlwaysRerunProbeCheck`, which flags every file
-    unconditionally, this lets a test drive an extra file through a real, empty (not unprocessable)
-    violations result.
-    """
-
     __slots__ = ()
 
     check_id = "selective-draining-probe"
@@ -2088,11 +1819,9 @@ def test_process_files_records_an_unavailable_direct_input_check(tmp_path: Path)
 
 
 def test_drain_cross_file_candidates_skips_an_unresolvable_extra_path(tmp_path: Path) -> None:
-    # A path-resolution failure for one drained candidate must be isolated to that candidate, the same
-    # way a check's own drain_cross_file_candidates() raising already is above -- not escape and abort
-    # the whole run over one bad path from one check.
+
     class _UnresolvablePath(Path):
-        def resolve(self, _strict: bool = False) -> NoReturn:  # noqa: FBT002 -- matches Path.resolve()'s own signature
+        def resolve(self, _strict: bool = False) -> NoReturn:
             msg = "simulated resolve failure"
             raise OSError(msg)
 
@@ -2101,7 +1830,7 @@ def test_drain_cross_file_candidates_skips_an_unresolvable_extra_path(tmp_path: 
     probe = _DrainingProbeCheck(extra_files=[_UnresolvablePath(tmp_path / "unresolvable.py")])
     orchestrator = CheckOrchestrator(checks=[probe])
 
-    violations = orchestrator.process_files([str(main_file)])  # must not raise
+    violations = orchestrator.process_files([str(main_file)])
 
     assert str(main_file) in violations
 
@@ -2118,7 +1847,7 @@ def test_drain_cross_file_candidates_skips_an_unresolvable_direct_path(
     monkeypatch.setattr(CheckOrchestrator, "_process_single_file", lambda *_args: [])
     real_resolve = Path.resolve
 
-    def resolve(filepath: Path, strict: bool = False) -> Path:  # noqa: FBT002
+    def resolve(filepath: Path, strict: bool = False) -> Path:
         if filepath == main_file:
             msg = "simulated resolve failure"
             raise OSError(msg)
@@ -2157,12 +1886,7 @@ def test_drain_cross_file_candidates_does_not_record_derived_rechecks_as_direct_
 def test_drain_cross_file_candidates_recovers_a_dependent_processed_before_its_dependency(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A caller passed to the same run as its own callee, ordered before it, must still be re-examined
-    # once the callee's own later examination reveals it dirty -- not silently suppressed by treating
-    # every original input file as permanently "already processed" from the very start of the run
-    # (ADR-0041's own processing-order regression). Passed as a relative path (the pre-commit/prek norm)
-    # so a fix that resolves it before re-checking, but reports it under that resolved path instead of
-    # its own original spelling, would also be caught.
+
     monkeypatch.chdir(tmp_path)
     caller = Path("caller.py")
     caller.write_text("x = 1\n")
@@ -2174,11 +1898,8 @@ def test_drain_cross_file_candidates_recovers_a_dependent_processed_before_its_d
 
     violations = orchestrator.process_files([str(caller), str(callee)])
 
-    # caller (direct) + callee (direct) + caller again (re-examined once callee's own drain flagged it).
     assert probe.call_count == 3
-    # Reported under its own original (relative) key, not a second, separately-resolved one, and with
-    # exactly one violation -- the re-check's own result replacing the first, now-stale one rather than
-    # being appended alongside it.
+
     assert str(caller.resolve()) not in violations
     assert len(violations[str(caller)]) == 1
 
@@ -2186,9 +1907,7 @@ def test_drain_cross_file_candidates_recovers_a_dependent_processed_before_its_d
 def test_drain_cross_file_candidates_clears_a_dependents_stale_violation_once_the_recheck_is_clean(
     tmp_path: Path,
 ) -> None:
-    # The caller's own first examination flags it; once the callee's later examination marks it dirty,
-    # the re-check comes back clean (the underlying issue is now fixed) -- that must replace, not merely
-    # fail to add to, the first, now-stale violation, or it would linger in the report forever.
+
     caller = tmp_path / "caller.py"
     caller.write_text("x = 1\n")
     callee = tmp_path / "callee.py"
@@ -2218,13 +1937,6 @@ def test_drain_cross_file_candidates_reports_nothing_for_an_extra_file_with_no_v
 
 
 class _AppendingFixCheck(_AlwaysRerunProbeCheck):
-    """A `fix()` that appends its own `marker` line to the file, optionally sleeping between reading
-    `source` and writing it back to widen a concurrent-fix race window -- proves `_check_file`'s own
-    per-file lock (`_fix_lock_path`) actually serializes two would-be-concurrent writers (e.g. two
-    separate `CheckOrchestrator` instances, simulating two separate pre-commit/prek worker processes)
-    rather than letting one silently clobber the other's already-applied fix.
-    """
-
     __slots__ = ("marker", "write_delay_seconds")
 
     check_id = "appending-fix-probe"
@@ -2254,12 +1966,7 @@ class _AppendingFixCheck(_AlwaysRerunProbeCheck):
 def test_check_file_serializes_concurrent_fixes_to_the_same_file_across_orchestrators(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Simulates two separate CheckOrchestrator instances (standing in for two separate pre-commit/prek
-    # worker processes, e.g. two overlapping hook configurations, or a future check implementing
-    # drain_cross_file_candidates() while also being fixable -- redundant-type-conversion's own drain
-    # can't trigger this today, since that check never writes) both fixing the same file at once. Without
-    # _check_file's own per-file lock, whichever write lands last would silently discard the other's
-    # already-applied fix (a classic lost update), since both would read the same pre-fix content.
+
     monkeypatch.chdir(tmp_path)
     shared_file = tmp_path / "shared.py"
     shared_file.write_text("x = 1\n")
@@ -2271,7 +1978,7 @@ def test_check_file_serializes_concurrent_fixes_to_the_same_file_across_orchestr
 
     thread = threading.Thread(target=slow_orchestrator._check_file, args=(shared_file, [slow_check]))
     thread.start()
-    time.sleep(0.1)  # lets the slow orchestrator acquire the lock and start its own (slow) fix first
+    time.sleep(0.1)
     fast_orchestrator._check_file(shared_file, [fast_check])
     thread.join(timeout=5)
     assert not thread.is_alive()
@@ -2282,17 +1989,6 @@ def test_check_file_serializes_concurrent_fixes_to_the_same_file_across_orchestr
 
 
 class _ExternallyModifiedFixCheck(_AlwaysRerunProbeCheck):
-    """A `fix()` that, when `simulate_external_edit` is set, writes an
-    out-of-band edit (standing in for an editor, or a concurrent process
-    outside this tool's own per-file fix lock) to `filepath` between
-    `_apply_fixes`' own read and this check's own write -- proves
-    `atomic_write_text()`'s source-identity check actually aborts the write
-    instead of silently clobbering that edit, the scenario `_check_file`'s
-    own lock (see `_AppendingFixCheck` above) cannot cover because the other
-    writer here never goes through this tool at all. With it unset, `fix()`
-    behaves like an ordinary, uncontested single-write check.
-    """
-
     __slots__ = ("simulate_external_edit",)
 
     check_id = "externally-modified-fix-probe"
@@ -2319,8 +2015,7 @@ class _ExternallyModifiedFixCheck(_AlwaysRerunProbeCheck):
 
 
 def test_apply_fixes_applies_normally_when_nothing_else_touches_the_file(tmp_path: Path) -> None:
-    # Companion to the abort case below: the identity check must never
-    # reject an ordinary, uncontested fix just because it exists.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
     check = _ExternallyModifiedFixCheck(simulate_external_edit=False)
@@ -2346,9 +2041,7 @@ def test_apply_fixes_aborts_when_file_is_externally_modified_during_fix(tmp_path
     assert violation.fix_outcome is not FixOutcome.REJECTED
     assert violation.fix_outcome is not FixOutcome.ERRORED
     assert violation.fix_outcome is not FixOutcome.APPLIED
-    # The check's own fix was discarded; the externally written content
-    # (what a real concurrent editor/process would have left behind) is what
-    # survives on disk, not a silent merge of both writes.
+
     assert filepath.read_text() == "x = 1\n# external edit\n"
 
 
@@ -2411,11 +2104,7 @@ class _CrashingAlwaysRerunCheck(_AlwaysRerunProbeCheck):
 def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a_cacheable_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A combined had_rule_failure flag must not gate caching on whether
-    # *any* check in this call crashed, cacheable or not -- that would let
-    # an always-rerun check's own crash silently disable caching for an
-    # unrelated, successfully-completed cacheable check sharing the same
-    # file, forcing it to be needlessly recomputed on every future run.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -2424,7 +2113,7 @@ def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a
     )
     first = orchestrator.process_files([str(filepath)])
     assert {v.error_code for v in first[str(filepath)]} == {"TR1"}
-    assert orchestrator.rule_failures == [(str(filepath), "crashing-always-rerun-probe")]  # pytriage: TR6
+    assert orchestrator.rule_failures == [(str(filepath), "crashing-always-rerun-probe")]
 
     monkeypatch.setattr(
         MeaninglessVarsCheck,
@@ -2440,10 +2129,7 @@ def test_process_files_a_non_cacheable_checks_own_crash_does_not_block_caching_a
 
 
 def test_process_files_non_cacheable_check_never_serves_a_stale_result(tmp_path: Path) -> None:
-    # A non-cacheable check's own violations must never come from the
-    # cache: its result can depend on state outside the single file it was
-    # given (e.g. another file's current type), which the cache has no way
-    # to invalidate on.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
@@ -2473,9 +2159,7 @@ def test_process_files_non_cacheable_check_results_are_never_written_to_cache(tm
 def test_process_files_non_cacheable_check_does_not_disturb_a_cacheable_checks_own_caching(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # ch. issue #108: adding an always-rerun check alongside an already
-    # cacheable one must not silently disable the cacheable check's own
-    # caching for files they share.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -2500,23 +2184,17 @@ def test_process_files_non_cacheable_check_does_not_disturb_a_cacheable_checks_o
 def test_process_single_file_reports_unprocessable_when_always_rerun_group_fails_after_a_cache_hit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A cache hit for the cacheable group must not silently swallow a
-    # read/parse failure in the always-rerun group's own fresh check --
-    # e.g. a race where the file becomes unreadable between the cache
-    # lookup and the always-rerun group's own _check_file() call.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
     meaningless_vars_only = CheckOrchestrator(checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE)])
-    meaningless_vars_only.process_files([str(filepath)])  # populates the cache
+    meaningless_vars_only.process_files([str(filepath)])
 
     combined = CheckOrchestrator(
         checks=[MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE), _AlwaysRerunProbeCheck()]
     )
 
-    # MeaninglessVarsCheck's own result for this file is already cached above, so
-    # _process_single_file only ever calls _check_file for the always-rerun
-    # group (checks == [_AlwaysRerunProbeCheck()]) here -- nothing else calls this stub.
     def unreadable_always_rerun_group(
         _self: CheckOrchestrator, _fp: Path, _checks: list[ASTCheck], **_kwargs: object
     ) -> list[Violation] | None:
@@ -2527,7 +2205,7 @@ def test_process_single_file_reports_unprocessable_when_always_rerun_group_fails
     violations = combined.process_files([str(filepath)])
 
     assert violations == {}
-    assert combined.unprocessable_files == [str(filepath)]  # pytriage: TR6
+    assert combined.unprocessable_files == [str(filepath)]
 
 
 def test_process_files_enabling_a_non_cacheable_check_does_not_change_cache_identity(
@@ -2545,21 +2223,15 @@ def test_process_files_enabling_a_non_cacheable_check_does_not_change_cache_iden
 
 
 def test_fix_mode_skips_a_file_entirely_on_a_clean_cache_hit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # See ADR-0044: a fix-mode cache hit reporting zero violations means
-    # there is nothing to fix, so the file never needs to be read or
-    # parsed at all on a later run.
+
     filepath = tmp_path / "module.py"
-    # "result" only appears in prose, never as an actual assignment target,
-    # so meaningless-vars' own content prefilter matches this file (it
-    # greps for the literal word) while its real, AST-based check() finds
-    # nothing to flag.
+
     filepath.write_text('"""Doc mentioning a result value."""\n\n\ndef greet() -> str:\n    return "hi"\n')
 
     first = CheckOrchestrator(checks=[MeaninglessVarsCheck()], fix_mode=True)
     first_violations = first.process_files([str(filepath)])
     assert first_violations == {}
-    # Guards against this test passing "for free" because the file never
-    # matched meaningless-vars' own prefilter in the first place.
+
     assert first.cache.get_cached_result(filepath, first.cache.hook_name) is not None
 
     monkeypatch.setattr(
@@ -2573,18 +2245,13 @@ def test_fix_mode_skips_a_file_entirely_on_a_clean_cache_hit(tmp_path: Path, mon
 def test_fix_mode_clean_cacheable_hit_still_fixes_a_dirty_always_rerun_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # See ADR-0044: a clean cacheable-group cache hit doesn't skip the
-    # always-rerun group -- it still runs fresh, and in fix mode still gets
-    # fixed if it finds anything, without re-running the (already known
-    # clean) cacheable group.
+
     filepath = tmp_path / "module.py"
-    # "result" (prose only, see test_fix_mode_skips_a_file_entirely_on_a_clean_cache_hit)
-    # keeps meaningless-vars clean while still matching its own prefilter;
-    # the 3 blank lines are what excessive-blank-lines needs to fix.
+
     filepath.write_text('"""Doc mentioning a result value."""\n\n\n\ndef greet() -> str:\n    return "hi"\n')
 
     populate = CheckOrchestrator(checks=[MeaninglessVarsCheck()], fix_mode=True)
-    populate.process_files([str(filepath)])  # clean for meaningless-vars; populates its cache entry
+    populate.process_files([str(filepath)])
     assert populate.cache.get_cached_result(filepath, populate.cache.hook_name) is not None
 
     monkeypatch.setattr(
@@ -2600,15 +2267,13 @@ def test_fix_mode_clean_cacheable_hit_still_fixes_a_dirty_always_rerun_check(
 
 
 def test_fix_mode_falls_through_to_a_full_recompute_when_cache_hit_shows_a_violation(tmp_path: Path) -> None:
-    # See ADR-0044: cached violations never carry fix_data, so a fix-mode
-    # cache hit that reports a violation can't be used to fix it -- it must
-    # fall through to a real check()+fix() pass, the same as a cache miss.
+
     filepath = tmp_path / "module.py"
     filepath.write_text('"""Doc."""\n\n\n\ndef greet() -> str:\n    return "hi"\n')
 
     check_only = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck()])
     populated = check_only.process_files([str(filepath)])
-    assert populated[str(filepath)][0].error_code == "TR2"  # pytriage: TR6
+    assert populated[str(filepath)][0].error_code == "TR2"
     assert check_only.cache.get_cached_result(filepath, check_only.cache.hook_name) is not None
 
     fixer = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck()], fix_mode=True)
@@ -2618,14 +2283,7 @@ def test_fix_mode_falls_through_to_a_full_recompute_when_cache_hit_shows_a_viola
 
 
 def test_fix_mode_does_not_cache_a_run_that_actually_changed_the_file(tmp_path: Path) -> None:
-    # See ADR-0044 and _apply_fixes' own docstring: a run where a fix
-    # changed the file is never cached, even for the check that was
-    # fixed -- a check with zero violations elsewhere in the same run is
-    # never re-verified against the file's final content once some other
-    # check's fix touched it, so nothing in the group is known-accurate
-    # this run. Caching a changed file's result anyway would let a sibling
-    # check's own stale "clean" entry survive being served after another
-    # check's fix invalidated it.
+
     filepath = tmp_path / "module.py"
     filepath.write_text('"""Doc."""\n\n\n\ndef greet() -> str:\n    return "hi"\n')
 
@@ -2636,9 +2294,7 @@ def test_fix_mode_does_not_cache_a_run_that_actually_changed_the_file(tmp_path: 
 
 
 def test_fix_mode_writes_cache_once_the_file_stops_changing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # See ADR-0044: fix mode writes to the cache too, so a file fixed once
-    # converges to a clean cache hit on the first run after it, once that
-    # run's own fix pass no longer changes anything.
+
     filepath = tmp_path / "module.py"
     filepath.write_text('"""Doc."""\n\n\n\ndef greet() -> str:\n    return "hi"\n')
 
@@ -2662,12 +2318,7 @@ def test_fix_mode_writes_cache_once_the_file_stops_changing(tmp_path: Path, monk
 def test_fix_mode_does_not_cache_a_check_id_with_a_rejected_fix(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # See ADR-0044: _refresh_stale_positions() leaves a check_id's other
-    # still-open violations unrefreshed once any of its violations hits a
-    # terminal negative fix outcome this run -- caching that check_id's
-    # results anyway could serve a stale position later, so it must be
-    # excluded from the write entirely, the same way an incomplete
-    # (crashed/unavailable) check_id already is.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "\n\n\nimport requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
@@ -2688,18 +2339,9 @@ def test_fix_mode_does_not_cache_a_check_id_with_a_rejected_fix(
 
 
 def test_fix_mode_two_configs_do_not_collide_on_the_same_files_cache_entry(tmp_path: Path) -> None:
-    # See ADR-0044: before the hook_name/cache_version split, two
-    # orchestrators sharing one hardcoded hook_name but a different
-    # cache_version (from differing check config, e.g. this repo's own
-    # default vs. permissive --meaningless-vars-level hooks) would wipe
-    # each other's entire per-file cache blob on write -- every run of one
-    # config would evict whatever the other config's own last run wrote,
-    # forcing both into a permanent cache miss against each other forever.
+
     filepath = tmp_path / "module.py"
-    # "result" (prose only) matches both instances' own prefilter (the name
-    # set doesn't vary by level -- only the reporting threshold does) while
-    # staying clean for both, so neither run performs a fix that would
-    # change the file's content hash between the two writes below.
+
     filepath.write_text('"""Doc mentioning a result value."""\n\n\ndef greet() -> str:\n    return "hi"\n')
 
     default = CheckOrchestrator(checks=[MeaninglessVarsCheck()], fix_mode=True)
@@ -2733,13 +2375,10 @@ def test_check_unavailable_error_is_recorded_once_and_disables_that_check(tmp_pa
     orchestrator = CheckOrchestrator(checks=[check])
     all_violations = orchestrator.process_files([str(filepath_1), str(filepath_2)])
 
-    # Deliberately not recorded as an ordinary rule_failures entry — see
-    # CheckUnavailableError's own docstring.
     assert orchestrator.rule_failures == []
     assert orchestrator.unavailable_checks == [("always-rerun-probe", "some prerequisite is missing")]
     assert all_violations == {}
-    # Attempted on the first file only -- the second file's own call is
-    # skipped entirely rather than failing (and recording) all over again.
+
     assert check.attempts == 1
 
 
@@ -2761,11 +2400,7 @@ def test_check_unavailable_error_does_not_discard_other_checks_results(tmp_path:
 
 
 def test_refresh_stale_positions_skips_a_check_already_known_unavailable(tmp_path: Path) -> None:
-    # A check that raised CheckUnavailableError during this same file's own
-    # _check_file pass is already recorded in _unavailable_check_ids by the
-    # time a different check's fix (here, MeaninglessVarsCheck's own rename)
-    # triggers _refresh_stale_positions for that file -- it must not be
-    # attempted (and fail) all over again there.
+
     class _UnavailableCheck(_AlwaysRerunProbeCheck):
         __slots__ = ("attempts",)
 
@@ -2816,9 +2451,7 @@ def test_main_reports_check_unavailable_error_once_and_exits_nonzero(
 
 
 def test_apply_fixes_skips_check_with_no_fixable_violations(tmp_path: Path) -> None:
-    # redundant-super-init never marks violations fixable; when mixed with
-    # a fixable meaningless-vars violation in the same file, its check must be
-    # skipped in the fix loop rather than attempting (and no-op'ing) a fix.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import requests\n\n"
@@ -2845,13 +2478,7 @@ def test_apply_fixes_skips_check_with_no_fixable_violations(tmp_path: Path) -> N
 
 
 def test_apply_fixes_does_not_mark_fixed_a_violation_fix_left_untouched(tmp_path: Path) -> None:
-    # validate-function-name's fix() loops over violations and
-    # can skip some (should_autofix refuses to rename methods) while fixing
-    # others in the same call. _apply_fixes must not mark every violation
-    # of a check as fixed just because fix() returned True at all,
-    # regardless of whether that specific violation was actually touched —
-    # a rename that should_autofix skips must not be reported [FIXED]
-    # while the file still has the old name.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import json\n\n\n"
@@ -2878,13 +2505,7 @@ def test_apply_fixes_does_not_mark_fixed_a_violation_fix_left_untouched(tmp_path
 
 
 def test_apply_fixes_distinguishes_violations_with_identical_messages(tmp_path: Path) -> None:
-    # a free function and an unrelated method can produce
-    # byte-identical violation messages (same func_name, same suggested
-    # name, same reason). Marking "fixed" by message text alone would lose
-    # their identity — after the free function is renamed, its own old
-    # message is still "present" via the method's untouched violation, so
-    # the fixed one must not be reported as still-fixable just because
-    # something with the same text remains.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "def get_data():\n"
@@ -2913,12 +2534,7 @@ def test_apply_fixes_distinguishes_violations_with_identical_messages(tmp_path: 
 def test_apply_fixes_marks_violation_rejected_when_fix_produces_invalid_syntax(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Simulates a bug in a check's fix logic that would write invalid
-    # syntax: atomic_write_text() must refuse the write, and only that
-    # check's own violation is reported as rejected — an unrelated check's
-    # violation in the same file must still be fixed normally, matching the
-    # existing per-check try/except isolation (one check's bad fix doesn't
-    # block another's unrelated one).
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "\n\n\nimport requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
@@ -2949,12 +2565,7 @@ def test_apply_fixes_marks_violation_rejected_when_fix_produces_invalid_syntax(
 def test_apply_fixes_marks_violation_errored_when_fix_raises_unexpectedly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A bug in a check's own fix() (raising something other than
-    # FixValidationError) must be marked distinctly from a rejected fix:
-    # fix() never even produced output to validate here, so this isn't
-    # "atomic_write_text() refused a bad write" but "the check's fix logic
-    # itself blew up." An unrelated check's fix in the same file must still
-    # apply normally.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "\n\n\nimport requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
@@ -2984,13 +2595,7 @@ def test_apply_fixes_marks_violation_errored_when_fix_raises_unexpectedly(
 def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # a check that writes more than once per fix() call
-    # (looping over violations individually, like validate_function_name)
-    # can commit some violations before a later write raises. Marking every
-    # violation in the batch [FIX ERRORED] regardless would misreport an
-    # already-applied fix as "not applied", leaving the user unable to tell
-    # which change actually landed on disk. Only the violation(s) still
-    # present after the crash must be marked errored.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import requests\n\n"
@@ -3005,8 +2610,7 @@ def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
     def partial_then_raise(
         _self: MeaninglessVarsCheck, fp: Path, _violations: object, source: str, *_args: object, **_kwargs: object
     ) -> None:
-        # Simulates a multi-write check that already committed the fix for
-        # "data" before crashing while attempting "result".
+
         atomic_write_text(
             fp,
             "import requests\n\n"
@@ -3044,12 +2648,7 @@ def test_apply_fixes_marks_already_resolved_violation_fixed_not_errored(
 def test_apply_fixes_records_rule_failure_when_fix_raises_after_resolving_everything(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # if fix() commits every requested edit successfully and
-    # then raises afterwards (e.g. during unrelated cleanup), every
-    # violation ends up correctly marked [FIXED] and none are left to mark
-    # [FIX ERRORED] — but the exception itself must still be recorded
-    # somewhere, or a genuine internal failure would be completely
-    # invisible behind what looks like a fully successful fix.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(
         "import requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
@@ -3074,7 +2673,7 @@ def test_apply_fixes_records_rule_failure_when_fix_raises_after_resolving_everyt
     violation = violations[str(filepath)][0]
     assert violation.fix_outcome is FixOutcome.APPLIED
     assert violation.fix_outcome is not FixOutcome.ERRORED
-    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]  # pytriage: TR6
+    assert orchestrator.rule_failures == [(str(filepath), "meaningless-vars")]
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
     )
@@ -3110,11 +2709,7 @@ def _run_vfn_fix_with_patched_apply_fix(
 def test_apply_fixes_marks_only_the_rejected_violation_of_a_multi_write_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # validate-function-name's fix() writes once per violation rather than
-    # once per check. When one of those writes is rejected, the orchestrator
-    # must attribute the rejection to that specific violation, not the
-    # whole check — an earlier rename that already committed must still be
-    # reported [FIXED], not swept into [FIX REJECTED] alongside it.
+
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
@@ -3139,11 +2734,7 @@ def test_apply_fixes_marks_only_the_rejected_violation_of_a_multi_write_check(
 def test_apply_fixes_marks_only_the_aborted_violation_of_a_multi_write_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Same per-violation scoping as the [FIX REJECTED] case above, but for a
-    # concurrent on-disk modification: an earlier rename in this loop that
-    # already committed must still be reported [FIXED], not swept into
-    # [FIX ABORTED] alongside a later violation whose own write collided
-    # with an on-disk change.
+
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
@@ -3168,22 +2759,14 @@ def test_apply_fixes_marks_only_the_aborted_violation_of_a_multi_write_check(
 def test_apply_fixes_keeps_aborted_violation_aborted_even_when_the_external_edit_removes_it(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The post-fix recheck (_mark_resolved_and_get_still_present) must never
-    # report [FIXED] just because a violation is no longer detected -- the
-    # very external edit that caused the abort can easily be the reason it's
-    # gone (e.g. someone else already renamed the function), but this run's
-    # own write never landed and must not be credited for that. get_config
-    # is an unrelated, unaffected violation in the same batch, proving the
-    # fix above doesn't regress an ordinary successful multi-write fix.
+
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
     def flaky_apply_fix(fp: Path, suggestion: Suggestion) -> FixOutcome:
         if suggestion.func_name == "get_active":
             stale_source = fp.read_text()
-            # Simulate a concurrent process independently renaming the
-            # function to a compliant name between should_autofix()'s own
-            # read and this apply_fix() call.
+
             fp.write_text(stale_source.replace("def get_active(", "def is_active("))
             atomic_write_text(fp, "def get_active(user):\n    pass\n", "utf-8", stale_source)
         return original_apply_fix(fp, suggestion)
@@ -3202,17 +2785,7 @@ def test_apply_fixes_keeps_aborted_violation_aborted_even_when_the_external_edit
 def test_apply_fixes_keeps_aborted_violation_aborted_when_the_external_edit_leaves_invalid_python(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The concurrent edit that aborts get_active's own fix also happens to
-    # overwrite the whole file with invalid Python (a half-written save, a
-    # merge conflict marker) -- destroying get_config's own already-applied
-    # rename too. The post-fix recheck (_mark_resolved_and_get_still_present)
-    # must not let that SyntaxError escape into _apply_fixes' outer except
-    # Exception, which would blanket-mark every fixable violation for this
-    # check [FIX ERRORED] and record a spurious rule failure. get_active's
-    # own [FIX ABORTED] (decided before the file was clobbered) must survive
-    # untouched; get_config -- genuinely unconfirmable now that the file no
-    # longer parses -- must fall back to ordinary [FIXABLE], not a false
-    # [FIX ERRORED] for a check that never actually raised.
+
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
@@ -3238,13 +2811,7 @@ def test_apply_fixes_keeps_aborted_violation_aborted_when_the_external_edit_leav
 def test_apply_fixes_marks_errored_violation_of_a_multi_write_check_when_apply_fix_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # validate-function-name's own fix() already catches any
-    # exception apply_fix() raises other than FixValidationError internally
-    # (logging it and moving on to the next violation), so it never
-    # propagates to CheckOrchestrator._apply_fixes' own [FIX ERRORED]
-    # handling at all — that handling is only reachable for single-write
-    # checks. The check itself must mark the specific violation it failed
-    # to fix, the same way it already does for a rejected fix.
+
     filepath = _write_get_config_and_get_active_module(tmp_path)
     original_apply_fix = vfn_module.apply_fix
 
@@ -3270,8 +2837,7 @@ def test_apply_fixes_marks_errored_violation_of_a_multi_write_check_when_apply_f
 def _disappear_before_refetch(
     _orchestrator: CheckOrchestrator, _meaningless_vars: MeaninglessVarsCheck, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # If the file can't be re-read inside _apply_fixes (e.g. deleted by a
-    # concurrent process), that check's fix is skipped rather than crashing.
+
     original_read = CheckOrchestrator._read_source
     calls = {"n": 0}
 
@@ -3287,18 +2853,13 @@ def _disappear_before_refetch(
 def _disappear_after_fix(
     _orchestrator: CheckOrchestrator, _meaningless_vars: MeaninglessVarsCheck, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # If the file can't be re-read for the post-fix verification (e.g.
-    # deleted right after the fix wrote it), the fix isn't reported as
-    # fixed even though it actually happened — this run just can't confirm
-    # it, so it stays conservative rather than guessing.
+
     original_read = CheckOrchestrator._read_source
     calls = {"n": 0}
 
     def flaky_read(self: CheckOrchestrator, fp: Path) -> tuple[str, str] | None:
         calls["n"] += 1
-        # Call 1 is _check_file's own initial read, call 2 is _apply_fixes'
-        # pre-fix read — both must succeed so the real fix actually runs.
-        # Call 3 is the new post-fix verification read.
+
         if calls["n"] <= 2:
             return original_read(self, fp)
         return None
@@ -3324,11 +2885,7 @@ def _recompute_finds_no_fixable_violations(
 def _recompute_raises(
     _orchestrator: CheckOrchestrator, meaningless_vars: MeaninglessVarsCheck, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A crash in _apply_fixes' own pre-fix recompute call is distinct from
-    # fix() itself raising (which is caught separately and marked [FIX
-    # ERRORED], see test_apply_fixes_marks_violation_errored_when_fix_raises_unexpectedly)
-    # — fix() is never even reached here. The original, already-reported
-    # violation must stay exactly as it was rather than silently vanishing.
+
     original_check = meaningless_vars.check
     calls = {"n": 0}
 
@@ -3395,11 +2952,6 @@ def test_apply_fixes_marks_nothing_fixed(
 
 
 class _LineRemovingFixCheck(_AlwaysRerunProbeCheck):
-    """Removes a *different* check's violation on demand, so the outcomes
-    below can be exercised without depending on which shipped checks happen
-    to interact today (see `docs/adr/0053-indirect-resolution-outcome.md`).
-    """
-
     __slots__ = ("target",)
 
     check_id = "line-remover"
@@ -3432,10 +2984,6 @@ class _LineRemovingFixCheck(_AlwaysRerunProbeCheck):
 
 
 class _LineFlaggingCheck(_AlwaysRerunProbeCheck):
-    """Never resolves anything itself, so any outcome its violations end up
-    with came from another check's fix.
-    """
-
     __slots__ = ()
 
     check_id = "line-flagger"
@@ -3463,10 +3011,6 @@ class _LineFlaggingCheck(_AlwaysRerunProbeCheck):
 
 
 class _UnfixableLineFlaggingCheck(_LineFlaggingCheck):
-    """A flagger with no autofix of its own at all, like
-    redundant-super-init.
-    """
-
     __slots__ = ()
 
     check_id = "unfixable-line-flagger"
@@ -3479,11 +3023,6 @@ class _UnfixableLineFlaggingCheck(_LineFlaggingCheck):
 
 
 class _PairFlaggingFixCheck(_AlwaysRerunProbeCheck):
-    """Reports a fixable and a non-fixable violation for the same line, and
-    deletes that line to fix the first one -- so the second goes away
-    without any fix ever having been applied for it.
-    """
-
     __slots__ = ()
 
     check_id = "pair-flagger"
@@ -3530,10 +3069,7 @@ def _run_line_probes(tmp_path: Path, checks: list[ASTCheck], source: str = "") -
 def test_apply_fixes_marks_a_violation_another_checks_fix_removed_as_resolved_indirectly(
     tmp_path: Path, remover_runs_first: bool
 ) -> None:
-    # ch. 1: "MUST distinguish between a diagnostic that was fixed and a
-    # diagnostic that disappeared as a side effect of another fix". Whichever
-    # way round the two run, the flagger's own fix() is what never resolves
-    # anything, so the outcome must not depend on that ordering.
+
     remover = _LineRemovingFixCheck()
     flagger = _LineFlaggingCheck()
     checks: list[ASTCheck] = [remover, flagger] if remover_runs_first else [flagger, remover]
@@ -3551,7 +3087,7 @@ def test_apply_fixes_marks_a_violation_another_checks_fix_removed_as_resolved_in
 def test_apply_fixes_leaves_a_surviving_violation_open_when_another_check_fixes_an_unrelated_line(
     tmp_path: Path,
 ) -> None:
-    # The file changed this run, but the flagged line is still there.
+
     by_check = _run_line_probes(tmp_path, [_LineRemovingFixCheck(target=_UNRELATED_LINE), _LineFlaggingCheck()])
     (flagged,) = by_check["line-flagger"]
 
@@ -3562,10 +3098,7 @@ def test_apply_fixes_leaves_a_surviving_violation_open_when_another_check_fixes_
 
 
 def test_apply_fixes_marks_only_the_violation_another_checks_fix_actually_removed(tmp_path: Path) -> None:
-    # Removing the first flagged line also shifts the second one up, so the
-    # survivor is reported by a different object than the one snapshotted
-    # before the fix -- it must not be swept up with the violation that
-    # genuinely went away.
+
     by_check = _run_line_probes(
         tmp_path,
         [_LineRemovingFixCheck(), _LineFlaggingCheck()],
@@ -3584,10 +3117,7 @@ def test_apply_fixes_marks_only_the_violation_another_checks_fix_actually_remove
 def test_apply_fixes_keeps_a_failed_fix_distinguishable_from_an_indirect_resolution(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The flagger's own fix() failed to write the file, and another check's
-    # fix then removed the violation anyway. [FIX FAILED] reports something
-    # the user may need to act on (a full disk, a read-only file), which
-    # relabeling it as resolved would hide.
+
     def failing_fix(
         _self: object, _fp: Path, violations: list[Violation], *_args: object, **_kwargs: object
     ) -> FixResult:
@@ -3605,7 +3135,7 @@ def test_apply_fixes_keeps_a_failed_fix_distinguishable_from_an_indirect_resolut
 def test_apply_fixes_marks_a_non_fixable_violation_another_checks_fix_removed_as_resolved_indirectly(
     tmp_path: Path,
 ) -> None:
-    # ch. 1 draws no line at fixable diagnostics.
+
     (flagged,) = _run_line_probes(tmp_path, [_LineRemovingFixCheck(), _UnfixableLineFlaggingCheck()])[
         "unfixable-line-flagger"
     ]
@@ -3616,10 +3146,7 @@ def test_apply_fixes_marks_a_non_fixable_violation_another_checks_fix_removed_as
 def test_apply_fixes_does_not_attribute_a_disappearance_to_a_fix_when_the_file_was_edited_externally(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The remover's own write aborts because something outside this run
-    # edited the file (ADR-0042), and that same edit is what removed the
-    # flagger's violation -- so there is no fix of this run's own to
-    # attribute it to (ADR-0053).
+
     def racing_fix(
         _self: object, fp: Path, _violations: object, source: str, *_args: object, **_kwargs: object
     ) -> None:
@@ -3635,11 +3162,7 @@ def test_apply_fixes_does_not_attribute_a_disappearance_to_a_fix_when_the_file_w
 
 
 def test_apply_fixes_marks_a_violation_its_own_checks_fix_took_with_it(tmp_path: Path) -> None:
-    # No other check is even enabled here: the violation went away because
-    # the same check's fix deleted the line, having only ever been asked to
-    # fix the other half. Nothing was applied for it either way, which is
-    # what this outcome means -- so it must not be dropped, and the report
-    # must not name a different check (ADR-0053).
+
     by_message = {v.message: v for v in _run_line_probes(tmp_path, [_PairFlaggingFixCheck()])["pair-flagger"]}
 
     assert by_message["fixable half"].fix_outcome is FixOutcome.APPLIED
@@ -3650,7 +3173,7 @@ def test_apply_fixes_marks_a_violation_its_own_checks_fix_took_with_it(tmp_path:
 def _run_shipped_fix_pair(tmp_path: Path, source: str) -> dict[str, list[Violation]]:
     filepath = tmp_path / "module.py"
     filepath.write_text(source)
-    # ALL_CHECKS order, which is what decides who fixes first.
+
     checks: list[ASTCheck] = [
         MeaninglessVarsCheck(level=MeaninglessVarsLevel.PERMISSIVE),
         RedundantAssignmentCheck(level=AggressivenessLevel.PERMISSIVE),
@@ -3661,9 +3184,7 @@ def _run_shipped_fix_pair(tmp_path: Path, source: str) -> dict[str, list[Violati
 
 
 def test_apply_fixes_marks_a_shipped_checks_violation_another_shipped_fix_removed(tmp_path: Path) -> None:
-    # Two real checks, in their real order: meaningless-vars reports `data`
-    # but has no autofix for this shape, and redundant-assignment then
-    # inlines the assignment away, taking the reported violation with it.
+
     by_check = _run_shipped_fix_pair(
         tmp_path, "import requests\n\n\ndef request():\n    data = requests.get(url)\n    return data\n"
     )
@@ -3675,12 +3196,7 @@ def test_apply_fixes_marks_a_shipped_checks_violation_another_shipped_fix_remove
 
 
 def test_apply_fixes_does_not_double_report_a_violation_whose_message_another_fix_rewrote(tmp_path: Path) -> None:
-    # meaningless-vars renames `data` to `response` before
-    # redundant-assignment runs, so redundant-assignment's own message names a
-    # different variable before and after -- for one and the same violation,
-    # which it then fixes itself. Deciding what went missing by message alone
-    # would report that violation twice, [FIXED] under the new wording and
-    # [RESOLVED INDIRECTLY] under the old (ADR-0053).
+
     by_check = _run_shipped_fix_pair(
         tmp_path, "import requests\n\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
     )
@@ -3696,8 +3212,7 @@ def test_apply_fixes_does_not_double_report_a_violation_whose_message_another_fi
 def test_report_prints_an_indirectly_resolved_violation_distinctly(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Nothing is left for the user to run --fix for, but the report must
-    # still account for the violation it originally reported.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(f"{_UNRELATED_LINE}{_FLAGGED_LINE}")
     orchestrator = CheckOrchestrator(
@@ -3715,8 +3230,7 @@ def test_report_prints_an_indirectly_resolved_violation_distinctly(
 
 
 def test_load_checks_explicit_check_args_none_default() -> None:
-    # Passing check_args explicitly (not relying on the None default)
-    # takes the same path as leaving it unset.
+
     checks = load_checks(select={"meaningless-vars"}, check_args={})
     assert len(checks) == 1
     assert checks[0].check_id == "meaningless-vars"
@@ -3730,22 +3244,13 @@ def test_load_checks_ignore_set_skips_matching_check() -> None:
 
 
 def test_load_checks_ignore_composes_with_select() -> None:
-    # `select` must not make `ignore` a no-op entirely (an
-    # `elif` instead of two independent checks) -- `--select`+`--ignore`
-    # must be composable, the way `ruff check --select`/`--ignore` can be.
+
     checks = load_checks(select={"meaningless-vars", "redundant-super-init"}, ignore={"meaningless-vars"})
     assert {c.check_id for c in checks} == {"redundant-super-init"}
 
 
 def test_all_checks_have_unique_check_ids_and_error_codes() -> None:
-    # ALL_CHECKS is a fixed, hand-maintained list with no dynamic/plugin
-    # loading (ch. 18: "MUST NOT silently resolve conflicting rule
-    # identifiers in an ambiguous way") — a collision would only come from
-    # a direct edit to this list, which docs/adding-a-check.md's "next
-    # unused number" convention is meant to prevent. This locks that
-    # invariant in so a future duplicate fails loudly here instead of
-    # silently letting `--select`/`--ignore` and the cache key treat two
-    # different checks as the same one.
+
     instances = [cls() for cls in ALL_CHECKS]
     check_ids = [c.check_id for c in instances]
     error_codes = [c.error_code for c in instances]
@@ -3756,9 +3261,7 @@ def test_all_checks_have_unique_check_ids_and_error_codes() -> None:
 def test_load_checks_check_specific_args_are_applied(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Exercises the generic re-instantiate-with-kwargs branch in
-    # `load_checks` against a synthetic check with a second, unrelated
-    # configurable `__init__`, rather than meaningless-vars' own.
+
     class ConfigurableCheck:
         check_id = "configurable"
 
@@ -3837,10 +3340,7 @@ def test_fixed_hook_entrypoints_list_only_their_own_checks(
 def test_fixed_hook_entrypoint_selecting_only_a_check_it_cannot_run_exits_zero(
     tmp_path: Path, entrypoint: Callable[[list[str] | None], int], selected: str
 ) -> None:
-    # One project-wide selection is shared by both hooks, so a check this
-    # entry point can't run is dropped rather than rejected -- and dropping
-    # everything exits 0, the way `ruff format` does with a lint-only
-    # config. `--isolated` keeps this repo's own pyproject.toml out of it.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -3870,11 +3370,7 @@ def test_main_no_violations_returns_zero(tmp_path: Path) -> None:
 
 
 def test_main_verbose_flag_does_not_change_a_clean_runs_exit_code(tmp_path: Path) -> None:
-    # Exercises the --verbose branch in-process for coverage; the actual
-    # observable stderr/exit-code behavior it enables is proven end-to-end
-    # via a real subprocess in test_main.py (pytest's own logging-capture
-    # handler makes an in-process assertion about default log output
-    # unreliable -- see test_real_invocation_does_not_leak_a_traceback_onto_stderr).
+
     filepath = tmp_path / "clean.py"
     filepath.write_text("x = 1\n")
 
@@ -3884,66 +3380,44 @@ def test_main_verbose_flag_does_not_change_a_clean_runs_exit_code(tmp_path: Path
 def test_main_unparseable_file_returns_one(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
-    # An unparseable file must not be silently dropped with exit
-    # code 0 — that would be indistinguishable from a clean run with
-    # nothing to report. Content includes "data" so the file clears every
-    # check's prefilter pattern and actually reaches parsing rather than
-    # being dropped as a non-candidate beforehand.
+
     filepath = tmp_path / "broken.py"
     filepath.write_text("data = foo(:\n")
 
     with caplog.at_level("DEBUG"):
         assert main([str(filepath)]) == 1
     assert f"{filepath}: error: could not be read or parsed; file skipped" in capsys.readouterr().err
-    # The clean diagnostic above already reports this; a raw traceback
-    # alongside it on stderr would just be redundant noise (ch. 7: "MUST NOT
-    # emit uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
 def test_main_permission_denied_file_returns_one_inside_git_repo(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Inside a real git repo, the prefilter's `git grep`
-    # subprocess (not the Python-only fallback the other tmp_path-based
-    # tests exercise, since they aren't git repos) reports a
-    # permission-denied file only via a "failed to stat" line on its own
-    # stderr, without changing its exit code for the files it *could*
-    # read. main() must inspect that stderr — otherwise the file would be
-    # silently dropped before ever reaching _check_file, and the whole run
-    # would report exit code 0, as if the file never existed.
-    # MeaninglessVarsCheck has a prefilter pattern ("data" is one of its
-    # meaningless names), so this only exercises the check that actually
-    # calls into git grep.
+
     git = shutil.which("git")
     assert git is not None
 
     with contextlib.chdir(tmp_path):
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
 
         filepath = tmp_path / "module.py"
         filepath.write_text("data = 1\n")
-        subprocess.run([git, "add", "module.py"], check=True, cwd=tmp_path)  # noqa: S603
+        subprocess.run([git, "add", "module.py"], check=True, cwd=tmp_path)
 
         with restricted_permissions(filepath, 0o000, restore=0o644), caplog.at_level("DEBUG"):
             exit_code = main(["module.py", "--select", "meaningless-vars"])
 
         assert exit_code == 1
         assert "module.py: error: could not be read or parsed; file skipped" in capsys.readouterr().err
-        # The clean diagnostic above already reports this; a raw traceback
-        # alongside it on stderr would just be redundant noise (ch. 7: "MUST
-        # NOT emit uncontrolled human-oriented text into a machine-readable
-        # output stream").
+
         assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
 def test_main_check_crash_returns_one_and_reports_check_and_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # A check that crashes on every file it sees must not make the whole
-    # run look clean (exit code 0, nothing printed) just because no other
-    # check reported a violation for the same files.
+
     monkeypatch.setattr(MeaninglessVarsCheck, "check", raises(ValueError, "simulated check failure"))
 
     filepath = tmp_path / "module.py"
@@ -3977,12 +3451,7 @@ def test_main_reports_non_fixable_violation(tmp_path: Path, capsys: pytest.Captu
 
 
 def test_main_reports_column_alongside_line(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    # Violation.col is computed accurately (meaningless-vars reports the assigned
-    # name's own ast.col_offset, converted to a character offset), and
-    # main()'s printed line must include it, not just the line -- ch. 7:
-    # "MUST report line and column information accurately when available".
-    # "data" starts at the 0-indexed character offset 4; main() reports
-    # the conventional 1-based column, 5.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("def process():\n    data = requests.get(url)\n    return data\n")
 
@@ -4019,11 +3488,7 @@ def test_main_fix_flag_marks_violation_fixed(tmp_path: Path, capsys: pytest.Capt
     assert "[FIXED]" in err
     fixed_line = next(line for line in err.splitlines() if "[FIXED]" in line)
     assert "Run with --fix" not in fixed_line
-    # ch. 32: "MUST verify that the reported result matches the actual final
-    # file state" -- the rejected/errored/failed variants of this test
-    # already assert the file stays untouched; only the success path was
-    # never checked against the real on-disk content, just the printed
-    # [FIXED] line.
+
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
     )
@@ -4035,9 +3500,7 @@ def test_main_fix_flag_reports_rejected_fix(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # A fix rejected for invalid syntax must be reported distinctly from
-    # both [FIXED] and the ordinary [FIXABLE]/"Run with --fix" hint, since
-    # re-running --fix would just fail identically again.
+
     def broken_fix(_self: object, fp: Path, *_args: object, **_kwargs: object) -> None:
         atomic_write_text(fp, "def broken(:\n", "utf-8", fp.read_text())
 
@@ -4059,10 +3522,7 @@ def test_main_fix_flag_reports_rejected_fix(
     assert "[FIXED]" not in err
     assert "Run with --fix" not in err
     assert "data = requests.get(url)" in filepath.read_text()
-    # [FIX REJECTED] above already reports this; a raw traceback alongside
-    # it on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -4072,10 +3532,7 @@ def test_main_fix_flag_reports_errored_fix(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # A fix() that raises something other than FixValidationError must be
-    # reported distinctly from [FIXED], [FIX REJECTED], and the ordinary
-    # [FIXABLE]/"Run with --fix" hint — re-running --fix would just crash
-    # identically again, so suggesting it would be misleading.
+
     def broken_fix(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("simulated fix bug")
 
@@ -4098,22 +3555,14 @@ def test_main_fix_flag_reports_errored_fix(
     assert "[FIX REJECTED]" not in err
     assert "Run with --fix" not in err
     assert "data = requests.get(url)" in filepath.read_text()
-    # [FIX ERRORED] above already reports this; a raw traceback alongside it
-    # on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
 def test_main_fix_flag_reports_failed_fix(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
-    # A fix() that catches its own OSError (disk full, permission denied)
-    # and returns a failure outcome must
-    # be reported distinctly from [FIXED] and the ordinary [FIXABLE]/"Run
-    # with --fix" hint -- re-running --fix would just fail identically
-    # again, and unlike [FIX ERRORED] this isn't a bug in the check's own
-    # logic, so the hint must not claim it is.
+
     subdir = tmp_path / "readonly"
     subdir.mkdir()
     filepath = subdir / "module.py"
@@ -4133,10 +3582,7 @@ def test_main_fix_flag_reports_failed_fix(
     assert "Run with --fix" not in err
     assert "could not write the file" in err
     assert "data = requests.get(url)" in filepath.read_text()
-    # [FIX FAILED] above already reports this; a raw traceback alongside it
-    # on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -4169,11 +3615,7 @@ def test_main_fix_flag_reports_aborted_fix(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # A file changed on disk after _apply_fixes read it but before this
-    # check's own write landed -- an editor, or a process outside this run's
-    # own per-file fix lock. Must be reported distinctly from
-    # [FIXED]/[FIX REJECTED]/[FIX ERRORED]/[FIX FAILED]: re-running --fix is
-    # the right recovery here, not a bug report or an environmental failure.
+
     def racing_fix(
         _self: object, fp: Path, _violations: object, source: str, *_args: object, **_kwargs: object
     ) -> None:
@@ -4204,33 +3646,21 @@ def test_main_fix_flag_reports_aborted_fix(
     assert "[FIX REJECTED]" not in err
     assert "[FIX FAILED]" not in err
     assert "please report it" not in err
-    # ConcurrentModificationError has its own except clause in _apply_fixes,
-    # distinct from the generic except Exception branch that records a rule
-    # failure -- an abort is an expected, cleanly-reported outcome, not an
-    # internal bug, so it must never also surface as one.
+
     assert f"{filepath}: error: check 'meaningless-vars' raised an unexpected exception" not in err
-    # The externally written content survives untouched -- this check's own
-    # attempted fix must never land on top of it.
+
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    data = requests.get(url)\n    return data.status_code\n"
         "# edited elsewhere\n"
     )
-    # [FIX ABORTED] above already reports this; a raw traceback alongside it
-    # on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
 def test_main_reports_rule_failure_when_reread_fails_mid_fix_loop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # _apply_fixes() re-reads the file before recomputing each
-    # check's fresh violations (a previous check's fix in the same loop may
-    # have already modified it). If that re-read itself fails, the loop
-    # must not just `continue` with zero signal anywhere -- otherwise the
-    # stale violation would be left unmarked and reported as an ordinary
-    # [FIXABLE], as if --fix had never even been attempted for it.
+
     original_read_source = CheckOrchestrator._read_source
     calls = 0
 
@@ -4253,21 +3683,16 @@ def test_main_reports_rule_failure_when_reread_fails_mid_fix_loop(
         "class Child(Base):\n    def __init__(self, **kwargs):\n        super().__init__(**kwargs)\n"
     )
 
-    # A second, never-fixable check alongside meaningless-vars: its own
-    # violation must be left alone by the marking loop below (only
-    # meaningless-vars' violation matches check.check_id), exercising that the
-    # loop's `if` condition can also be False for a violation from an
-    # unrelated check_id, not just True for a matching, fixable one.
     checks = load_checks(select={"meaningless-vars", "redundant-super-init"})
     orchestrator = CheckOrchestrator(checks=checks, fix_mode=True)
     violations = orchestrator.process_files([str(filepath)])
 
-    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures  # pytriage: TR6
+    assert (str(filepath), "meaningless-vars") in orchestrator.rule_failures
     meaningless_vars_violation = next(v for v in violations[str(filepath)] if v.check_id == "meaningless-vars")
     super_init_violation = next(v for v in violations[str(filepath)] if v.check_id == "redundant-super-init")
     assert meaningless_vars_violation.fix_outcome is FixOutcome.ERRORED
     assert super_init_violation.fix_outcome is not FixOutcome.ERRORED
-    # The re-read failure means nothing was ever written back.
+
     assert "data = requests.get(url)" in filepath.read_text()
 
 
@@ -4277,13 +3702,7 @@ def test_main_reports_rule_failure_when_recompute_raises_mid_fix_loop(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # _apply_fixes() recomputes fresh violations via check.check()
-    # against the current file state before calling check.fix(). If that
-    # recompute itself raises, it must not be left to only the broad outer
-    # `except Exception` to catch -- that would log the exception but
-    # never record a rule_failure or mark any violation, so the run could
-    # look completely clean depending on what else was reported for the
-    # file.
+
     original_check = MeaninglessVarsCheck.check
     calls = 0
 
@@ -4309,11 +3728,6 @@ def test_main_reports_rule_failure_when_recompute_raises_mid_fix_loop(
         "class Child(Base):\n    def __init__(self, **kwargs):\n        super().__init__(**kwargs)\n"
     )
 
-    # A second, never-fixable check alongside meaningless-vars: its own
-    # violation must be left alone by the marking loop below (only
-    # meaningless-vars' violation matches check.check_id), exercising that the
-    # loop's `if` condition can also be False for a violation from an
-    # unrelated check_id, not just True for a matching, fixable one.
     with caplog.at_level("DEBUG"):
         exit_code = main([str(filepath), "--select", "meaningless-vars,redundant-super-init", "--fix"])
     assert exit_code == 1
@@ -4322,12 +3736,9 @@ def test_main_reports_rule_failure_when_recompute_raises_mid_fix_loop(
     assert f"{filepath}: error: check 'meaningless-vars' raised an unexpected exception" in err
     assert "[FIX ERRORED]" in err
     assert "Run with --fix" not in err
-    # Nothing was ever written back -- the recompute failed before fix() could run.
+
     assert "data = requests.get(url)" in filepath.read_text()
-    # The error line above already reports this; a raw traceback alongside
-    # it on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -4337,11 +3748,7 @@ def test_main_reports_rule_failure_when_fix_raises_after_resolving_everything(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # fix() can commit every requested edit and then raise
-    # afterwards (e.g. during unrelated cleanup) — every violation ends up
-    # correctly reported [FIXED], but the exception itself must still
-    # surface in the run's own output, or a genuine internal failure would
-    # be completely invisible behind what reads as full success.
+
     def fix_then_raise(_self: object, filepath: Path, *_args: object, **_kwargs: object) -> None:
         atomic_write_text(
             filepath,
@@ -4369,10 +3776,7 @@ def test_main_reports_rule_failure_when_fix_raises_after_resolving_everything(
     assert filepath.read_text() == (
         "import requests\n\ndef request():\n    response = requests.get(url)\n    return response.status_code\n"
     )
-    # The error line above already reports this; a raw traceback alongside
-    # it on stderr would just be redundant noise (ch. 7: "MUST NOT emit
-    # uncontrolled human-oriented text into a machine-readable output
-    # stream").
+
     assert all(record.levelname == "DEBUG" for record in caplog.records)
 
 
@@ -4389,13 +3793,7 @@ def test_main_exclude_pattern_excludes_all_files_returns_zero(
 def test_main_check_specific_cli_arg_round_trip(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # redundant-assignment's own --redundant-assignment-level flag (see
-    # test_main_level_flag_switches_between_conservative_and_permissive_reporting
-    # below) already exercises this wiring against a shipped check; this
-    # synthetic one keeps that coverage independent of TR5's own reporting
-    # rules.
-    # Exercises main()'s OPTIONS -> parse_args -> resolved-config ->
-    # check_args wiring end-to-end against a synthetic check.
+
     class _Marker(Enum):
         DEFAULT = auto()
         CUSTOM = auto()
@@ -4427,11 +3825,6 @@ def test_main_check_specific_cli_arg_round_trip(
                 )
             ]
 
-    # main() and load_checks() each hold their own `ALL_CHECKS` name binding
-    # (imported via `from . import ALL_CHECKS` into `_cli.py` and
-    # `_orchestrator.py` respectively) -- both need patching for the
-    # synthetic check to reach both main()'s own CLI-arg wiring and
-    # load_checks()'s instantiation.
     monkeypatch.setattr(_cli, "ALL_CHECKS", [*ALL_CHECKS, ConfigurableCheck])
     monkeypatch.setattr(_orchestrator, "ALL_CHECKS", [*ALL_CHECKS, ConfigurableCheck])
 
@@ -4466,16 +3859,12 @@ class _LevelFlagCase(NamedTuple):
         _LevelFlagCase(
             "redundant-assignment",
             "--redundant-assignment-level",
-            # A type-annotated single-use assignment scores just above the
-            # conservative report ceiling but under the permissive one (see
-            # tests/redundant_assignment/test_check.py::test_annotated_assignment_tracked).
             'def example():\n    x: str = "foo"\n    func(x)\n',
             "'x'",
         ),
         _LevelFlagCase(
             "meaningless-vars",
             "--meaningless-vars-level",
-            # "result = 42" has no suggested rename.
             "def other():\n    result = 42\n    return result\n",
             "'result'",
         ),
@@ -4485,11 +3874,7 @@ class _LevelFlagCase(NamedTuple):
 def test_main_level_flag_switches_between_conservative_and_permissive_reporting(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], case: _LevelFlagCase
 ) -> None:
-    # Issue #76 (redundant-assignment) / docs/adr/0031 (meaningless-vars):
-    # both checks share one conservative/permissive vocabulary for "how
-    # eagerly does this check speak up" -- the default must agree with an
-    # explicit "conservative", and only "permissive" surfaces this
-    # borderline violation.
+
     filepath = tmp_path / "module.py"
     filepath.write_text(case.source)
 
@@ -4530,16 +3915,11 @@ def test_main_unknown_check_name_returns_two(tmp_path: Path, capsys: pytest.Capt
     exit_code = main([str(filepath), flag, "not-a-real-check"])
     assert exit_code == 2
 
-    # Both the offending flag and where the value came from are named —
-    # otherwise --select and --ignore errors are indistinguishable, and a
-    # config-file typo reads as if it came from the command line.
-    err = capsys.readouterr().err
-    assert f"Unknown check `not-a-real-check` in `{flag}` from the CLI" in err
+    assert f"Unknown check `not-a-real-check` in `{flag}` from the CLI" in capsys.readouterr().err
 
 
 def test_main_ignoring_all_checks_returns_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    # Enabling no checks is a legitimate configuration, not an error:
-    # `ruff check` with `select = []` likewise reports nothing and exits 0.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
@@ -4558,13 +3938,7 @@ def test_main_ignoring_all_checks_returns_zero(tmp_path: Path, capsys: pytest.Ca
 def test_main_trailing_comma_does_not_report_blank_unknown_check(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], flag: str, meaningless_vars_runs: bool
 ) -> None:
-    # A trailing comma must not leave an empty string in the parsed set,
-    # reported as a confusing blank "Unknown checks: " instead of being
-    # tolerated like --exclude's own comma list already is. Asserting on
-    # the TR1 violation itself (not just the exit code) is what actually
-    # proves meaningless-vars was recognized: a bogus "Unknown checks"
-    # error would also exit 1 for --select (masking a real violation), so
-    # the exit code alone can't tell the two apart.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -4577,11 +3951,7 @@ def test_main_trailing_comma_does_not_report_blank_unknown_check(
 
 
 def test_main_select_only_commas_is_a_configuration_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    # A --select naming no check at all (once blanks are filtered) is
-    # malformed input, not a request to run nothing — `ruff` likewise
-    # rejects `--select=` as an unknown rule selector rather than treating
-    # it like `select = []`. The blank value must not be echoed back as a
-    # nameless "Unknown check ``".
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
@@ -4594,9 +3964,7 @@ def test_main_select_only_commas_is_a_configuration_error(tmp_path: Path, capsys
 
 
 def test_main_select_and_ignore_compose(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    # `--select`+`--ignore` together must not behave like
-    # `--select` alone, silently dropping `--ignore` (see
-    # `test_load_checks_ignore_composes_with_select`).
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
 
@@ -4653,11 +4021,7 @@ def test_main_accumulates_repeated_check_selection_arguments(
 
 
 def test_main_malformed_cli_argument_exits_via_argparse(capsys: pytest.CaptureFixture[str]) -> None:
-    # argparse's own error handling for a malformed argument (e.g. an
-    # unknown flag) bypasses main()'s own return value entirely via
-    # sys.exit(2) — a third, separate value from this project's own 0/1
-    # exit-code contract, worth locking down explicitly rather than leaving
-    # it as undocumented, incidental argparse behavior.
+
     with pytest.raises(SystemExit) as exc_info:
         main(["--not-a-real-flag"])
 
@@ -4698,11 +4062,7 @@ def isolated_tri006_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> I
     ids=[str(p.relative_to(_FIXTURES_DIR)) for p in _BAD_FIXTURE_PATHS],
 )
 def test_fix_converges_after_one_pass_across_all_checks(fixture_path: Path, isolated_tri006_daemon: Path) -> None:
-    # ch. 10: "MUST ensure that applying the same fix repeatedly converges
-    # to a stable result"; "MUST test fix idempotence explicitly". Runs
-    # --fix (every check together, matching real pre-commit/prek usage)
-    # twice over every existing bad/*.py fixture and asserts the second
-    # pass leaves the file exactly as the first pass did.
+
     target = isolated_tri006_daemon / fixture_path.name
     target.write_text(fixture_path.read_text(encoding="utf-8"), encoding="utf-8")
 
@@ -4718,19 +4078,7 @@ def test_fix_converges_after_one_pass_across_all_checks(fixture_path: Path, isol
 def test_main_handles_path_containing_spaces_and_unicode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # ch. 31: "MUST test paths containing spaces and Unicode." meaningless-vars
-    # declares a prefilter pattern, so a normal run first passes this path to
-    # git_grep_filter()'s real `git grep` subprocess call as a plain argument,
-    # never through a shell (0006/0015's file-discovery audit) -- but only
-    # inside a real git repo; a bare tmp_path (outside any repo, as every
-    # other test in this file uses it) makes `git grep` error out and
-    # silently fall back to the Python-only path instead, which has no
-    # subprocess argument-passing to prove safe in the first place, and would
-    # still produce the same passing result -- silently masking exactly
-    # the bug this test exists to catch. Spies on the real subprocess.run
-    # (still executed for real, never mocked out) to confirm git grep
-    # itself actually received and matched this path rather than silently
-    # falling back.
+
     git = shutil.which("git")
     assert git is not None
 
@@ -4743,24 +4091,19 @@ def test_main_handles_path_containing_spaces_and_unicode(
     )
 
     real_run = subprocess.run
-    # Every subprocess.run call made once the spy is installed below is a
-    # git-grep call: meaningless-vars' own two prefilter patterns ("data",
-    # "result") are the only thing that invokes git_grep_filter() for this
-    # single-file, single-check run (a lone file argument never triggers
-    # expand_directories()'s own git ls-files call).
+
     grep_commands: list[list[str]] = []
     grep_results: list[subprocess.CompletedProcess[str]] = []
 
     def _spy_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        completed_process = real_run(*args, **kwargs)  # type: ignore[call-overload]
-        grep_commands.append(args[0])  # type: ignore[arg-type]
+        completed_process = real_run(*args, **kwargs)
+        grep_commands.append(args[0])
         grep_results.append(completed_process)
         return completed_process
 
     with contextlib.chdir(tmp_path):
-        # Args are hardcoded test setup, not untrusted input.
-        subprocess.run([git, "init", "-q"], check=True)  # noqa: S603
-        subprocess.run([git, "add", filepath], check=True)  # noqa: S603
+        subprocess.run([git, "init", "-q"], check=True)
+        subprocess.run([git, "add", filepath], check=True)
 
         monkeypatch.setattr(subprocess, "run", _spy_run)
         exit_code = main([str(filepath), "--select", "meaningless-vars", "--fix"])
@@ -4768,11 +4111,8 @@ def test_main_handles_path_containing_spaces_and_unicode(
     assert grep_results, "git grep was never invoked -- fell back to the Python-only path"
     assert all(result.stderr == "" for result in grep_results)
     assert any(result.returncode == 0 for result in grep_results)
-    # Prove the path itself reached the command as a real, intact argument --
-    # a command that dropped the pathspec (searching the whole repo instead
-    # of this one file) would still find the sole match and pass every
-    # assertion above, silently losing path scoping without this check.
-    assert all(str(filepath) in command for command in grep_commands)  # pytriage: TR6
+
+    assert all(str(filepath) in command for command in grep_commands)
 
     assert exit_code == 1
     assert "[FIXED]" in capsys.readouterr().err
@@ -4782,10 +4122,7 @@ def test_main_handles_path_containing_spaces_and_unicode(
 
 
 def test_process_files_handles_a_large_file(tmp_path: Path) -> None:
-    # ch. 31: "MUST test large files." This is a correctness check, not a
-    # performance benchmark (ch. 24/30's own concern) -- it only proves
-    # every violation in a large file is still found and fixed correctly,
-    # with nothing dropped, corrupted, or left unprocessed.
+
     function_count = 300
     source = "import requests\n\n" + "\n\n".join(
         f"def func_{i}():\n    data = requests.get(url)\n    return data.status_code" for i in range(function_count)
@@ -4824,8 +4161,7 @@ def test_per_file_ignores_runs_a_check_on_the_files_it_does_not_match(tmp_path: 
 
 
 def test_a_per_file_ignored_check_is_still_handed_the_files_content(tmp_path: Path) -> None:
-    # Suppressing a report in one file must not withhold that file from the
-    # cross-file analysis another file's report depends on; see ADR-0049.
+
     ignored = tmp_path / "dependency.py"
     ignored.write_text("x = 1\n")
     checked = tmp_path / "importer.py"
@@ -4896,9 +4232,7 @@ def test_a_cross_file_candidate_is_skipped_where_its_check_is_ignored(tmp_path: 
 
 
 def test_an_ignored_check_leaves_the_remaining_ones_their_own_cache_identity(tmp_path: Path) -> None:
-    # The cached result of a run that skipped a check must never be served to
-    # a run that did not, which is what deciding hook_name per file buys;
-    # see ADR-0049.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("data = 1\n")
     cache_dir = tmp_path / ".cache"
@@ -4917,8 +4251,7 @@ def test_an_ignored_check_leaves_the_remaining_ones_their_own_cache_identity(tmp
 
 
 def test_an_ignored_file_is_not_fed_to_a_check_already_found_unavailable(tmp_path: Path) -> None:
-    # A missing prerequisite does not get better on the next file, so the
-    # check is not worth feeding again this run either.
+
     checked = tmp_path / "importer.py"
     checked.write_text("x = 1\n")
     ignored = tmp_path / "dependency.py"
@@ -4937,8 +4270,7 @@ def test_an_ignored_file_is_not_fed_to_a_check_already_found_unavailable(tmp_pat
 def test_a_prefilter_skips_the_files_its_own_check_is_ignored_for(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Scanning for a check that cannot run is the expensive half of deciding
-    # something already decided; see ADR-0049.
+
     ignored = tmp_path / "skip_me.py"
     ignored.write_text("x = 1\n")
     checked = tmp_path / "check_me.py"
@@ -4970,7 +4302,7 @@ def test_a_prefilter_skips_the_files_its_own_check_is_ignored_for(
     )
 
     assert scanned["probe-marker"] == [checked_path]
-    # A check that has to be handed the file regardless is still asked.
+
     assert scanned["cross-file-marker"] == sorted([checked_path, ignored_path])
 
 
@@ -4990,10 +4322,7 @@ def test_an_exclude_pattern_is_resolved_against_its_anchor(tmp_path: Path, patte
 
 
 def _cross_file_probe_orchestrator(tmp_path: Path, probe: _CrossFileProbeCheck) -> CheckOrchestrator:
-    """A cacheable check that sees every file, plus a cross-file check the
-    named file switches off -- so a second run hits the cache with nothing
-    left to re-run.
-    """
+
     return CheckOrchestrator(
         checks=[_MarkerFixableCheck(check_id="probe-a"), probe],
         cache_dir=tmp_path / ".cache",
@@ -5002,8 +4331,7 @@ def _cross_file_probe_orchestrator(tmp_path: Path, probe: _CrossFileProbeCheck) 
 
 
 def test_a_clean_cache_hit_still_hands_an_ignored_file_to_a_cross_file_check(tmp_path: Path) -> None:
-    # Nothing else opens the file on this path, so the direct-input lifecycle
-    # has to; see ADR-0049.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n")
 
@@ -5032,9 +4360,7 @@ def test_an_unreadable_file_is_reported_even_on_a_clean_cache_hit(tmp_path: Path
 
 
 def test_an_entry_for_a_check_this_run_cannot_run_changes_nothing(tmp_path: Path) -> None:
-    # One table serves both published hooks (ADR-0045), so an entry naming
-    # only the other one's check must not make this run read a file its own
-    # prefilter already dropped.
+
     filepath = tmp_path / "module.py"
     filepath.write_text("def broken(\n")
     orchestrator = CheckOrchestrator(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -331,7 +331,7 @@ def test_expand_directories_caps_gitignore_warning_at_a_bounded_number_of_paths(
 def _patch_status_popen(monkeypatch: pytest.MonkeyPatch, status_command: list[str] | None) -> None:
     real_popen = subprocess.Popen
 
-    def fake_popen(cmd: list[str], *args: object, **kwargs: Any) -> subprocess.Popen[bytes]:
+    def fake_popen(cmd: list[str], *args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
         if "status" in cmd:
             if status_command is None:
                 raise FileNotFoundError("git not found")
@@ -4095,7 +4095,7 @@ def test_main_handles_path_containing_spaces_and_unicode(
     grep_commands: list[list[str]] = []
     grep_results: list[subprocess.CompletedProcess[str]] = []
 
-    def _spy_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    def _spy_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         completed_process = real_run(*args, **kwargs)
         grep_commands.append(args[0])
         grep_results.append(completed_process)

--- a/tests/test_redundant_super_init.py
+++ b/tests/test_redundant_super_init.py
@@ -87,50 +87,49 @@ class Child(Base):
     assert "Base.__init__()" in violation.message
 
 
-def test_check_records_each_suppressed_pytriage_usage() -> None:
-    source = """class Base:
-    def __init__(self):
-        pass
-
-
-class First(Base):
-    def __init__(self, **kwargs):  # pytriage: TR3
-        super().__init__(**kwargs)
-
-
-class Second(Base):
-    def __init__(self, **kwargs):  # pytriage: TR3
-        super().__init__(**kwargs)
-"""
+@pytest.mark.parametrize(
+    ("second_fragment", "expected_lines"),
+    [
+        (
+            (
+                "class Second(Base):\n"
+                "    def __init__(self, **kwargs):  # pytriage: TR3\n"
+                "        super().__init__(**kwargs)\n"
+            ),
+            [7, 12],
+        ),
+        (
+            (
+                "# fmt: off\n"
+                "class Second(Base):\n"
+                "    def __init__(self, **kwargs):\n"
+                "        super().__init__(**kwargs)\n"
+                "# fmt: on\n"
+            ),
+            [7],
+        ),
+    ],
+    ids=["pytriage", "format-suppressed"],
+)
+def test_check_records_suppression_usage_for_each_reportable_candidate(
+    second_fragment: str, expected_lines: list[int]
+) -> None:
+    source = (
+        "class Base:\n"
+        "    def __init__(self):\n"
+        "        pass\n"
+        "\n\n"
+        "class First(Base):\n"
+        "    def __init__(self, **kwargs):  # pytriage: TR3\n"
+        "        super().__init__(**kwargs)\n"
+        "\n\n"
+        f"{second_fragment}"
+    )
 
     check_result = RedundantSuperInitCheck().check(Path("test.py"), ast.parse(source), source)
 
     assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [7, 12]
-
-
-def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
-    source = """class Base:
-    def __init__(self):
-        pass
-
-
-class First(Base):
-    def __init__(self, **kwargs):  # pytriage: TR3
-        super().__init__(**kwargs)
-
-
-# fmt: off
-class Second(Base):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-# fmt: on
-"""
-
-    check_result = RedundantSuperInitCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [7]
+    assert [usage.line for usage in check_result.suppression_usages] == expected_lines
 
 
 @pytest.mark.parametrize(

--- a/tests/test_redundant_super_init.py
+++ b/tests/test_redundant_super_init.py
@@ -87,6 +87,52 @@ class Child(Base):
     assert "Base.__init__()" in violation.message
 
 
+def test_check_records_each_suppressed_pytriage_usage() -> None:
+    source = """class Base:
+    def __init__(self):
+        pass
+
+
+class First(Base):
+    def __init__(self, **kwargs):  # pytriage: TR3
+        super().__init__(**kwargs)
+
+
+class Second(Base):
+    def __init__(self, **kwargs):  # pytriage: TR3
+        super().__init__(**kwargs)
+"""
+
+    check_result = RedundantSuperInitCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [7, 12]
+
+
+def test_check_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
+    source = """class Base:
+    def __init__(self):
+        pass
+
+
+class First(Base):
+    def __init__(self, **kwargs):  # pytriage: TR3
+        super().__init__(**kwargs)
+
+
+# fmt: off
+class Second(Base):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+# fmt: on
+"""
+
+    check_result = RedundantSuperInitCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [7]
+
+
 @pytest.mark.parametrize(
     ("source", "flagged"),
     [

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -6,9 +6,18 @@ from typing import cast
 
 import pytest
 
-from pre_commit_hooks.ast_checks._base import ASTCheck, CheckResult, FixOutcome, FixResult, SuppressionUsage, Violation
+from pre_commit_hooks.ast_checks._base import (
+    ASTCheck,
+    BaseCheck,
+    CheckResult,
+    FixOutcome,
+    FixResult,
+    SuppressionUsage,
+    Violation,
+)
 from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks._orchestrator import CheckOrchestrator, load_checks
+from pre_commit_hooks.ast_checks.excessive_blank_lines import ExcessiveBlankLinesCheck
 from pre_commit_hooks.ast_checks.meaningless_vars import MeaninglessVarsCheck, MeaninglessVarsLevel
 from pre_commit_hooks.ast_checks.unused_pytriage import UnusedPytriageCheck
 from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck
@@ -129,27 +138,24 @@ def test_unused_pytriage_uses_cached_suppression_usage(tmp_path: Path, monkeypat
 
 
 def test_unused_pytriage_supports_checks_with_a_default_tracking_hook(tmp_path: Path) -> None:
-    class PlainCheck:
-        check_id = "plain-check"
-        error_code = "TR99"
-        cacheable = False
-        tracks_direct_inputs = False
+    class PlainCheck(BaseCheck):
+        @property
+        def check_id(self) -> str:
+            return "plain-check"
 
-        @staticmethod
-        def get_prefilter_pattern() -> list[str]:
+        @property
+        def error_code(self) -> str:
+            return "TR99"
+
+        @property
+        def cacheable(self) -> bool:
+            return False
+
+        def get_prefilter_pattern(self) -> list[str]:
             return ["# pytriage:"]
 
-        @staticmethod
-        def check(_filepath: Path, _tree: object, _source: str) -> CheckResult:
+        def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> CheckResult:
             return CheckResult([], [SuppressionUsage("plain-check", "TR99", 2)])
-
-        @staticmethod
-        def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
-            return PlainCheck.check(_filepath, _tree, _source)
-
-        @staticmethod
-        def fix(_filepath: Path, violations: list[Violation], _source: str, _tree: object) -> FixResult:
-            return FixResult.for_violations(violations, FixOutcome.DECLINED)
 
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1\n# pytriage: TR99\n")
@@ -158,9 +164,6 @@ def test_unused_pytriage_supports_checks_with_a_default_tracking_hook(tmp_path: 
         CheckOrchestrator(checks=[cast("ASTCheck", PlainCheck()), UnusedPytriageCheck()]).process_files([str(filepath)])
         == {}
     )
-    assert PlainCheck.fix(
-        filepath, [Violation("plain-check", "TR99", 2, 0, "unused", fixable=False)], "", object()
-    ).outcomes == (FixOutcome.DECLINED,)
 
 
 def test_unused_pytriage_failure_is_recorded(tmp_path: Path) -> None:
@@ -180,12 +183,119 @@ def test_unused_pytriage_failure_is_recorded(tmp_path: Path) -> None:
     assert orchestrator.rule_failures == [(str(filepath), "unused-pytriage")]
 
 
+def test_unused_pytriage_refresh_records_an_audit_failure_after_fix(tmp_path: Path) -> None:
+    class FailingRefreshAudit(UnusedPytriageCheck):
+        __slots__ = ("calls",)
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def check_with_suppression_usage(
+            self, source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
+        ) -> CheckResult:
+            self.calls += 1
+            if self.calls == 2:
+                raise RuntimeError("refresh audit failed")
+            return super().check_with_suppression_usage(source, usages, active_error_codes)
+
+    filepath = tmp_path / "module.py"
+    filepath.write_text('"""Doc."""  # pytriage: TR99\n\n\n\ndef example() -> str:\n    return "hi"\n')
+    audit = FailingRefreshAudit()
+    orchestrator = CheckOrchestrator(checks=[ExcessiveBlankLinesCheck(), audit], fix_mode=True)
+
+    orchestrator.process_files([str(filepath)])
+
+    assert audit.calls == 2
+    assert orchestrator.rule_failures == [(str(filepath), "unused-pytriage")]
+
+
+def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path: Path) -> None:
+    class CacheableCheck(BaseCheck):
+        @property
+        def check_id(self) -> str:
+            return "cacheable-check"
+
+        @property
+        def error_code(self) -> str:
+            return "TR97"
+
+        def get_prefilter_pattern(self) -> list[str] | None:
+            return None
+
+        def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> CheckResult:
+            return CheckResult()
+
+    class AlwaysFixingCheck(BaseCheck):
+        __slots__ = ()
+
+        @property
+        def check_id(self) -> str:
+            return "always-fixing-check"
+
+        @property
+        def error_code(self) -> str:
+            return "TR98"
+
+        @property
+        def cacheable(self) -> bool:
+            return False
+
+        def get_prefilter_pattern(self) -> list[str] | None:
+            return None
+
+        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
+            if "# fixed\n" in source:
+                return CheckResult()
+            return CheckResult([Violation(self.check_id, self.error_code, 1, 0, "needs fixing", fixable=True)])
+
+        def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+            return CheckResult(
+                self.check(filepath, tree, source),
+                [SuppressionUsage(self.check_id, self.error_code, 1)],
+            )
+
+        def fix(
+            self, filepath: Path, violations: list[Violation], source: str, _tree: ast.Module, _encoding: str = "utf-8"
+        ) -> FixResult:
+            filepath.write_text(source + "# fixed\n")
+            return FixResult.for_violations(violations, FixOutcome.APPLIED)
+
+    class RecordingAudit(UnusedPytriageCheck):
+        __slots__ = ("calls",)
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[tuple[SuppressionUsage, ...], frozenset[str]]] = []
+
+        def check_with_suppression_usage(
+            self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
+        ) -> CheckResult:
+            self.calls.append((usages, active_error_codes))
+            return CheckResult()
+
+    filepath = tmp_path / "module.py"
+    filepath.write_text("x = 1  # pytriage: TR99\n")
+    cache_dir = tmp_path / "cache"
+    cacheable_check = cast("ASTCheck", CacheableCheck())
+    CheckOrchestrator(checks=[cacheable_check], cache_dir=cache_dir).process_files([str(filepath)])
+    audit = RecordingAudit()
+
+    CheckOrchestrator(
+        checks=[cacheable_check, AlwaysFixingCheck(), audit], cache_dir=cache_dir, fix_mode=True
+    ).process_files([str(filepath)])
+
+    assert audit.calls[-1] == ((SuppressionUsage("always-fixing-check", "TR98", 1),), frozenset({"TR97", "TR98"}))
+
+
 def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])
     monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: None)
+    violations_result = CheckResult([Violation("test", "TR99", 1, 0, "message", fixable=False)])
 
-    orchestrator._refresh_unused_pytriage(filepath, [], [UnusedPytriageCheck()], CheckResult())
+    orchestrator._refresh_unused_pytriage(filepath, [], [UnusedPytriageCheck()], violations_result)
+
+    assert violations_result == [Violation("test", "TR99", 1, 0, "message", fixable=False)]
+    assert orchestrator.rule_failures == []
 
 
 def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -198,9 +308,13 @@ def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monk
         error_code = "TR99"
 
     monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    violations_result = CheckResult([Violation("test", "TR99", 1, 0, "message", fixable=False)])
     orchestrator._refresh_unused_pytriage(
-        filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], CheckResult()
+        filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], violations_result
     )
+
+    assert violations_result == [Violation("test", "TR99", 1, 0, "message", fixable=False)]
+    assert orchestrator.rule_failures == []
 
 
 def test_unused_pytriage_refresh_records_a_check_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from pre_commit_hooks.ast_checks._base import ASTCheck, CheckResult, FixOutcome, FixResult, SuppressionUsage, Violation
+from pre_commit_hooks.ast_checks._cli import main
+from pre_commit_hooks.ast_checks._orchestrator import CheckOrchestrator, load_checks
+from pre_commit_hooks.ast_checks.meaningless_vars import MeaninglessVarsCheck, MeaninglessVarsLevel
+from pre_commit_hooks.ast_checks.unused_pytriage import UnusedPytriageCheck
+from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck
+
+
+def test_unused_pytriage_reports_redundant_known_suppression(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("def example():\n    result = 1  # pytriage: TR1\n    return result\n")
+
+    assert (
+        main(
+            [
+                str(filepath),
+                "--select",
+                "meaningless-vars,unused-pytriage",
+            ]
+        )
+        == 1
+    )
+
+    assert "TR8" in capsys.readouterr().err
+
+
+def test_unused_pytriage_alone_does_not_audit_inactive_checks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("def example():\n    result = 1  # pytriage: TR1\n    return result\n")
+
+    assert main([str(filepath), "--select", "unused-pytriage"]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_unused_pytriage_is_opt_in_by_default() -> None:
+    assert "unused-pytriage" not in {check.check_id for check in load_checks()}
+    assert "unused-pytriage" in {check.check_id for check in load_checks(select={"unused-pytriage"})}
+
+
+def test_unused_pytriage_keeps_a_used_suppression_clean(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("def example():\n    result = get_result()  # pytriage: TR1\n    return result\n")
+
+    assert (
+        main([str(filepath), "--select", "meaningless-vars,unused-pytriage", "--meaningless-vars-level", "permissive"])
+        == 0
+    )
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize(
+    "comment",
+    ["# pytriage: TR1,TR1", "# pytriage: TR99", "# pytriage: TR8"],
+    ids=["duplicate", "unknown", "self"],
+)
+def test_unused_pytriage_ignores_non_reportable_entries(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], comment: str
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text(f"def example():\n    result = 42  {comment}\n    return result\n")
+
+    assert main([str(filepath), "--select", "meaningless-vars,unused-pytriage"]) == (1 if "TR1" in comment else 0)
+    if "TR1" in comment:
+        assert "TR1, TR1" in capsys.readouterr().err
+    else:
+        assert capsys.readouterr().err == ""
+
+
+def test_unused_pytriage_does_not_audit_format_suppressed_comments(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("# fmt: off\ndef example():\n    result = 42  # pytriage: TR1\n    return result\n# fmt: on\n")
+
+    assert main([str(filepath), "--select", "meaningless-vars,unused-pytriage"]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_unused_pytriage_reports_at_the_final_location_after_other_fixes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text('"""Doc."""\n\n\n\ndef example():\n    result = 42  # pytriage: TR1\n    return result\n')
+
+    assert (
+        main(
+            [
+                str(filepath),
+                "--select",
+                "excessive-blank-lines,meaningless-vars,unused-pytriage",
+                "--fix",
+            ]
+        )
+        == 1
+    )
+    assert ":5:18: TR8:" in capsys.readouterr().err
+
+
+def test_unused_pytriage_uses_cached_suppression_usage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("def example():\n    result = get_result()  # pytriage: TR1\n    return result\n")
+    cache_dir = tmp_path / "cache"
+    check_args = {"meaningless-vars": {"level": MeaninglessVarsLevel.PERMISSIVE}}
+    checks = load_checks(select={"meaningless-vars", "unused-pytriage"}, check_args=check_args)
+
+    first = CheckOrchestrator(checks=checks, cache_dir=cache_dir)
+    assert first.process_files([str(filepath)]) == {}
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> list[object]:
+        raise AssertionError("meaningless-vars should be served from its cache")
+
+    monkeypatch.setattr(MeaninglessVarsCheck, "check", fail_if_called)
+    second = CheckOrchestrator(
+        checks=load_checks(select={"meaningless-vars", "unused-pytriage"}, check_args=check_args), cache_dir=cache_dir
+    )
+    assert second.process_files([str(filepath)]) == {}
+
+
+def test_unused_pytriage_supports_checks_without_tracking_hook(tmp_path: Path) -> None:
+    class PlainCheck:
+        check_id = "plain-check"
+        error_code = "TR99"
+        cacheable = False
+        tracks_direct_inputs = False
+
+        @staticmethod
+        def get_prefilter_pattern() -> list[str]:
+            return ["# pytriage:"]
+
+        @staticmethod
+        def check(_filepath: Path, _tree: object, _source: str) -> CheckResult:
+            return CheckResult([], [SuppressionUsage("plain-check", "TR99", 2)])
+
+        @staticmethod
+        def fix(_filepath: Path, violations: list[Violation], _source: str, _tree: object) -> FixResult:
+            return FixResult.for_violations(violations, FixOutcome.DECLINED)
+
+    filepath = tmp_path / "module.py"
+    filepath.write_text("x = 1\n# pytriage: TR99\n")
+
+    assert (
+        CheckOrchestrator(checks=[cast("ASTCheck", PlainCheck()), UnusedPytriageCheck()]).process_files([str(filepath)])
+        == {}
+    )
+    assert PlainCheck.fix(
+        filepath, [Violation("plain-check", "TR99", 2, 0, "unused", fixable=False)], "", object()
+    ).outcomes == (FixOutcome.DECLINED,)
+
+
+def test_unused_pytriage_failure_is_recorded(tmp_path: Path) -> None:
+    class FailingAudit(UnusedPytriageCheck):
+        __slots__ = ()
+
+        def check_with_suppression_usage(
+            self, _source: str, _usages: tuple[SuppressionUsage, ...], _active_error_codes: frozenset[str]
+        ) -> CheckResult:
+            raise RuntimeError("audit failed")
+
+    filepath = tmp_path / "module.py"
+    filepath.write_text("x = 1  # pytriage: TR99\n")
+    orchestrator = CheckOrchestrator(checks=[FailingAudit()])
+
+    assert orchestrator.process_files([str(filepath)]) == {}
+    assert orchestrator.rule_failures == [(str(filepath), "unused-pytriage")]
+
+
+def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    filepath = tmp_path / "module.py"
+    orchestrator = CheckOrchestrator(checks=[])
+    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: None)
+
+    orchestrator._refresh_unused_pytriage(filepath, [], [UnusedPytriageCheck()], CheckResult())
+
+
+def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    filepath = tmp_path / "module.py"
+    orchestrator = CheckOrchestrator(checks=[])
+    orchestrator._unavailable_check_ids.add("unavailable")
+
+    class UnavailableCheck:
+        check_id = "unavailable"
+        error_code = "TR99"
+
+    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    orchestrator._refresh_unused_pytriage(
+        filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], CheckResult()
+    )
+
+
+def test_unused_pytriage_refresh_records_a_check_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    filepath = tmp_path / "module.py"
+    orchestrator = CheckOrchestrator(checks=[])
+
+    class FailingCheck:
+        check_id = "failing-check"
+        error_code = "TR99"
+
+        @staticmethod
+        def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
+            raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    orchestrator._refresh_unused_pytriage(
+        filepath, [cast("ASTCheck", FailingCheck())], [UnusedPytriageCheck()], CheckResult()
+    )
+
+    assert orchestrator.rule_failures == [(str(filepath), "failing-check")]
+
+
+def test_unused_pytriage_fix_declines() -> None:
+    violation = Violation("unused-pytriage", "TR8", 1, 0, "unused", fixable=False)
+
+    fix_result = UnusedPytriageCheck().fix(Path("test.py"), [violation], "x = 1\n", ast.parse("x = 1\n"))
+
+    assert fix_result.outcomes == (FixOutcome.DECLINED,)
+
+
+def test_validate_function_name_records_a_pytriage_usage() -> None:
+    source = "def get_total(numbers):  # pytriage: TR4\n    return sum(numbers)\n"
+
+    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("validate-function-name", "TR4", 1)
+    ]
+
+
+def test_validate_function_name_records_each_suppressed_pytriage_usage() -> None:
+    source = (
+        "def get_total(numbers):  # pytriage: TR4\n"
+        "    return sum(numbers)\n"
+        "def get_max(numbers):  # pytriage: TR4\n"
+        "    return max(numbers)\n"
+    )
+
+    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [1, 3]
+
+
+def test_validate_function_name_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
+    source = (
+        "def get_total(numbers):  # pytriage: TR4\n"
+        "    return sum(numbers)\n"
+        "# fmt: off\n"
+        "def get_max(numbers):\n"
+        "    return max(numbers)\n"
+        "# fmt: on\n"
+    )
+
+    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [usage.line for usage in check_result.suppression_usages] == [1]

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -231,42 +231,39 @@ def test_unused_pytriage_fix_declines() -> None:
     assert fix_result.outcomes == (FixOutcome.DECLINED,)
 
 
-def test_validate_function_name_records_a_pytriage_usage() -> None:
-    source = "def get_total(numbers):  # pytriage: TR4\n    return sum(numbers)\n"
-
-    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
+@pytest.mark.parametrize(
+    ("source", "expected_lines"),
+    [
+        ("def get_total(numbers):  # pytriage: TR4\n    return sum(numbers)\n", [1]),
+        (
+            (
+                "def get_total(numbers):  # pytriage: TR4\n"
+                "    return sum(numbers)\n"
+                "def get_max(numbers):  # pytriage: TR4\n"
+                "    return max(numbers)\n"
+            ),
+            [1, 3],
+        ),
+        (
+            (
+                "def get_total(numbers):  # pytriage: TR4\n"
+                "    return sum(numbers)\n"
+                "# fmt: off\n"
+                "def get_max(numbers):\n"
+                "    return max(numbers)\n"
+                "# fmt: on\n"
+            ),
+            [1],
+        ),
+    ],
+    ids=["single", "multiple", "format-suppressed"],
+)
+def test_validate_function_name_records_pytriage_usage(source: str, expected_lines: list[int]) -> None:
+    check_result = ValidateFunctionNameCheck().check_with_suppression_tracking(
+        Path("test.py"), ast.parse(source), source
+    )
 
     assert check_result == []
     assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
-        ("validate-function-name", "TR4", 1)
+        ("validate-function-name", "TR4", line) for line in expected_lines
     ]
-
-
-def test_validate_function_name_records_each_suppressed_pytriage_usage() -> None:
-    source = (
-        "def get_total(numbers):  # pytriage: TR4\n"
-        "    return sum(numbers)\n"
-        "def get_max(numbers):  # pytriage: TR4\n"
-        "    return max(numbers)\n"
-    )
-
-    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [1, 3]
-
-
-def test_validate_function_name_ignores_a_format_suppressed_candidate_when_tracking_usage() -> None:
-    source = (
-        "def get_total(numbers):  # pytriage: TR4\n"
-        "    return sum(numbers)\n"
-        "# fmt: off\n"
-        "def get_max(numbers):\n"
-        "    return max(numbers)\n"
-        "# fmt: on\n"
-    )
-
-    check_result = ValidateFunctionNameCheck().check(Path("test.py"), ast.parse(source), source)
-
-    assert check_result == []
-    assert [usage.line for usage in check_result.suppression_usages] == [1]

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -290,6 +290,92 @@ def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path
     assert [violation.check_id for violation in violations_for_file].count("always-fixing-check") == 1
 
 
+def test_unused_pytriage_rerun_discards_stale_cached_usage_after_always_fix(
+    tmp_path: Path,
+) -> None:
+    class CacheableCheck(BaseCheck):
+        @property
+        def check_id(self) -> str:
+            return "cacheable-check"
+
+        @property
+        def error_code(self) -> str:
+            return "TR97"
+
+        def get_prefilter_pattern(self) -> list[str] | None:
+            return None
+
+        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
+            if "# fixed" in source:
+                return CheckResult()
+            return CheckResult(
+                [Violation(self.check_id, self.error_code, 2, 0, "needs fixing", fixable=False)],
+                [SuppressionUsage(self.check_id, self.error_code, 1)],
+            )
+
+    class AlwaysFixingCheck(BaseCheck):
+        __slots__ = ()
+
+        @property
+        def check_id(self) -> str:
+            return "always-fixing-check"
+
+        @property
+        def error_code(self) -> str:
+            return "TR98"
+
+        @property
+        def cacheable(self) -> bool:
+            return False
+
+        def get_prefilter_pattern(self) -> list[str] | None:
+            return None
+
+        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
+            if "# fixed" in source:
+                return CheckResult()
+            return CheckResult([Violation(self.check_id, self.error_code, 2, 0, "needs fixing", fixable=True)])
+
+        def fix(
+            self, filepath: Path, violations: list[Violation], source: str, _tree: ast.Module, _encoding: str = "utf-8"
+        ) -> FixResult:
+            filepath.write_text(source.replace("bad = 1", "good = 1") + "# fixed\n")
+            return FixResult.for_violations(violations, FixOutcome.APPLIED)
+
+    class RecordingAudit(UnusedPytriageCheck):
+        __slots__ = ("calls",)
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[tuple[SuppressionUsage, ...], frozenset[str]]] = []
+
+        def check_with_suppression_usage(
+            self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
+        ) -> CheckResult:
+            self.calls.append((usages, active_error_codes))
+            return CheckResult(
+                [] if usages else [Violation(self.check_id, self.error_code, 1, 0, "unused", fixable=False)]
+            )
+
+    filepath = tmp_path / "module.py"
+    filepath.write_text("x = 1  # pytriage: TR97\nbad = 1\n")
+    cache_dir = tmp_path / "cache"
+    cacheable_check = cast("ASTCheck", CacheableCheck())
+    CheckOrchestrator(checks=[cacheable_check], cache_dir=cache_dir).process_files([str(filepath)])
+    audit = RecordingAudit()
+
+    violations = CheckOrchestrator(
+        checks=[cacheable_check, AlwaysFixingCheck(), audit], cache_dir=cache_dir, fix_mode=True
+    ).process_files([str(filepath)])
+
+    assert audit.calls[-1] == ((), frozenset({"TR97", "TR98"}))
+    assert [violation.check_id for violation in violations[str(filepath)]] == [
+        "always-fixing-check",
+        "cacheable-check",
+        "unused-pytriage",
+    ]
+    assert "# pytriage: TR97" in filepath.read_text()
+
+
 def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -22,6 +22,9 @@ from pre_commit_hooks.ast_checks.excessive_blank_lines import ExcessiveBlankLine
 from pre_commit_hooks.ast_checks.meaningless_vars import MeaninglessVarsCheck, MeaninglessVarsLevel
 from pre_commit_hooks.ast_checks.unused_pytriage import UnusedPytriageCheck
 from pre_commit_hooks.ast_checks.validate_function_name import ValidateFunctionNameCheck
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_unused_pytriage_reports_redundant_known_suppression(
@@ -376,10 +379,22 @@ def test_unused_pytriage_rerun_discards_stale_cached_usage_after_always_fix(
     assert "# pytriage: TR97" in filepath.read_text()
 
 
-def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def patch_parsed_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[tuple[str, ast.Module] | None], None]:
+    def patch(parsed: tuple[str, ast.Module] | None) -> None:
+        monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: parsed)
+
+    return patch
+
+
+def test_unused_pytriage_refresh_handles_a_missing_file(
+    tmp_path: Path, patch_parsed_source: Callable[[tuple[str, ast.Module] | None], None]
+) -> None:
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])
-    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: None)
+    patch_parsed_source(None)
     violations_result = CheckResult([Violation("test", "TR99", 1, 0, "message", fixable=False)])
 
     orchestrator._refresh_unused_pytriage(filepath, [], [UnusedPytriageCheck()], violations_result)
@@ -388,7 +403,9 @@ def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypa
     assert orchestrator.rule_failures == []
 
 
-def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unused_pytriage_refresh_skips_an_unavailable_check(
+    tmp_path: Path, patch_parsed_source: Callable[[tuple[str, ast.Module] | None], None]
+) -> None:
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])
     orchestrator._unavailable_check_ids.add("unavailable")
@@ -397,7 +414,7 @@ def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monk
         check_id = "unavailable"
         error_code = "TR99"
 
-    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    patch_parsed_source(("x = 1\n", ast.parse("x = 1\n")))
     violations_result = CheckResult([Violation("test", "TR99", 1, 0, "message", fixable=False)])
     orchestrator._refresh_unused_pytriage(
         filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], violations_result
@@ -407,45 +424,46 @@ def test_unused_pytriage_refresh_skips_an_unavailable_check(tmp_path: Path, monk
     assert orchestrator.rule_failures == []
 
 
-def test_unused_pytriage_refresh_records_a_check_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "case",
+    [
+        (RuntimeError("refresh failed"), "failing-check", True, []),
+        (
+            CheckUnavailableError("refresh unavailable"),
+            "unavailable-check",
+            False,
+            [("unavailable-check", "refresh unavailable")],
+        ),
+    ],
+    ids=["failure", "unavailable"],
+)
+def test_unused_pytriage_refresh_records_check_outcomes(
+    tmp_path: Path,
+    patch_parsed_source: Callable[[tuple[str, ast.Module] | None], None],
+    case: tuple[Exception, str, bool, list[tuple[str, str]]],
+) -> None:
+    raised, check_id, expect_rule_failure, expected_unavailable = case
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])
 
-    class FailingCheck:
-        check_id = "failing-check"
+    class RaisedCheck:
         error_code = "TR99"
+
+        @property
+        def check_id(self) -> str:
+            return check_id
 
         @staticmethod
         def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
-            raise RuntimeError("refresh failed")
+            raise raised
 
-    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    patch_parsed_source(("x = 1\n", ast.parse("x = 1\n")))
     orchestrator._refresh_unused_pytriage(
-        filepath, [cast("ASTCheck", FailingCheck())], [UnusedPytriageCheck()], CheckResult()
+        filepath, [cast("ASTCheck", RaisedCheck())], [UnusedPytriageCheck()], CheckResult()
     )
 
-    assert orchestrator.rule_failures == [(str(filepath), "failing-check")]
-
-
-def test_unused_pytriage_refresh_records_an_unavailable_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    filepath = tmp_path / "module.py"
-    orchestrator = CheckOrchestrator(checks=[])
-
-    class UnavailableCheck:
-        check_id = "unavailable-check"
-        error_code = "TR99"
-
-        @staticmethod
-        def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
-            raise CheckUnavailableError("refresh unavailable")
-
-    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
-    orchestrator._refresh_unused_pytriage(
-        filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], CheckResult()
-    )
-
-    assert orchestrator.rule_failures == []
-    assert orchestrator.unavailable_checks == [("unavailable-check", "refresh unavailable")]
+    assert orchestrator.rule_failures == ([(filepath.as_posix(), check_id)] if expect_rule_failure else [])
+    assert orchestrator.unavailable_checks == expected_unavailable
 
 
 def test_unused_pytriage_fix_declines() -> None:

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -128,7 +128,7 @@ def test_unused_pytriage_uses_cached_suppression_usage(tmp_path: Path, monkeypat
     assert second.process_files([str(filepath)]) == {}
 
 
-def test_unused_pytriage_supports_checks_without_tracking_hook(tmp_path: Path) -> None:
+def test_unused_pytriage_supports_checks_with_a_default_tracking_hook(tmp_path: Path) -> None:
     class PlainCheck:
         check_id = "plain-check"
         error_code = "TR99"
@@ -142,6 +142,10 @@ def test_unused_pytriage_supports_checks_without_tracking_hook(tmp_path: Path) -
         @staticmethod
         def check(_filepath: Path, _tree: object, _source: str) -> CheckResult:
             return CheckResult([], [SuppressionUsage("plain-check", "TR99", 2)])
+
+        @staticmethod
+        def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
+            return PlainCheck.check(_filepath, _tree, _source)
 
         @staticmethod
         def fix(_filepath: Path, violations: list[Violation], _source: str, _tree: object) -> FixResult:

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -10,6 +10,7 @@ from pre_commit_hooks.ast_checks._base import (
     ASTCheck,
     BaseCheck,
     CheckResult,
+    CheckUnavailableError,
     FixOutcome,
     FixResult,
     SuppressionUsage,
@@ -130,7 +131,7 @@ def test_unused_pytriage_uses_cached_suppression_usage(tmp_path: Path, monkeypat
     def fail_if_called(*_args: object, **_kwargs: object) -> list[object]:
         raise AssertionError("meaningless-vars should be served from its cache")
 
-    monkeypatch.setattr(MeaninglessVarsCheck, "check", fail_if_called)
+    monkeypatch.setattr(MeaninglessVarsCheck, "_check", fail_if_called)
     second = CheckOrchestrator(
         checks=load_checks(select={"meaningless-vars", "unused-pytriage"}, check_args=check_args), cache_dir=cache_dir
     )
@@ -270,7 +271,7 @@ def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path
             self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
         ) -> CheckResult:
             self.calls.append((usages, active_error_codes))
-            return CheckResult()
+            return CheckResult([Violation("unused-pytriage", "TR8", 1, 0, "stale audit", fixable=False)])
 
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1  # pytriage: TR99\n")
@@ -279,11 +280,14 @@ def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path
     CheckOrchestrator(checks=[cacheable_check], cache_dir=cache_dir).process_files([str(filepath)])
     audit = RecordingAudit()
 
-    CheckOrchestrator(
+    violations = CheckOrchestrator(
         checks=[cacheable_check, AlwaysFixingCheck(), audit], cache_dir=cache_dir, fix_mode=True
     ).process_files([str(filepath)])
 
     assert audit.calls[-1] == ((SuppressionUsage("always-fixing-check", "TR98", 1),), frozenset({"TR97", "TR98"}))
+    violations_for_file = violations[str(filepath)]
+    assert [violation.check_id for violation in violations_for_file].count("unused-pytriage") == 1
+    assert [violation.check_id for violation in violations_for_file].count("always-fixing-check") == 1
 
 
 def test_unused_pytriage_refresh_handles_a_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -335,6 +339,27 @@ def test_unused_pytriage_refresh_records_a_check_failure(tmp_path: Path, monkeyp
     )
 
     assert orchestrator.rule_failures == [(str(filepath), "failing-check")]
+
+
+def test_unused_pytriage_refresh_records_an_unavailable_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    filepath = tmp_path / "module.py"
+    orchestrator = CheckOrchestrator(checks=[])
+
+    class UnavailableCheck:
+        check_id = "unavailable-check"
+        error_code = "TR99"
+
+        @staticmethod
+        def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
+            raise CheckUnavailableError("refresh unavailable")
+
+    monkeypatch.setattr(CheckOrchestrator, "_parsed_source", lambda _self, _filepath: ("x = 1\n", ast.parse("x = 1\n")))
+    orchestrator._refresh_unused_pytriage(
+        filepath, [cast("ASTCheck", UnavailableCheck())], [UnusedPytriageCheck()], CheckResult()
+    )
+
+    assert orchestrator.rule_failures == []
+    assert orchestrator.unavailable_checks == [("unavailable-check", "refresh unavailable")]
 
 
 def test_unused_pytriage_fix_declines() -> None:

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -27,6 +27,127 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+class _CacheableRerunCheck(BaseCheck):
+    __slots__ = ("_suppression_usage_line", "_violation_line")
+
+    def __init__(self, *, violation_line: int | None, suppression_usage_line: int | None) -> None:
+        self._violation_line = violation_line
+        self._suppression_usage_line = suppression_usage_line
+
+    @property
+    def check_id(self) -> str:
+        return "cacheable-check"
+
+    @property
+    def error_code(self) -> str:
+        return "TR97"
+
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return None
+
+    def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
+        if "# fixed" in source or self._violation_line is None:
+            return CheckResult()
+        suppression_usages = (
+            ()
+            if self._suppression_usage_line is None
+            else (SuppressionUsage(self.check_id, self.error_code, self._suppression_usage_line),)
+        )
+        return CheckResult(
+            [Violation(self.check_id, self.error_code, self._violation_line, 0, "needs fixing", fixable=False)],
+            suppression_usages,
+        )
+
+
+class _AlwaysFixingRerunCheck(BaseCheck):
+    __slots__ = ("_replacement", "_suppression_usage_line", "_violation_line")
+
+    def __init__(
+        self,
+        *,
+        violation_line: int,
+        suppression_usage_line: int | None,
+        replacement: tuple[str, str] | None = None,
+    ) -> None:
+        self._violation_line = violation_line
+        self._suppression_usage_line = suppression_usage_line
+        self._replacement = replacement
+
+    @property
+    def check_id(self) -> str:
+        return "always-fixing-check"
+
+    @property
+    def error_code(self) -> str:
+        return "TR98"
+
+    @property
+    def cacheable(self) -> bool:
+        return False
+
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return None
+
+    def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
+        if "# fixed" in source:
+            return CheckResult()
+        return CheckResult(
+            [Violation(self.check_id, self.error_code, self._violation_line, 0, "needs fixing", fixable=True)]
+        )
+
+    def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        suppression_usages = (
+            ()
+            if self._suppression_usage_line is None
+            else (SuppressionUsage(self.check_id, self.error_code, self._suppression_usage_line),)
+        )
+        return CheckResult(self.check(filepath, tree, source), suppression_usages)
+
+    def fix(
+        self, filepath: Path, violations: list[Violation], source: str, _tree: ast.Module, _encoding: str = "utf-8"
+    ) -> FixResult:
+        if self._replacement is None:
+            fixed_source = source + "# fixed\n"
+        else:
+            fixed_source = source.replace(*self._replacement) + "# fixed\n"
+        filepath.write_text(fixed_source)
+        return FixResult.for_violations(violations, FixOutcome.APPLIED)
+
+
+class _RecordingRerunAudit(UnusedPytriageCheck):
+    __slots__ = ("_report_with_usages", "calls")
+
+    def __init__(self, *, report_with_usages: bool) -> None:
+        self._report_with_usages = report_with_usages
+        self.calls: list[tuple[tuple[SuppressionUsage, ...], frozenset[str]]] = []
+
+    def check_with_suppression_usage(
+        self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
+    ) -> CheckResult:
+        self.calls.append((usages, active_error_codes))
+        if self._report_with_usages or not usages:
+            return CheckResult([Violation(self.check_id, self.error_code, 1, 0, "unused", fixable=False)])
+        return CheckResult()
+
+
+def _make_cacheable_rerun_check(
+    *, violation_line: int | None, suppression_usage_line: int | None
+) -> _CacheableRerunCheck:
+    return _CacheableRerunCheck(violation_line=violation_line, suppression_usage_line=suppression_usage_line)
+
+
+def _make_always_fixing_rerun_check(
+    *, violation_line: int, suppression_usage_line: int | None, replacement: tuple[str, str] | None = None
+) -> _AlwaysFixingRerunCheck:
+    return _AlwaysFixingRerunCheck(
+        violation_line=violation_line, suppression_usage_line=suppression_usage_line, replacement=replacement
+    )
+
+
+def _make_recording_rerun_audit(*, report_with_usages: bool) -> _RecordingRerunAudit:
+    return _RecordingRerunAudit(report_with_usages=report_with_usages)
+
+
 def test_unused_pytriage_reports_redundant_known_suppression(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -214,77 +335,21 @@ def test_unused_pytriage_refresh_records_an_audit_failure_after_fix(tmp_path: Pa
 
 
 def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path: Path) -> None:
-    class CacheableCheck(BaseCheck):
-        @property
-        def check_id(self) -> str:
-            return "cacheable-check"
-
-        @property
-        def error_code(self) -> str:
-            return "TR97"
-
-        def get_prefilter_pattern(self) -> list[str] | None:
-            return None
-
-        def check(self, _filepath: Path, _tree: ast.Module, _source: str) -> CheckResult:
-            return CheckResult()
-
-    class AlwaysFixingCheck(BaseCheck):
-        __slots__ = ()
-
-        @property
-        def check_id(self) -> str:
-            return "always-fixing-check"
-
-        @property
-        def error_code(self) -> str:
-            return "TR98"
-
-        @property
-        def cacheable(self) -> bool:
-            return False
-
-        def get_prefilter_pattern(self) -> list[str] | None:
-            return None
-
-        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
-            if "# fixed\n" in source:
-                return CheckResult()
-            return CheckResult([Violation(self.check_id, self.error_code, 1, 0, "needs fixing", fixable=True)])
-
-        def check_with_suppression_tracking(self, filepath: Path, tree: ast.Module, source: str) -> CheckResult:
-            return CheckResult(
-                self.check(filepath, tree, source),
-                [SuppressionUsage(self.check_id, self.error_code, 1)],
-            )
-
-        def fix(
-            self, filepath: Path, violations: list[Violation], source: str, _tree: ast.Module, _encoding: str = "utf-8"
-        ) -> FixResult:
-            filepath.write_text(source + "# fixed\n")
-            return FixResult.for_violations(violations, FixOutcome.APPLIED)
-
-    class RecordingAudit(UnusedPytriageCheck):
-        __slots__ = ("calls",)
-
-        def __init__(self) -> None:
-            self.calls: list[tuple[tuple[SuppressionUsage, ...], frozenset[str]]] = []
-
-        def check_with_suppression_usage(
-            self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
-        ) -> CheckResult:
-            self.calls.append((usages, active_error_codes))
-            return CheckResult([Violation("unused-pytriage", "TR8", 1, 0, "stale audit", fixable=False)])
-
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1  # pytriage: TR99\n")
     cache_dir = tmp_path / "cache"
-    cacheable_check = cast("ASTCheck", CacheableCheck())
+    cacheable_check = cast("ASTCheck", _make_cacheable_rerun_check(violation_line=None, suppression_usage_line=None))
     CheckOrchestrator(checks=[cacheable_check], cache_dir=cache_dir).process_files([str(filepath)])
-    audit = RecordingAudit()
+    audit = _make_recording_rerun_audit(report_with_usages=True)
 
     violations = CheckOrchestrator(
-        checks=[cacheable_check, AlwaysFixingCheck(), audit], cache_dir=cache_dir, fix_mode=True
+        checks=[
+            cacheable_check,
+            _make_always_fixing_rerun_check(violation_line=1, suppression_usage_line=1),
+            audit,
+        ],
+        cache_dir=cache_dir,
+        fix_mode=True,
     ).process_files([str(filepath)])
 
     assert audit.calls[-1] == ((SuppressionUsage("always-fixing-check", "TR98", 1),), frozenset({"TR97", "TR98"}))
@@ -296,78 +361,23 @@ def test_unused_pytriage_rerun_retains_always_rerun_suppression_context(tmp_path
 def test_unused_pytriage_rerun_discards_stale_cached_usage_after_always_fix(
     tmp_path: Path,
 ) -> None:
-    class CacheableCheck(BaseCheck):
-        @property
-        def check_id(self) -> str:
-            return "cacheable-check"
-
-        @property
-        def error_code(self) -> str:
-            return "TR97"
-
-        def get_prefilter_pattern(self) -> list[str] | None:
-            return None
-
-        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
-            if "# fixed" in source:
-                return CheckResult()
-            return CheckResult(
-                [Violation(self.check_id, self.error_code, 2, 0, "needs fixing", fixable=False)],
-                [SuppressionUsage(self.check_id, self.error_code, 1)],
-            )
-
-    class AlwaysFixingCheck(BaseCheck):
-        __slots__ = ()
-
-        @property
-        def check_id(self) -> str:
-            return "always-fixing-check"
-
-        @property
-        def error_code(self) -> str:
-            return "TR98"
-
-        @property
-        def cacheable(self) -> bool:
-            return False
-
-        def get_prefilter_pattern(self) -> list[str] | None:
-            return None
-
-        def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
-            if "# fixed" in source:
-                return CheckResult()
-            return CheckResult([Violation(self.check_id, self.error_code, 2, 0, "needs fixing", fixable=True)])
-
-        def fix(
-            self, filepath: Path, violations: list[Violation], source: str, _tree: ast.Module, _encoding: str = "utf-8"
-        ) -> FixResult:
-            filepath.write_text(source.replace("bad = 1", "good = 1") + "# fixed\n")
-            return FixResult.for_violations(violations, FixOutcome.APPLIED)
-
-    class RecordingAudit(UnusedPytriageCheck):
-        __slots__ = ("calls",)
-
-        def __init__(self) -> None:
-            self.calls: list[tuple[tuple[SuppressionUsage, ...], frozenset[str]]] = []
-
-        def check_with_suppression_usage(
-            self, _source: str, usages: tuple[SuppressionUsage, ...], active_error_codes: frozenset[str]
-        ) -> CheckResult:
-            self.calls.append((usages, active_error_codes))
-            return CheckResult(
-                [] if usages else [Violation(self.check_id, self.error_code, 1, 0, "unused", fixable=False)]
-            )
-
     filepath = tmp_path / "module.py"
     filepath.write_text("x = 1  # pytriage: TR97\nbad = 1\n")
     cache_dir = tmp_path / "cache"
-    cacheable_check = cast("ASTCheck", CacheableCheck())
+    cacheable_check = cast("ASTCheck", _make_cacheable_rerun_check(violation_line=2, suppression_usage_line=1))
     CheckOrchestrator(checks=[cacheable_check], cache_dir=cache_dir).process_files([str(filepath)])
-    audit = RecordingAudit()
+    audit = _make_recording_rerun_audit(report_with_usages=False)
 
     violations = CheckOrchestrator(
-        checks=[cacheable_check, AlwaysFixingCheck(), audit], cache_dir=cache_dir, fix_mode=True
+        checks=[
+            cacheable_check,
+            _make_always_fixing_rerun_check(
+                violation_line=2, suppression_usage_line=None, replacement=("bad = 1", "good = 1")
+            ),
+            audit,
+        ],
+        cache_dir=cache_dir,
+        fix_mode=True,
     ).process_files([str(filepath)])
 
     assert audit.calls[-1] == ((), frozenset({"TR97", "TR98"}))
@@ -442,7 +452,7 @@ def test_unused_pytriage_refresh_records_check_outcomes(
     patch_parsed_source: Callable[[tuple[str, ast.Module] | None], None],
     case: tuple[Exception, str, bool, list[tuple[str, str]]],
 ) -> None:
-    raised, check_id, expect_rule_failure, expected_unavailable = case
+    raised, expected_check_id, expect_rule_failure, expected_unavailable = case
     filepath = tmp_path / "module.py"
     orchestrator = CheckOrchestrator(checks=[])
 
@@ -451,7 +461,7 @@ def test_unused_pytriage_refresh_records_check_outcomes(
 
         @property
         def check_id(self) -> str:
-            return check_id
+            return expected_check_id
 
         @staticmethod
         def check_with_suppression_tracking(_filepath: Path, _tree: object, _source: str) -> CheckResult:
@@ -462,7 +472,7 @@ def test_unused_pytriage_refresh_records_check_outcomes(
         filepath, [cast("ASTCheck", RaisedCheck())], [UnusedPytriageCheck()], CheckResult()
     )
 
-    assert orchestrator.rule_failures == ([(filepath.as_posix(), check_id)] if expect_rule_failure else [])
+    assert orchestrator.rule_failures == ([(filepath.as_posix(), expected_check_id)] if expect_rule_failure else [])
     assert orchestrator.unavailable_checks == expected_unavailable
 
 

--- a/tests/test_unused_pytriage.py
+++ b/tests/test_unused_pytriage.py
@@ -381,3 +381,21 @@ def test_validate_function_name_records_pytriage_usage(source: str, expected_lin
     assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
         ("validate-function-name", "TR4", line) for line in expected_lines
     ]
+
+
+def test_validate_function_name_tracks_a_suppression_alongside_an_unsuppressed_suggestion() -> None:
+    source = (
+        "def get_total(numbers):  # pytriage: TR4\n"
+        "    return sum(numbers)\n"
+        "def get_max(numbers):\n"
+        "    return max(numbers)\n"
+    )
+
+    check_result = ValidateFunctionNameCheck().check_with_suppression_tracking(
+        Path("test.py"), ast.parse(source), source
+    )
+
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("validate-function-name", "TR4", 1)
+    ]
+    assert [violation.error_code for violation in check_result] == ["TR4"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the opt-in `unused-pytriage` (TR8) check to identify redundant `# pytriage` suppression codes.
  * Tracks suppression usage across checks, including TR5 and TR6 analyses, with auditing against final source.
  * Supports multiple and unknown suppression codes, cached results, and combined check selection.
  * Reports unused suppressions without modifying comments, including when fixes are enabled.
  * Excludes formatting-suppressed lines and reduces redundant analysis.

* **Documentation**
  * Added usage guidance, glossary definitions, release notes, and design documentation for suppression auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->