### PR TITLE
Do not report context managers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,14 +105,13 @@ repos:
           ]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/
         args:
           [
             --fix,
-            --isolated,
             --meaningless-vars-level=permissive,
             --redundant-assignment-level=permissive,
           ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Changed
+
+- `validate-function-name` no longer reports `get_`-prefixed context-manager functions, since their names can describe project-specific resource acquisition.
+
 ## [0.2.1] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-08-22
+
 ### Changed
 
 - `validate-function-name` no longer reports `get_`-prefixed context-manager functions, since their names can describe project-specific resource acquisition.

--- a/docs/rules/validate-function-name.md
+++ b/docs/rules/validate-function-name.md
@@ -63,6 +63,7 @@ Applies equally to `async def get_*` functions.
   - Functions that only call other `get_*` functions
   - Test functions: `test_get_*`
   - Lazy singleton and cache accessors: a `get_` function that only builds or loads its result on a guarded fallback path (e.g. `if _cache is None: _cache = build(); return _cache`) keeps its `get_` prefix, since the guarded work isn't what happens on every call
+  - Context-manager functions: the `get_` prefix can describe resource acquisition, so the name is left to the project
 
 ```yaml
 - id: ruff-extra-rules

--- a/src/pre_commit_hooks/__init__.py
+++ b/src/pre_commit_hooks/__init__.py
@@ -1,3 +1,3 @@
 """Custom pre-commit hooks for code quality enforcement."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/validate_function_name/analysis.py
@@ -782,6 +782,9 @@ def suggest_name_for(func_node: ast.FunctionDef | ast.AsyncFunctionDef, analysis
     if is_decorator_override_or_abstract(func_node):
         return old, "skip: decorated with @override or @abstractmethod"
 
+    if _is_context_manager(func_node):
+        return old, "context manager name is left to the author"
+
     if analysis["delegates_get"]:
         return old, "delegates to another get_ function; skipping suggestion"
 
@@ -824,11 +827,6 @@ def suggest_name_for(func_node: ast.FunctionDef | ast.AsyncFunctionDef, analysis
         suggested = entity or old
         reason = "@property: prefer noun name rather than verb"
         return suggested, reason
-
-    if _is_context_manager(func_node):
-        if isinstance(getattr(func_node, "parent", None), ast.ClassDef):
-            return old, "context manager method; get prefix is acceptable"
-        return entity or old, "context manager; prefer noun phrase"
 
     # A generator's calling contract (must be iterated, can't be used as a
     # plain return value) is a stronger, unambiguous signal than any verb

--- a/tests/validate_function_name/test_analysis.py
+++ b/tests/validate_function_name/test_analysis.py
@@ -1334,8 +1334,8 @@ def test_extract_first_verb(docstring_line: str, verb: str | None) -> None:
         (
             ("from contextlib import contextmanager\n\n@contextmanager\ndef get_transaction():\n    yield object()\n"),
             "get_transaction",
-            "transaction",
-            "context manager; prefer noun phrase",
+            "get_transaction",
+            "context manager name is left to the author",
         ),
         (
             (
@@ -1346,20 +1346,20 @@ def test_extract_first_verb(docstring_line: str, verb: str | None) -> None:
                 "    yield object()\n"
             ),
             "get_tempfile_session",
-            "tempfile_session",
-            "context manager; prefer noun phrase",
+            "get_tempfile_session",
+            "context manager name is left to the author",
         ),
         (
             ("import contextlib\n\n@contextlib.contextmanager\ndef get_connection():\n    yield object()\n"),
             "get_connection",
-            "connection",
-            "context manager; prefer noun phrase",
+            "get_connection",
+            "context manager name is left to the author",
         ),
         (
             ("import contextlib\n\n@contextlib.asynccontextmanager\nasync def get_lock():\n    yield object()\n"),
             "get_lock",
-            "lock",
-            "context manager; prefer noun phrase",
+            "get_lock",
+            "context manager name is left to the author",
         ),
     ],
     ids=[
@@ -1370,10 +1370,10 @@ def test_extract_first_verb(docstring_line: str, verb: str | None) -> None:
         "validates-only-suggests-validate",
         "transforms-only-suggests-transform",
         "generator-outranks-disk-read",
-        "context-manager-uses-noun-phrase",
-        "async-context-manager-uses-noun-phrase",
-        "qualified-context-manager-uses-noun-phrase",
-        "qualified-async-context-manager-uses-noun-phrase",
+        "context-manager-name-is-accepted",
+        "async-context-manager-name-is-accepted",
+        "qualified-context-manager-name-is-accepted",
+        "qualified-async-context-manager-name-is-accepted",
     ],
 )
 def test_suggest_name_for(source: str, func_name: str, suggested_name: str, reason: str) -> None:

--- a/tests/validate_function_name/test_check.py
+++ b/tests/validate_function_name/test_check.py
@@ -110,18 +110,20 @@ def test_fix_applies_safe_suggestion(tmp_path: Path) -> None:
     assert "def is_data() -> bool:" in filepath.read_text()
 
 
-def test_fix_applies_context_manager_rename(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("decorator", "definition"),
+    [
+        ("contextmanager", "def get_transaction():"),
+        ("asynccontextmanager", "async def get_connection():"),
+        ("contextlib.contextmanager", "def get_lock():"),
+        ("contextlib.asynccontextmanager", "async def get_session():"),
+    ],
+    ids=["sync", "async", "qualified-sync", "qualified-async"],
+)
+def test_context_manager_names_are_not_reported(tmp_path: Path, decorator: str, definition: str) -> None:
     filepath = tmp_path / "mod.py"
     source = (
-        "from contextlib import asynccontextmanager\n"
-        "\n"
-        "@asynccontextmanager\n"
-        "async def get_tempfile_session():\n"
-        "    yield object()\n"
-        "\n"
-        "async def use_session():\n"
-        "    async with get_tempfile_session() as session:\n"
-        "        return session\n"
+        f'import contextlib\n\n@{decorator}\n{definition}\n    """Load the managed resource."""\n    yield object()\n'
     )
     filepath.write_text(source)
     tree = ast.parse(source)
@@ -129,11 +131,9 @@ def test_fix_applies_context_manager_rename(tmp_path: Path) -> None:
     check = ValidateFunctionNameCheck()
     violations = check.check(filepath, tree, source)
 
-    assert len(violations) == 1
-    assert violations[0].fixable is True
-    assert FixOutcome.APPLIED in check.fix(filepath, violations, source, tree).outcomes
-    assert "async def tempfile_session()" in filepath.read_text()
-    assert "async with tempfile_session() as session:" in filepath.read_text()
+    assert violations == []
+    assert FixOutcome.APPLIED not in check.fix(filepath, violations, source, tree).outcomes
+    assert filepath.read_text() == source
 
 
 def test_sync_lazy_accessor_property_suggestion_is_not_fixable(tmp_path: Path) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Context-manager functions prefixed with `get_` are no longer incorrectly flagged or renamed.
  - Behavior is consistent for synchronous, asynchronous, and qualified context-manager decorators.

- **Documentation**
  - Updated rule documentation and changelog to describe the preserved naming exception.

- **Chores**
  - Updated the release version to 0.2.2 and refreshed the pre-commit validation hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->