### PR TITLE
fix(misplaced-comment): preserve all Sphinx markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Changed
+
+- `misplaced-comment` preserves `#:` documentation comments wherever they appear.
+
 ## [0.2.0] - 2026-08-21
 
 ### Changed

--- a/docs/audits/sphinx-doc-comment-scope.md
+++ b/docs/audits/sphinx-doc-comment-scope.md
@@ -1,0 +1,18 @@
+# Research: Sphinx `#:` documentation-comment scope
+
+## Finding
+
+Sphinx `autodoc` defines `#:` as a documentation comment for module data members and class attributes. It recognises a one-line comment on the assignment or one or more contiguous lines before it. The published class example also recognises `self` assignments in `__init__` as instance attributes. Ordinary function-local assignments are not a documented target.
+
+The implementation confirms that distinction. Its parser records assignments in module and class context, and records assignments inside `__init__` under the containing class; it returns no qualified name for other function-local assignments. It handles both `ast.Assign` and `ast.AnnAssign`, and also `ast.TypeAlias` in current Sphinx.
+
+Therefore, excluding every comment that starts `#:` is the safe rule for a formatter that must never rewrite a Sphinx documentation comment. A narrower exemption limited to module-level assignments remains vulnerable to documented class and `__init__` attribute comments. This is intentionally conservative: Sphinx's current parser skips `try` handlers and `finally` suites, but leaving a possible documentation comment unchanged is safer than making a destructive inference about a user's documentation toolchain.
+
+## Sources
+
+- [Sphinx autodoc: doc comments and docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#doc-comments-and-docstrings) defines `#:` comments, their permitted placement, and shows class and `__init__` instance attributes.
+- [Sphinx autodoc: automatic data and attributes](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#automatically-document-attributes-or-data) defines `autodata` for module variables/constants and `autoattribute` for class attributes.
+- [Sphinx parser scope selection](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/pycode/parser.py#L1854-L1870) rejects ordinary function locals while retaining class `__init__` instance attributes.
+- [Sphinx parser assignment comment collection](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/pycode/parser.py#L1978-L2085) processes `Assign` and `AnnAssign`; [PEP 695 aliases](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/pycode/parser.py#L2254-L2266) are processed too.
+- [Sphinx parser try traversal](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/pycode/parser.py#L2181-L2195) visits only a `try` body's and `else` suite, not its handlers or `finally` suite.
+- [ModuleAnalyzer](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/pycode/__init__.py#L799-L848) exposes those parsed comments as class and module attribute documentation.

--- a/docs/rules/misplaced-comment.md
+++ b/docs/rules/misplaced-comment.md
@@ -22,7 +22,7 @@ result = func(
 
 ## Features
 
-- Automatically moves comments from closing bracket lines to expression lines, except Sphinx `#:` documentation comments on module-level assignments
+- Automatically moves comments from closing bracket lines to expression lines, except `#:` documentation comments
 - Places comments inline if they fit within 88 characters, matching this project's own line-length convention; otherwise places them as preceding comments on their own line
 - Never moves linter pragma comments (`noqa`, `type: ignore`, `pragma:`, etc.)
 - Inline suppression with `# pytriage: TR7`

--- a/src/pre_commit_hooks/ast_checks/misplaced_comment.py
+++ b/src/pre_commit_hooks/ast_checks/misplaced_comment.py
@@ -10,7 +10,6 @@ Inline ignore: # pytriage: TR7
 
 from __future__ import annotations
 
-import ast
 import functools
 import logging
 import re
@@ -35,6 +34,7 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
+    import ast
     from pathlib import Path
 
 logger = logging.getLogger("misplaced_comment")
@@ -94,7 +94,6 @@ class _MisplacedComment:
 
 def _scan_misplaced_comments(
     tokens: tuple[tokenize.TokenInfo, ...],
-    tree: ast.Module,
 ) -> list[_MisplacedComment]:
     """Find comments trailing bracket-only closing lines.
 
@@ -112,11 +111,6 @@ def _scan_misplaced_comments(
     for token in tokens:
         tokens_by_line.setdefault(token.start[0], []).append(token)
 
-    sphinx_attribute_comment_lines = {
-        node.end_lineno
-        for node in tree.body
-        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.end_lineno is not None
-    }
     found: list[_MisplacedComment] = []
     seen_bracket_lines: set[int] = set()
 
@@ -130,15 +124,10 @@ def _scan_misplaced_comments(
 
         line_tokens = tokens_by_line[bracket_line]
         comment_token = next((t for t in line_tokens if t.type == tokenize.COMMENT), None)
-        is_sphinx_attribute_comment = (
-            comment_token is not None
-            and comment_token.string.startswith("#:")
-            and bracket_line in sphinx_attribute_comment_lines
-        )
         if (
             comment_token is not None
             and not is_linter_pragma(comment_token.string)
-            and not is_sphinx_attribute_comment
+            and not comment_token.string.startswith("#:")
             and is_bracket_only_line(line_tokens)
         ):
             found.append(
@@ -167,9 +156,9 @@ class MisplacedCommentCheck(BaseCheck):
     def get_prefilter_pattern(self) -> list[str] | None:
         return ["#"]
 
-    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+    def check(self, _filepath: Path, _tree: ast.Module, source: str) -> CheckResult:
         tokens = tuple(tokenize_source(source))
-        found = _scan_misplaced_comments(tokens, tree)
+        found = _scan_misplaced_comments(tokens)
         if not found:
             return CheckResult()
 
@@ -210,11 +199,11 @@ class MisplacedCommentCheck(BaseCheck):
         filepath: Path,
         violations: list[Violation],
         source: str,
-        tree: ast.Module,
+        _tree: ast.Module,
         encoding: str = "utf-8",
     ) -> FixResult:
         tokens = tuple(tokenize_source(source))
-        found = _scan_misplaced_comments(tokens, tree)
+        found = _scan_misplaced_comments(tokens)
         if not found:
             return FixResult.for_violations(violations, FixOutcome.DECLINED)
 

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -10,6 +10,38 @@ from pre_commit_hooks.ast_checks._cli import main
 from pre_commit_hooks.ast_checks.misplaced_comment import MisplacedCommentCheck
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "misplaced_comments"
+MODULE_TRY_ASSIGN_SOURCE = (
+    "try:\n"
+    "    value = make_value(\n"
+    "        argument\n"
+    "    )  #: Description\n"
+    "except ImportError:\n"
+    "    value = make_placeholder()\n"
+)
+MODULE_TRY_ANN_ASSIGN_SOURCE = (
+    "try:\n"
+    "    value: object = make_value(\n"
+    "        argument\n"
+    "    )  #: Description\n"
+    "except ImportError:\n"
+    "    value = make_placeholder()\n"
+)
+ASYNC_FUNCTION_LOCAL_SOURCE = "async def make_value():\n    process(\n        argument\n    )  #: Description\n"
+CLASS_ATTRIBUTE_SOURCE = (
+    "class Serializer:\n"
+    "    pipeline = SerializerPipeline(\n"
+    '        name="optional",\n'
+    "        is_binary=True,\n"
+    "    )  #: Complete optional serializer\n"
+)
+INSTANCE_ATTRIBUTE_SOURCE = (
+    "class Serializer:\n"
+    "    def __init__(self) -> None:\n"
+    "        self.pipeline = SerializerPipeline(\n"
+    '            name="optional",\n'
+    "            is_binary=True,\n"
+    "        )  #: Complete optional serializer\n"
+)
 
 
 def test_check_id_and_error_code() -> None:
@@ -102,12 +134,46 @@ def test_check_records_suppression_usage_for_each_reportable_candidate(
             0,
         ),
         (
+            MODULE_TRY_ASSIGN_SOURCE,
+            MODULE_TRY_ASSIGN_SOURCE,
+            0,
+        ),
+        (
+            MODULE_TRY_ANN_ASSIGN_SOURCE,
+            MODULE_TRY_ANN_ASSIGN_SOURCE,
+            0,
+        ),
+        (
             "def make_value():\n    process(\n        argument\n    )  #: Description\n",
-            "def make_value():\n    process(\n        argument  #: Description\n    )\n",
-            1,
+            "def make_value():\n    process(\n        argument\n    )  #: Description\n",
+            0,
+        ),
+        (
+            ASYNC_FUNCTION_LOCAL_SOURCE,
+            ASYNC_FUNCTION_LOCAL_SOURCE,
+            0,
+        ),
+        (
+            CLASS_ATTRIBUTE_SOURCE,
+            CLASS_ATTRIBUTE_SOURCE,
+            0,
+        ),
+        (
+            INSTANCE_ATTRIBUTE_SOURCE,
+            INSTANCE_ATTRIBUTE_SOURCE,
+            0,
         ),
     ],
-    ids=["module-level-assignment", "module-level-annotated-assignment", "nested-expression"],
+    ids=[
+        "module-level-assignment",
+        "module-level-annotated-assignment",
+        "module-level-try-assignment",
+        "module-level-try-annotated-assignment",
+        "function-local-marker",
+        "async-function-local-marker",
+        "class-attribute",
+        "instance-attribute",
+    ],
 )
 def test_cli_fix_handles_sphinx_attribute_comments(
     source: str,
@@ -116,10 +182,10 @@ def test_cli_fix_handles_sphinx_attribute_comments(
     tmp_path: Path,
 ) -> None:
     filepath = tmp_path / "module.py"
-    filepath.write_text(source)
+    filepath.write_bytes(source.encode())
 
     assert main(["--select", "misplaced-comment", "--fix", str(filepath)]) == expected_exit_code
-    assert filepath.read_text() == expected_source
+    assert filepath.read_bytes() == expected_source.encode()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_misplaced_comment.py
+++ b/tests/test_misplaced_comment.py
@@ -44,6 +44,12 @@ INSTANCE_ATTRIBUTE_SOURCE = (
 )
 
 
+def _write_module_source(tmp_path: Path, source: str) -> Path:
+    filepath = tmp_path / "module.py"
+    filepath.write_bytes(source.encode())
+    return filepath
+
+
 def test_check_id_and_error_code() -> None:
     check = MisplacedCommentCheck()
     assert check.check_id == "misplaced-comment"
@@ -181,8 +187,7 @@ def test_cli_fix_handles_sphinx_attribute_comments(
     expected_exit_code: int,
     tmp_path: Path,
 ) -> None:
-    filepath = tmp_path / "module.py"
-    filepath.write_bytes(source.encode())
+    filepath = _write_module_source(tmp_path, source)
 
     assert main(["--select", "misplaced-comment", "--fix", str(filepath)]) == expected_exit_code
     assert filepath.read_bytes() == expected_source.encode()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `misplaced-comment` now preserves `#:` documentation comments wherever they appear.
  - Comments on class attributes, instance attributes, assignments, and asynchronous function code remain unchanged when fixing files.
  - Prevented automatic comment movement in additional Sphinx-supported documentation-comment contexts.

- **Documentation**
  - Clarified the rule’s handling of `#:` documentation comments.
  - Added guidance on supported Sphinx comment scopes and parser edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->