### PR TITLE
Implement `redundant-dict-get`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: local-ruff-extra-rules-default
         name: Extra Python rule checks (self-check with default values + auto-fix)
-        description: Run our own AST-based checks against src/, tests/, and benchmarks/fixtures/, except redundant-type-conversion (see local-ruff-extra-rules-ty)
+        description: Run our own AST-based checks against src/, tests/, and benchmarks/fixtures/, except the checks in local-ruff-extra-rules-ty
         # `uv run` resolves this project's own managed venv regardless of
         # the ambient shell's PATH, since `language: system` hooks run
         # outside any pre-commit-managed environment (a plain `git commit`,
@@ -60,7 +60,7 @@ repos:
         exclude: ^tests/fixtures/
       - id: local-ruff-extra-rules-aggressive
         name: Extra Python rule checks (self-check with the strictest config)
-        description: Run our own AST-based checks against src/ and tests/, except redundant-type-conversion (see local-ruff-extra-rules-ty)
+        description: Run our own AST-based checks against src/ and tests/, except the checks in local-ruff-extra-rules-ty
         entry: uv run python -m pre_commit_hooks.ruff_extra_rules
         language: system
         types: [python]
@@ -72,9 +72,9 @@ repos:
             "--redundant-assignment-level=permissive",
           ]
       - id: local-ruff-extra-rules-ty
-        name: Extra Python rule checks (redundant-type-conversion, serial)
+        name: Extra Python rule checks (redundant-type-conversion, redundant-dict-get, serial)
         description: >-
-          Runs redundant-type-conversion (TR6) alone, as a single serial process: it's the only check
+          Runs redundant-type-conversion (TR6) and redundant-dict-get (TR9), as a single serial process: TR6 is the only check
           sharing a persistent ty daemon across files (ADR-0041), so running it inside the parallel-batched
           hooks above would make pre-commit/prek's own parallel workers contend with themselves over that
           one shared daemon instead of running independently.
@@ -86,7 +86,7 @@ repos:
         require_serial: true
         args: [--ignore=unused-pytriage]
       - id: local-ruff-extra-rules-ty-aggressive
-        name: Extra Python rule checks (redundant-type-conversion, serial, strictest config)
+        name: Extra Python rule checks (redundant-type-conversion, redundant-dict-get, serial, strictest config)
         description: >-
           Same as local-ruff-extra-rules-ty, at permissive confidence -- kept as its own hook (like
           local-ruff-extra-rules-aggressive) rather than folded into the one above: permissive considers

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,12 +1,12 @@
 - id: ruff-extra-rules
   name: Extra Python rule checks (ruff-extra-rules)
-  description: Run multiple AST-based checks in a single pass for improved performance. Excludes redundant-type-conversion (TR6) -- see the ruff-extra-rules-ty hook.
+  description: Run multiple AST-based checks in a single pass for improved performance. Excludes redundant-type-conversion (TR6) and redundant-dict-get (TR9) -- see the ruff-extra-rules-ty hook.
   entry: python -m pre_commit_hooks.ruff_extra_rules
   language: python
   types: [python]
 - id: ruff-extra-rules-ty
-  name: Extra Python rule checks (redundant-type-conversion)
-  description: Run redundant-type-conversion (TR6), plus unused-pytriage (TR8) when selected. TR6 is the only check that shares a persistent ty daemon across files (ADR-0041), so this hook runs as a single, serial process.
+  name: Extra Python rule checks (redundant-type-conversion, redundant-dict-get)
+  description: Run redundant-type-conversion (TR6) and redundant-dict-get (TR9), plus unused-pytriage (TR8) when selected. TR6 shares a persistent ty daemon across files (ADR-0041), so this hook runs as a single, serial process.
   entry: python -m pre_commit_hooks.ruff_extra_rules_ty
   language: python
   types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Added
+
+- `redundant-dict-get` (TR9) reports local `.get()` calls whose key presence is already proven. It is report-only.
+
 ## [0.2.2] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Individual checks are toggled with `--select`/`--ignore` (or the matching `pypro
 | [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TR6  | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
 | [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
 | [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; add it with `--extend-select=unused-pytriage`.                                                      |
+| [redundant-dict-get](docs/rules/redundant-dict-get.md)               | TR9  | Reports `dict.get()` calls where local code already proves the key exists.                                                                                                        |
 
 ## Installation
 
@@ -41,12 +42,12 @@ repos:
     rev: <tag> # pin a release tag; see the CHANGELOG for what each one changes
     hooks:
       - id: ruff-extra-rules
-      - id: ruff-extra-rules-ty # optional: adds redundant-type-conversion (TR6), see below
+      - id: ruff-extra-rules-ty # optional: adds redundant-type-conversion (TR6) and redundant-dict-get (TR9), see below
 ```
 
-`ruff-extra-rules-ty` normally runs [redundant-type-conversion](docs/rules/redundant-type-conversion.md) by itself. When `unused-pytriage` is enabled through `extend-select`, it also audits TR6 suppressions. The hook is optional and requires [`ty`](https://github.com/astral-sh/ty) on `PATH`.
+`ruff-extra-rules-ty` runs [redundant-type-conversion](docs/rules/redundant-type-conversion.md) and [redundant-dict-get](docs/rules/redundant-dict-get.md). When `unused-pytriage` is enabled through `extend-select`, it also audits TR6 and TR9 suppressions. The hook is optional and requires [`ty`](https://github.com/astral-sh/ty) on `PATH`.
 
-`ruff-extra-rules` always excludes `redundant-type-conversion`; `ruff-extra-rules-ty` owns that check and the shared `unused-pytriage` audit. Both read the same configuration and accept the same options; a check one hook can't run is simply left out rather than rejected, so a single configuration works for both.
+`ruff-extra-rules` always excludes `redundant-type-conversion` and `redundant-dict-get`; `ruff-extra-rules-ty` owns those checks and the shared `unused-pytriage` audit. Both read the same configuration and accept the same options; a check one hook can't run is simply left out rather than rejected, so a single configuration works for both.
 
 Run `check-ast` and `ruff-check` in the same `.pre-commit-config.yaml` — syntax errors are their job, not this tool's; see the [FAQ](docs/faq.md#does-this-catch-syntax-errors).
 

--- a/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
+++ b/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
@@ -1,0 +1,31 @@
+# Redundant dict.get uses local key-presence proofs
+
+## Context
+
+`dict.get(key)` expresses that a key might be absent. When the current path already proves that key exists, the optional-facing access hides an invariant and makes the code less direct. Replacing it with `dict[key]` is not an automatic fix: Python mapping implementations may give the two operations distinct behavior, even for a present key.
+
+`docs/audits/type-checker-coverage-for-redundant-dict-get.md` records that ty, Mypy, and Pyright do not report the supported proven-presence examples as redundant access.
+
+Required `TypedDict` keys were investigated as a type-backed proof source. `ty`'s hover response exposes an overload for both required and optional keys. Its return type separates a required `int` key from an optional `int` key, but cannot separate a required `int | None` key from an optional `int` key. Replacing `.get()` with subscription adds no `ty` diagnostic for an optional key, so diagnostic comparison cannot fill that gap. A local parser for TypedDict declarations, imports, inheritance, and requiredness would duplicate a partial type checker.
+
+## Decision
+
+`redundant-dict-get` (TR9) is a report-only AST check. It reports only `.get(key)` calls with one positional argument where the receiver is a direct local name and the key is a string literal or the same local-name key used in a supported membership proof.
+
+The initial proof providers are deliberately independent:
+
+- a direct local dict display with explicit string keys;
+- the true branch of `if key in mapping:` for a local dict display or a direct builtin `dict[...]` parameter annotation;
+- the path after `if key not in mapping:` for the same receiver forms, when its body terminates with `raise` or `return`.
+
+Facts are confined to one lexical scope and discarded when a tracked name is rebound, mutated through a subscription, passed to an unknown call, stored through an unsupported construct, or crosses a loop, try, with, class, function, lambda, or comprehension boundary. Dictionary unpacking, comprehensions, aliases, non-string literal keys, boolean-combined predicates, branch merges, and alternative terminating forms are out of scope.
+
+TR9 is default-enabled in the dedicated `ruff-extra-rules-ty` hook and remains excluded from the normal hook. `# pytriage: TR9` is its only inline suppression. It never applies an autofix. The normal/ty-hook split is represented by an explicit check-id collection rather than a one-off class-identity exclusion, so future checks can join the dedicated hook without changing entrypoint architecture.
+
+Required TypedDict detection is deferred until a type checker exposes a stable requiredness query that handles nullable required values. The local proof protocol is the extension point for that provider and for future relational container proofs; neither is approximated meanwhile.
+
+## Consequences
+
+TR9 catches local invariants without starting an external process or duplicating type-checker behavior. It intentionally leaves valid but more complex cases unreported to preserve false-positive safety.
+
+A future type-backed provider needs its own positive and negative compatibility controls, non-cacheable direct-input reconciliation, real-type-checker integration coverage, and a documented performance measurement before it can be enabled.

--- a/docs/audits/type-checker-coverage-for-redundant-dict-get.md
+++ b/docs/audits/type-checker-coverage-for-redundant-dict-get.md
@@ -1,0 +1,25 @@
+# Type-checker coverage for redundant-dict-get
+
+## Question
+
+Does a supported type checker already report a redundant `.get()` where local code proves the key exists?
+
+## Method
+
+On 2026-08-26, run each installed checker against one file containing:
+
+- a local dict display followed by `.get("port")`;
+- a required TypedDict key followed by `.get("port")`;
+- a `key not in mapping` return guard followed by `.get(key)`.
+
+The return types allow `None`, so an ordinary optional-result type error is not involved.
+
+## Results
+
+| Checker | Version | Result         |
+| ------- | ------- | -------------- |
+| ty      | 0.0.74  | No diagnostics |
+| Mypy    | 2.3.0   | No diagnostics |
+| Pyright | 1.1.411 | No diagnostics |
+
+None emitted a redundancy or style diagnostic for these proven-presence calls. TR9 therefore owns the invariant-expression diagnostic rather than duplicating a type error.

--- a/docs/rules/redundant-dict-get.md
+++ b/docs/rules/redundant-dict-get.md
@@ -1,6 +1,8 @@
 # redundant-dict-get (TR9)
 
-Reports `dict.get()` where the current local code already proves the requested key exists.
+Reports `dict.get()` where the current local code already proves the requested key exists. TR9 supports one
+positional key argument on a direct local-name receiver only. It does not report calls with a default value,
+such as `config.get("port", 0)`, or calls on non-local receivers.
 
 ## Example
 

--- a/docs/rules/redundant-dict-get.md
+++ b/docs/rules/redundant-dict-get.md
@@ -1,0 +1,38 @@
+# redundant-dict-get (TR9)
+
+Reports `dict.get()` where the current local code already proves the requested key exists.
+
+## Example
+
+```python
+config = {"host": "localhost", "port": 5432}
+
+port = config.get("port")
+```
+
+TR9 reports the access because the local dict display includes `"port"`. Write `config["port"]` to express the invariant directly.
+
+It also recognizes direct membership guards:
+
+```python
+if key not in config:
+    raise KeyError(key)
+
+port = config.get(key)
+```
+
+TR9 is conservative. It does not follow aliases, calls, mutations, loops, or complex control flow, and it never rewrites source automatically.
+
+## Hook
+
+TR9 runs with the dedicated type-aware hook:
+
+```yaml
+- id: ruff-extra-rules-ty
+```
+
+## Suppression
+
+```python
+port = config.get("port")  # pytriage: TR9
+```

--- a/src/pre_commit_hooks/ast_checks/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/__init__.py
@@ -6,6 +6,7 @@ from .excessive_blank_lines import ExcessiveBlankLinesCheck
 from .meaningless_vars import MeaninglessVarsCheck
 from .misplaced_comment import MisplacedCommentCheck
 from .redundant_assignment import RedundantAssignmentCheck
+from .redundant_dict_get import RedundantDictGetCheck
 from .redundant_super_init import RedundantSuperInitCheck
 from .redundant_type_conversion import RedundantTypeConversionCheck
 from .unused_pytriage import UnusedPytriageCheck
@@ -23,4 +24,5 @@ ALL_CHECKS: list[type[ASTCheck]] = [
     MisplacedCommentCheck,
     RedundantTypeConversionCheck,
     UnusedPytriageCheck,
+    RedundantDictGetCheck,
 ]

--- a/src/pre_commit_hooks/ast_checks/_ty_hook.py
+++ b/src/pre_commit_hooks/ast_checks/_ty_hook.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._base import ASTCheck
+
+TY_HOOK_CHECK_IDS = frozenset({"redundant-dict-get", "redundant-type-conversion"})
+
+
+def belongs_to_ty_hook(check_class: type[ASTCheck]) -> bool:
+    return check_class().check_id in TY_HOOK_CHECK_IDS

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/__init__.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from pre_commit_hooks.ast_checks._base import (
+    BaseCheck,
+    CheckResult,
+    FixOutcome,
+    FixResult,
+    Violation,
+    byte_col_to_char_col,
+    find_ignored_lines,
+    find_ignored_lines_and_pytriage_comments,
+    find_suppression_usage,
+    ignore_pattern_for,
+)
+
+from .candidates import find_candidates
+from .local import find_proofs as find_local_proofs
+
+if TYPE_CHECKING:
+    import ast
+    from pathlib import Path
+
+    from pre_commit_hooks.ast_checks._options import CheckOption
+
+CHECK_ID = "redundant-dict-get"
+ERROR_CODE = "TR9"
+IGNORE_PATTERN = ignore_pattern_for(ERROR_CODE)
+
+
+class RedundantDictGetCheck(BaseCheck):
+    __slots__ = ()
+
+    OPTIONS: ClassVar[tuple[CheckOption, ...]] = ()
+
+    @property
+    def check_id(self) -> str:
+        return CHECK_ID
+
+    @property
+    def error_code(self) -> str:
+        return ERROR_CODE
+
+    @property
+    def default_enabled(self) -> bool:
+        return True
+
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return [".get("]
+
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(tree, source, collect_suppression_usage=False)
+
+    def check_with_suppression_tracking(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        return self._check(tree, source, collect_suppression_usage=True)
+
+    def _check(self, tree: ast.Module, source: str, *, collect_suppression_usage: bool) -> CheckResult:
+        candidates = find_candidates(tree)
+        if not candidates:
+            return CheckResult()
+        if collect_suppression_usage:
+            ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(
+                source, IGNORE_PATTERN
+            )
+            pytriage_lines = {
+                comment.line
+                for comment in comments
+                if self.error_code in comment.codes and comment.line not in format_suppressed
+            }
+            analysis_ignored_lines = ignored_lines - pytriage_lines
+        else:
+            ignored_lines = find_ignored_lines(source, IGNORE_PATTERN)
+            format_suppressed = set()
+            comments = ()
+            analysis_ignored_lines = ignored_lines
+        active = [candidate for candidate in candidates if candidate.call.lineno not in analysis_ignored_lines]
+        if not active:
+            return CheckResult()
+        local_proofs = {proof.candidate: proof.reason for proof in find_local_proofs(tree, active)}
+        proofs = local_proofs
+        violations = []
+        usages = []
+        source_lines = source.splitlines(keepends=True)
+        for candidate in candidates:
+            if candidate not in proofs:
+                continue
+            if candidate.call.lineno in ignored_lines:
+                usage = find_suppression_usage(
+                    comments, format_suppressed, self.check_id, self.error_code, (candidate.call.lineno,)
+                )
+                assert usage is not None
+                usages.append(usage)
+                continue
+            violations.append(
+                Violation(
+                    check_id=CHECK_ID,
+                    error_code=ERROR_CODE,
+                    line=candidate.call.lineno,
+                    col=byte_col_to_char_col(
+                        source_lines[candidate.call.func.lineno - 1], candidate.call.func.col_offset
+                    ),
+                    message=(
+                        f"Redundant `dict.get()`: {proofs[candidate]}; "
+                        f"use `{candidate.receiver}[{candidate.replacement_key}]`. "
+                        f"Or add '# pytriage: {ERROR_CODE}' to suppress."
+                    ),
+                    fixable=False,
+                )
+            )
+        return CheckResult(violations, usages)
+
+    def fix(
+        self,
+        _filepath: Path,
+        violations: list[Violation],
+        _source: str,
+        _tree: ast.Module,
+        _encoding: str = "utf-8",
+    ) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/candidates.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/candidates.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    call: ast.Call
+    receiver: str
+    literal_key: str | None
+    name_key: str | None
+
+    @property
+    def replacement_key(self) -> str:
+        return repr(self.literal_key) if self.literal_key is not None else self.name_key or ""
+
+
+def find_candidates(tree: ast.Module) -> list[Candidate]:
+    return [candidate for node in ast.walk(tree) if (candidate := _candidate(node)) is not None]
+
+
+def _candidate(node: ast.AST) -> Candidate | None:
+    if not isinstance(node, ast.Call) or node.keywords or len(node.args) != 1:
+        return None
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+        return None
+    if not isinstance(node.func.value, ast.Name):
+        return None
+    key = node.args[0]
+    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+        return Candidate(call=node, receiver=node.func.value.id, literal_key=key.value, name_key=None)
+    if isinstance(key, ast.Name) and isinstance(key.ctx, ast.Load):
+        return Candidate(call=node, receiver=node.func.value.id, literal_key=None, name_key=key.id)
+    return None

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -165,14 +165,9 @@ def _invalidate_escaped_facts(
     candidate_by_call: dict[int, Candidate],
 ) -> None:
     for call in ast.walk(statement):
-        if not isinstance(call, ast.Call) or id(call) in candidate_by_call:
-            continue
-        if isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name):
-            _drop_name(facts, call.func.value.id)
-        for argument in [*call.args, *(keyword.value for keyword in call.keywords)]:
-            for name in ast.walk(argument):
-                if isinstance(name, ast.Name):
-                    _drop_name(facts, name.id)
+        if isinstance(call, ast.Call) and id(call) not in candidate_by_call:
+            facts.clear()
+            return
     for node in ast.walk(statement):
         if isinstance(node, ast.NamedExpr | ast.Yield | ast.YieldFrom):
             _invalidate_assigned_value_facts(node.value, facts)
@@ -283,13 +278,31 @@ def _binds_dict(tree: ast.Module) -> bool:
         for name in (
             iter_binding_names(node)
             if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
-            else (
-                node.name,
-                *(
-                    type_parameter.name
-                    for type_parameter in node.type_params
-                    if isinstance(type_parameter, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
-                ),
-            )
+            else _definition_binding_names(node)
         )
+    )
+
+
+def _definition_binding_names(
+    definition: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+) -> tuple[str, ...]:
+    arguments = (
+        [
+            *definition.args.posonlyargs,
+            *definition.args.args,
+            *definition.args.kwonlyargs,
+            *([definition.args.vararg] if definition.args.vararg is not None else []),
+            *([definition.args.kwarg] if definition.args.kwarg is not None else []),
+        ]
+        if isinstance(definition, ast.FunctionDef | ast.AsyncFunctionDef)
+        else []
+    )
+    return (
+        definition.name,
+        *(argument.arg for argument in arguments),
+        *(
+            type_parameter.name
+            for type_parameter in definition.type_params
+            if isinstance(type_parameter, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
+        ),
     )

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -38,6 +38,7 @@ def _visit_scope(
             _visit_if(statement, facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
             continue
         if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
+            facts.clear()
             _visit_scope(
                 statement.body,
                 _dict_parameter_facts(statement, builtin_dict_available=builtin_dict_available),
@@ -47,9 +48,12 @@ def _visit_scope(
             )
             continue
         if isinstance(statement, ast.ClassDef):
+            facts.clear()
             _visit_scope(statement.body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
             continue
-        if isinstance(statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith):
+        if isinstance(
+            statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith | ast.Match
+        ):
             _visit_compound_statement(
                 statement, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available
             )
@@ -67,15 +71,19 @@ def _visit_if(
     builtin_dict_available: bool,
 ) -> None:
     membership = _membership(statement.test)
+    if membership is None:
+        facts.clear()
+        _visit_scope(statement.body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+        _visit_scope(statement.orelse, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+        return
     body_facts = _copy_facts(facts)
     else_facts = _copy_facts(facts)
     post_guard_facts: set[str] | None = None
-    if membership is not None:
-        receiver, key, positive = membership
-        if positive and _receiver_marker() in facts.get(receiver, set()):
-            body_facts.setdefault(receiver, set()).add(_flow_key(key))
-        elif not statement.orelse and _receiver_marker() in facts.get(receiver, set()) and _terminates(statement.body):
-            post_guard_facts = {*facts[receiver], _flow_key(key)}
+    receiver, key, positive = membership
+    if positive and _receiver_marker() in facts.get(receiver, set()):
+        body_facts.setdefault(receiver, set()).add(_flow_key(key))
+    elif not statement.orelse and _receiver_marker() in facts.get(receiver, set()) and _terminates(statement.body):
+        post_guard_facts = {*facts[receiver], _flow_key(key)}
     _visit_scope(statement.body, body_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
     _visit_scope(statement.orelse, else_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
     facts.clear()
@@ -165,6 +173,9 @@ def _invalidate_escaped_facts(
             for name in ast.walk(argument):
                 if isinstance(name, ast.Name):
                     _drop_name(facts, name.id)
+    for node in ast.walk(statement):
+        if isinstance(node, ast.NamedExpr | ast.Yield | ast.YieldFrom):
+            _invalidate_assigned_value_facts(node.value, facts)
 
 
 def _invalidate_assigned_value_facts(value: ast.expr | None, facts: dict[str, set[str]]) -> None:
@@ -186,13 +197,13 @@ def _copy_facts(facts: dict[str, set[str]]) -> dict[str, set[str]]:
 
 
 def _visit_compound_statement(
-    statement: ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith,
+    statement: ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith | ast.Match,
     candidate_by_call: dict[int, Candidate],
     proofs: list[LocalProof],
     *,
     builtin_dict_available: bool,
 ) -> None:
-    bodies = [statement.body]
+    bodies = [case.body for case in statement.cases] if isinstance(statement, ast.Match) else [statement.body]
     if isinstance(statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar):
         bodies.append(statement.orelse)
     if isinstance(statement, ast.Try | ast.TryStar):
@@ -272,6 +283,13 @@ def _binds_dict(tree: ast.Module) -> bool:
         for name in (
             iter_binding_names(node)
             if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
-            else (node.name,)
+            else (
+                node.name,
+                *(
+                    type_parameter.name
+                    for type_parameter in node.type_params
+                    if isinstance(type_parameter, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
+                ),
+            )
         )
     )

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pre_commit_hooks.ast_checks._scope import iter_binding_names, iter_within_scope
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .candidates import Candidate
+
+
+@dataclass(frozen=True, slots=True)
+class LocalProof:
+    candidate: Candidate
+    reason: str
+
+
+def find_proofs(tree: ast.Module, candidates: Iterable[Candidate]) -> list[LocalProof]:
+    candidate_by_call = {id(candidate.call): candidate for candidate in candidates}
+    proofs: list[LocalProof] = []
+    _visit_scope(tree.body, {}, candidate_by_call, proofs, builtin_dict_available=not _binds_dict(tree))
+    return proofs
+
+
+def _visit_scope(
+    statements: list[ast.stmt],
+    facts: dict[str, set[str]],
+    candidate_by_call: dict[int, Candidate],
+    proofs: list[LocalProof],
+    *,
+    builtin_dict_available: bool,
+) -> None:
+    for statement in statements:
+        if isinstance(statement, ast.If):
+            _visit_if(statement, facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+            continue
+        if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
+            _visit_scope(
+                statement.body,
+                _dict_parameter_facts(statement, builtin_dict_available=builtin_dict_available),
+                candidate_by_call,
+                proofs,
+                builtin_dict_available=builtin_dict_available,
+            )
+            continue
+        if isinstance(statement, ast.ClassDef):
+            _visit_scope(statement.body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+            continue
+        if isinstance(statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith):
+            _visit_compound_statement(
+                statement, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available
+            )
+            facts.clear()
+            continue
+        _visit_statement(statement, facts, candidate_by_call, proofs)
+
+
+def _visit_if(
+    statement: ast.If,
+    facts: dict[str, set[str]],
+    candidate_by_call: dict[int, Candidate],
+    proofs: list[LocalProof],
+    *,
+    builtin_dict_available: bool,
+) -> None:
+    membership = _membership(statement.test)
+    body_facts = _copy_facts(facts)
+    else_facts = _copy_facts(facts)
+    post_guard_facts: set[str] | None = None
+    if membership is not None:
+        receiver, key, positive = membership
+        if positive and _receiver_marker() in facts.get(receiver, set()):
+            body_facts.setdefault(receiver, set()).add(_flow_key(key))
+        elif not statement.orelse and _receiver_marker() in facts.get(receiver, set()) and _terminates(statement.body):
+            post_guard_facts = {*facts[receiver], _flow_key(key)}
+    _visit_scope(statement.body, body_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+    _visit_scope(statement.orelse, else_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+    facts.clear()
+    if post_guard_facts is not None:
+        facts[receiver] = post_guard_facts
+
+
+def _visit_statement(
+    statement: ast.stmt,
+    facts: dict[str, set[str]],
+    candidate_by_call: dict[int, Candidate],
+    proofs: list[LocalProof],
+) -> None:
+    _invalidate_statement_bindings(statement, facts)
+    _invalidate_escaped_facts(statement, facts, candidate_by_call)
+    for call in iter_within_scope(statement):
+        candidate = candidate_by_call.get(id(call))
+        if (
+            candidate is not None
+            and _receiver_marker() in facts.get(candidate.receiver, set())
+            and _candidate_fact(candidate) in facts.get(candidate.receiver, set())
+        ):
+            reason = (
+                "key is present in this dict literal"
+                if candidate.literal_key is not None
+                else "key is present on this control-flow path"
+            )
+            proofs.append(LocalProof(candidate, reason))
+    if isinstance(statement, ast.Assign | ast.AnnAssign):
+        target_names = _target_names(statement)
+        for name in target_names:
+            _drop_name(facts, name)
+        for name in _mutation_targets(statement):
+            _drop_name(facts, name)
+        value = statement.value
+        if len(target_names) == 1 and (keys := _literal_dict_keys(value)) is not None:
+            facts[target_names[0]] = {_receiver_marker(), *keys}
+        else:
+            _invalidate_assigned_value_facts(value, facts)
+        return
+    if isinstance(statement, ast.AugAssign | ast.Delete):
+        for target in _mutation_targets(statement):
+            _drop_name(facts, target)
+
+
+def _membership(test: ast.expr) -> tuple[str, str, bool] | None:
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1 or len(test.comparators) != 1:
+        return None
+    if not isinstance(test.left, ast.Name) or not isinstance(test.comparators[0], ast.Name):
+        return None
+    if isinstance(test.ops[0], ast.In):
+        return test.comparators[0].id, test.left.id, True
+    if isinstance(test.ops[0], ast.NotIn):
+        return test.comparators[0].id, test.left.id, False
+    return None
+
+
+def _terminates(statements: list[ast.stmt]) -> bool:
+    return bool(statements) and isinstance(statements[-1], ast.Return | ast.Raise)
+
+
+def _literal_dict_keys(value: ast.expr | None) -> set[str] | None:
+    if not isinstance(value, ast.Dict) or any(key is None for key in value.keys):
+        return None
+    keys = {
+        _literal_key(key.value) for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    return keys if len(keys) == len(value.keys) else None
+
+
+def _target_names(statement: ast.Assign | ast.AnnAssign) -> list[str]:
+    targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+    return [name for target in targets for name in _target_names_from(target)]
+
+
+def _invalidate_escaped_facts(
+    statement: ast.stmt,
+    facts: dict[str, set[str]],
+    candidate_by_call: dict[int, Candidate],
+) -> None:
+    for call in ast.walk(statement):
+        if not isinstance(call, ast.Call) or id(call) in candidate_by_call:
+            continue
+        if isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name):
+            _drop_name(facts, call.func.value.id)
+        for argument in [*call.args, *(keyword.value for keyword in call.keywords)]:
+            for name in ast.walk(argument):
+                if isinstance(name, ast.Name):
+                    _drop_name(facts, name.id)
+
+
+def _invalidate_assigned_value_facts(value: ast.expr | None, facts: dict[str, set[str]]) -> None:
+    if value is None:
+        return
+    for name in ast.walk(value):
+        if isinstance(name, ast.Name) and isinstance(name.ctx, ast.Load):
+            _drop_name(facts, name.id)
+
+
+def _invalidate_statement_bindings(statement: ast.stmt, facts: dict[str, set[str]]) -> None:
+    for node in iter_within_scope(statement):
+        for name in iter_binding_names(node):
+            _drop_name(facts, name)
+
+
+def _copy_facts(facts: dict[str, set[str]]) -> dict[str, set[str]]:
+    return {name: keys.copy() for name, keys in facts.items()}
+
+
+def _visit_compound_statement(
+    statement: ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith,
+    candidate_by_call: dict[int, Candidate],
+    proofs: list[LocalProof],
+    *,
+    builtin_dict_available: bool,
+) -> None:
+    bodies = [statement.body]
+    if isinstance(statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar):
+        bodies.append(statement.orelse)
+    if isinstance(statement, ast.Try | ast.TryStar):
+        bodies.extend(handler.body for handler in statement.handlers)
+        bodies.append(statement.finalbody)
+    for body in bodies:
+        _visit_scope(body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+
+
+def _literal_key(key: str) -> str:
+    return f"literal:{key}"
+
+
+def _receiver_marker() -> str:
+    return "receiver"
+
+
+def _flow_key(key: str) -> str:
+    return f"flow:{key}"
+
+
+def _candidate_fact(candidate: Candidate) -> str:
+    if candidate.literal_key is not None:
+        return _literal_key(candidate.literal_key)
+    assert candidate.name_key is not None
+    return _flow_key(candidate.name_key)
+
+
+def _drop_name(facts: dict[str, set[str]], name: str) -> None:
+    facts.pop(name, None)
+    for keys in facts.values():
+        keys.discard(_flow_key(name))
+
+
+def _mutation_targets(statement: ast.Assign | ast.AnnAssign | ast.AugAssign | ast.Delete) -> set[str]:
+    targets = statement.targets if isinstance(statement, ast.Assign | ast.Delete) else [statement.target]
+    return {
+        target.value.id
+        for target in targets
+        if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name)
+    }
+
+
+def _target_names_from(target: ast.expr) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Starred):
+        return _target_names_from(target.value)
+    if isinstance(target, ast.Tuple | ast.List):
+        return [name for element in target.elts for name in _target_names_from(element)]
+    return []
+
+
+def _dict_parameter_facts(
+    function: ast.FunctionDef | ast.AsyncFunctionDef, *, builtin_dict_available: bool
+) -> dict[str, set[str]]:
+    if not builtin_dict_available:
+        return {}
+    arguments = [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]
+    return {
+        argument.arg: {_receiver_marker()} for argument in arguments if _is_builtin_dict_annotation(argument.annotation)
+    }
+
+
+def _is_builtin_dict_annotation(annotation: ast.expr | None) -> bool:
+    if isinstance(annotation, ast.Name):
+        return annotation.id == "dict"
+    if not isinstance(annotation, ast.Subscript) or not isinstance(annotation.value, ast.Name):
+        return False
+    return annotation.value.id == "dict"
+
+
+def _binds_dict(tree: ast.Module) -> bool:
+    return any(
+        name == "dict"
+        for node in ast.walk(tree)
+        for name in (
+            iter_binding_names(node)
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
+            else (node.name,)
+        )
+    )

--- a/src/pre_commit_hooks/ruff_extra_rules.py
+++ b/src/pre_commit_hooks/ruff_extra_rules.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import sys
 
-from .ast_checks import ALL_CHECKS, RedundantTypeConversionCheck
+from .ast_checks import ALL_CHECKS
 from .ast_checks.__main__ import run
 from .ast_checks._cli import main as run_checks
+from .ast_checks._ty_hook import belongs_to_ty_hook
 
-_CHECKS = [check_class for check_class in ALL_CHECKS if check_class is not RedundantTypeConversionCheck]
+_CHECKS = [check_class for check_class in ALL_CHECKS if not belongs_to_ty_hook(check_class)]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/pre_commit_hooks/ruff_extra_rules_ty.py
+++ b/src/pre_commit_hooks/ruff_extra_rules_ty.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import sys
 
-from .ast_checks import RedundantTypeConversionCheck, UnusedPytriageCheck
+from .ast_checks import ALL_CHECKS, UnusedPytriageCheck
 from .ast_checks.__main__ import run
 from .ast_checks._cli import main as run_checks
+from .ast_checks._ty_hook import belongs_to_ty_hook
 
-_CHECKS = [RedundantTypeConversionCheck, UnusedPytriageCheck]
+_CHECKS = [*(check_class for check_class in ALL_CHECKS if belongs_to_ty_hook(check_class)), UnusedPytriageCheck]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/redundant_dict_get/test_candidates.py
+++ b/tests/redundant_dict_get/test_candidates.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from pre_commit_hooks.ast_checks.redundant_dict_get.candidates import find_candidates
+
+
+@pytest.mark.parametrize(
+    (
+        "source",
+        "expected",
+    ),
+    [
+        ("value = config.get('port')\n", [("config", "port", None)]),
+        ("value = config.get(key)\n", [("config", None, "key")]),
+        ("value = config.get('port', None)\n", []),
+        ("value = config.get(key='port')\n", []),
+        ("value = factory().get('port')\n", []),
+        ("value = config.get(prefix + 'port')\n", []),
+    ],
+)
+def test_find_candidates_accepts_only_the_supported_get_shapes(
+    source: str, expected: list[tuple[str, str | None, str | None]]
+) -> None:
+    candidates = find_candidates(ast.parse(source))
+
+    assert [(candidate.receiver, candidate.literal_key, candidate.name_key) for candidate in candidates] == expected

--- a/tests/redundant_dict_get/test_check.py
+++ b/tests/redundant_dict_get/test_check.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from pre_commit_hooks.ast_checks._base import FixOutcome, Violation
+from pre_commit_hooks.ast_checks.redundant_dict_get import RedundantDictGetCheck
+
+
+def _check(source: str) -> list[Violation]:
+    return RedundantDictGetCheck().check(Path("test.py"), ast.parse(source), source)
+
+
+def test_identity_and_opt_in_properties() -> None:
+    check = RedundantDictGetCheck()
+
+    assert check.check_id == "redundant-dict-get"
+    assert check.error_code == "TR9"
+    assert check.default_enabled is True
+    assert check.cacheable is True
+    assert check.tracks_direct_inputs is False
+    assert check.get_prefilter_pattern() == [".get("]
+
+
+def test_check_reports_a_literal_dict_proof() -> None:
+    source = "config = {'port': 5432}\nvalue = config.get('port')\n"
+
+    violations = _check(source)
+
+    assert len(violations) == 1
+    assert violations[0].line == 2
+    assert violations[0].col == 8
+    assert violations[0].fixable is False
+    assert "dict literal" in violations[0].message
+    assert "config['port']" in violations[0].message
+    assert "pytriage: TR9" in violations[0].message
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "value = config.get('port')\n",
+        "config = {'port': 5432}\nvalue = config.get('port')  # pytriage: TR9\n",
+        "value = config['port']\n",
+    ],
+)
+def test_check_leaves_non_proofs_and_suppressed_calls_unreported(source: str) -> None:
+    assert _check(source) == []
+
+
+def test_check_skips_a_suppression_when_another_proof_is_active() -> None:
+    source = (
+        "first = {'port': 5432}\n"
+        "second = {'host': 'localhost'}\n"
+        "first_value = first.get('port')\n"
+        "second_value = second.get('host')  # pytriage: TR9\n"
+    )
+
+    assert [violation.line for violation in _check(source)] == [3]
+
+
+def test_tracking_records_a_suppressed_real_proof() -> None:
+    source = "config = {'port': 5432}\nvalue = config.get('port')  # pytriage: TR9\n"
+
+    check_result = RedundantDictGetCheck().check_with_suppression_tracking(Path("test.py"), ast.parse(source), source)
+
+    assert check_result == []
+    assert [(usage.check_id, usage.error_code, usage.line) for usage in check_result.suppression_usages] == [
+        ("redundant-dict-get", "TR9", 2)
+    ]
+
+
+def test_fix_always_declines() -> None:
+    violation = Violation(check_id="redundant-dict-get", error_code="TR9", line=1, col=0, message="x", fixable=False)
+
+    fix_result = RedundantDictGetCheck().fix(Path("test.py"), [violation], "x = 1\n", ast.parse("x = 1\n"))
+
+    assert fix_result.outcomes == (FixOutcome.DECLINED,)

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -106,12 +106,20 @@ def test_find_proofs_reports_the_supported_local_invariants(source: str, expecte
             "later_value = config.get('port')\n"
         ),
         "config = {'port': 5432}\nalias = (alias := config)\ndel alias['port']\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nremove()\nvalue = config.get('port')\n",
         ("def values() -> int | None:\n    config = {'port': 5432}\n    yield config\n    return config.get('port')\n"),
         (
             "def generic[dict](config: dict[str, int], key: str) -> int | None:\n"
             "    if key in config:\n"
             "        return config.get(key)\n"
             "    return None\n"
+        ),
+        (
+            "def outer(dict: object) -> None:\n"
+            "    def inner(config: dict[str, int], key: str) -> int | None:\n"
+            "        if key in config:\n"
+            "            return config.get(key)\n"
+            "        return None\n"
         ),
         (
             "def f(config: dict[str, int], key: str) -> int | None:\n"

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -94,6 +94,25 @@ def test_find_proofs_reports_the_supported_local_invariants(source: str, expecte
             "value = config.get(key)\n"
         ),
         "config = {'port': 5432}\nvalue = (config.pop('port'), config.get('port'))\n",
+        "config = {'port': 5432}\nif config.pop('port'):\n    value = config.get('port')\n",
+        ("config = {'port': 5432}\n@mutate(config)\ndef decorated() -> None:\n    pass\nvalue = config.get('port')\n"),
+        ("config = {'port': 5432}\nclass Derived(mutate(config)):\n    pass\nvalue = config.get('port')\n"),
+        (
+            "config = {'port': 5432}\n"
+            "match subject:\n"
+            "    case _:\n"
+            "        del config['port']\n"
+            "        value = config.get('port')\n"
+            "later_value = config.get('port')\n"
+        ),
+        "config = {'port': 5432}\nalias = (alias := config)\ndel alias['port']\nvalue = config.get('port')\n",
+        ("def values() -> int | None:\n    config = {'port': 5432}\n    yield config\n    return config.get('port')\n"),
+        (
+            "def generic[dict](config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
         (
             "def f(config: dict[str, int], key: str) -> int | None:\n"
             "    if key in config:\n"

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from pre_commit_hooks.ast_checks.redundant_dict_get.candidates import find_candidates
+from pre_commit_hooks.ast_checks.redundant_dict_get.local import find_proofs
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_lines"),
+    [
+        ("config = {'port': 5432}\nvalue = config.get('port')\n", [2]),
+        (
+            (
+                "def f(config: dict[str, int], key: str) -> int | None:\n"
+                "    if key in config:\n"
+                "        return config.get(key)\n"
+                "    return None\n"
+            ),
+            [3],
+        ),
+        (
+            (
+                "def f(config: dict[str, int], key: str) -> int | None:\n"
+                "    if key not in config:\n"
+                "        raise KeyError(key)\n"
+                "    return config.get(key)\n"
+            ),
+            [4],
+        ),
+        (
+            ("class Settings:\n    config = {'port': 5432}\n    port = config.get('port')\n"),
+            [3],
+        ),
+        (
+            "config = {'port': 5432}\nport: int\nvalue = config.get('port')\n",
+            [3],
+        ),
+        (
+            ("with open('config.json'):\n    config = {'port': 5432}\n    value = config.get('port')\n"),
+            [3],
+        ),
+        (
+            (
+                "try:\n"
+                "    config = {'port': 5432}\n"
+                "    value = config.get('port')\n"
+                "except OSError:\n"
+                "    config = {'port': 5432}\n"
+                "    value = config.get('port')\n"
+                "finally:\n"
+                "    config = {'port': 5432}\n"
+                "    value = config.get('port')\n"
+            ),
+            [3, 6, 9],
+        ),
+    ],
+)
+def test_find_proofs_reports_the_supported_local_invariants(source: str, expected_lines: list[int]) -> None:
+    tree = ast.parse(source)
+
+    proofs = find_proofs(tree, find_candidates(tree))
+
+    assert [proof.candidate.call.lineno for proof in proofs] == expected_lines
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "config = {'port': 5432}\nconfig['host'] = 'localhost'\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nconfig['port'] += 1\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\ndel config['port']\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nconsume(config)\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nalias = config\nvalue = alias.get('port')\n",
+        "config = {'port': 5432}\nalias = config\nalias.pop('port')\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nholder.config = config\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nconfig, other = build()\nvalue = config.get('port')\n",
+        (
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        key = 'other'\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
+        ("config = {'port': 5432}\nif condition:\n    config.pop('port')\nvalue = config.get('port')\n"),
+        (
+            "config = {'port': 5432}\n"
+            "if key not in config:\n"
+            "    raise KeyError(key)\n"
+            "else:\n"
+            "    config.pop(key)\n"
+            "value = config.get(key)\n"
+        ),
+        "config = {'port': 5432}\nvalue = (config.pop('port'), config.get('port'))\n",
+        (
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        return (key := 'other', config.get(key))[1]\n"
+            "    return None\n"
+        ),
+        (
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config and enabled:\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
+        (
+            "def f(config: dict[str, int]) -> int | None:\n"
+            "    if 'port' in config:\n"
+            "        return config.get('port')\n"
+            "    return None\n"
+        ),
+        (
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key == config:\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
+        (
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        return None\n"
+            "    return config.get(key)\n"
+        ),
+        (
+            "def f(config, key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
+        (
+            "dict = CustomMapping\n"
+            "def f(config: dict[str, int], key: str) -> int | None:\n"
+            "    if key in config:\n"
+            "        return config.get(key)\n"
+            "    return None\n"
+        ),
+        (
+            "def f(config: dict[str, int]) -> list[int | None]:\n"
+            "    config = {'port': 5432}\n"
+            "    return [config.get('port') for _ in range(1)]\n"
+        ),
+        (
+            "def f() -> int | None:\n"
+            "    config = {'port': 5432}\n"
+            "    for _ in range(1):\n"
+            "        return config.get('port')\n"
+            "    return None\n"
+        ),
+        ("def f(*config: dict[str, int]) -> int | None:\n    return config.get('port')\n"),
+        ("def f(**config: dict[str, int]) -> int | None:\n    return config.get('port')\n"),
+        "config = {'port': 5432}\nconfig, *other = build()\nvalue = config.get('port')\n",
+    ],
+)
+def test_find_proofs_rejects_mutation_escape_alias_and_non_dominating_cases(source: str) -> None:
+    tree = ast.parse(source)
+
+    assert find_proofs(tree, find_candidates(tree)) == []

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3301,7 +3301,7 @@ def test_load_checks_skips_check_whose_init_raises(
 
     monkeypatch.setattr(_orchestrator, "ALL_CHECKS", [*ALL_CHECKS, BrokenCheck])
 
-    assert len(load_checks()) == len(ALL_CHECKS) - 1
+    assert len(load_checks()) == sum(check().default_enabled for check in ALL_CHECKS)
 
 
 def test_load_checks_skips_check_when_custom_args_raise() -> None:
@@ -3321,24 +3321,32 @@ def test_main_list_checks(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("entrypoint", "expected_check", "unexpected_check"),
+    ("entrypoint", "expected_checks", "unexpected_checks"),
     [
-        (ruff_extra_rules.main, "meaningless-vars: TR1", "redundant-type-conversion: TR6"),
-        (ruff_extra_rules_ty.main, "redundant-type-conversion: TR6", "meaningless-vars: TR1"),
+        (
+            ruff_extra_rules.main,
+            ("meaningless-vars: TR1",),
+            ("redundant-type-conversion: TR6", "redundant-dict-get: TR9"),
+        ),
+        (
+            ruff_extra_rules_ty.main,
+            ("redundant-type-conversion: TR6", "redundant-dict-get: TR9"),
+            ("meaningless-vars: TR1",),
+        ),
     ],
     ids=["default", "ty"],
 )
 def test_fixed_hook_entrypoints_list_only_their_own_checks(
     capsys: pytest.CaptureFixture[str],
     entrypoint: Callable[[list[str] | None], int],
-    expected_check: str,
-    unexpected_check: str,
+    expected_checks: tuple[str, ...],
+    unexpected_checks: tuple[str, ...],
 ) -> None:
     assert entrypoint(["--list-checks"]) == 0
 
     out = capsys.readouterr().out
-    assert expected_check in out
-    assert unexpected_check not in out
+    assert all(check in out for check in expected_checks)
+    assert all(check not in out for check in unexpected_checks)
 
 
 def test_ty_hook_lists_the_shared_unused_pytriage_audit(capsys: pytest.CaptureFixture[str]) -> None:
@@ -3374,6 +3382,14 @@ def test_fixed_hook_entrypoint_runs_a_selected_check_it_does_own(tmp_path: Path)
     )
 
     assert exit_code == 1
+
+
+def test_ty_hook_runs_redundant_dict_get_by_default(tmp_path: Path) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text("config = {'port': 5432}\nvalue = config.get('port')\n")
+
+    assert ruff_extra_rules.main(["--isolated", "--select", "redundant-dict-get", str(filepath)]) == 0
+    assert ruff_extra_rules_ty.main(["--isolated", str(filepath)]) == 1
 
 
 def test_main_no_filenames_returns_zero() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the TR9 `redundant-dict-get` check to detect unnecessary dictionary `.get()` calls when key presence is already established.
  * Added a dedicated type-aware hook configuration for this check.
  * Added inline suppression support; findings are report-only and have no automatic fix.

* **Documentation**
  * Added rule documentation, usage guidance, changelog entries, design notes, and type-checker coverage details.

* **Tests**
  * Added comprehensive coverage for detection, suppression, control flow, mutations, and hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->