### PR TITLE
Extend `redundant-dict-get`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
           ]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.2.1
+    rev: v0.2.2
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - `redundant-dict-get` (TR9) reports local `.get()` calls whose key presence is already proven. It is report-only.
+- `redundant-dict-get` now recognizes bounded control-flow, alias, relational-container, and required-`TypedDict` proofs. Its new `level` setting defaults to `conservative`; `aggressive` retains direct `dict[...]` annotation heuristics.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Fixed
 
 - `redundant-dict-get` no longer retains key-presence proofs across rebinding, context-manager exits, match fall-through, or mutating loop paths, and recognizes validated local key collections inside read-only loops.
+- `redundant-dict-get` distinguishes literal dictionary keys from variable-name presence proofs, avoiding unrelated reports when their spellings match.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - `redundant-dict-get` (TR9) reports local `.get()` calls whose key presence is already proven. It is report-only.
-- `redundant-dict-get` now recognizes bounded control-flow, alias, relational-container, and required-`TypedDict` proofs. Its new `level` setting defaults to `conservative`; `aggressive` retains direct `dict[...]` annotation heuristics.
-
-### Fixed
-
-- `redundant-dict-get` no longer retains key-presence proofs across rebinding, context-manager exits, match fall-through, or mutating loop paths, and recognizes validated local key collections inside read-only loops.
-- `redundant-dict-get` distinguishes literal dictionary keys from variable-name presence proofs, avoiding unrelated reports when their spellings match.
-- `redundant-dict-get` no longer treats unpacked loop targets as known mapping keys or relies on shadowed `all` and `dict` builtins.
-- `redundant-dict-get` no longer applies pre-`try` facts to a `try` `else` body after the body changes them.
-- `redundant-dict-get` no longer retains facts through multi-target assignments with unsafe values.
+- `redundant-dict-get` recognizes bounded control-flow, aliases, relational containers, and required-`TypedDict` proofs. It keeps literal and variable-key facts distinct, accepts collection membership only from plain loop targets and trusted builtins, and discards facts after rebinding, mutation, unsafe assignments, context-manager exits, `try` `else` transitions, and match fall-through. Its `level` setting defaults to `conservative`; `aggressive` retains direct `dict[...]` annotation heuristics.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 - `redundant-dict-get` no longer retains key-presence proofs across rebinding, context-manager exits, match fall-through, or mutating loop paths, and recognizes validated local key collections inside read-only loops.
 - `redundant-dict-get` distinguishes literal dictionary keys from variable-name presence proofs, avoiding unrelated reports when their spellings match.
+- `redundant-dict-get` no longer treats unpacked loop targets as known mapping keys or relies on shadowed `all` and `dict` builtins.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 - `redundant-dict-get` no longer retains key-presence proofs across rebinding, context-manager exits, match fall-through, or mutating loop paths, and recognizes validated local key collections inside read-only loops.
 - `redundant-dict-get` distinguishes literal dictionary keys from variable-name presence proofs, avoiding unrelated reports when their spellings match.
 - `redundant-dict-get` no longer treats unpacked loop targets as known mapping keys or relies on shadowed `all` and `dict` builtins.
+- `redundant-dict-get` no longer applies pre-`try` facts to a `try` `else` body after the body changes them.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 - `redundant-dict-get` distinguishes literal dictionary keys from variable-name presence proofs, avoiding unrelated reports when their spellings match.
 - `redundant-dict-get` no longer treats unpacked loop targets as known mapping keys or relies on shadowed `all` and `dict` builtins.
 - `redundant-dict-get` no longer applies pre-`try` facts to a `try` `else` body after the body changes them.
+- `redundant-dict-get` no longer retains facts through multi-target assignments with unsafe values.
 
 ## [0.2.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 - `redundant-dict-get` (TR9) reports local `.get()` calls whose key presence is already proven. It is report-only.
 - `redundant-dict-get` now recognizes bounded control-flow, alias, relational-container, and required-`TypedDict` proofs. Its new `level` setting defaults to `conservative`; `aggressive` retains direct `dict[...]` annotation heuristics.
 
+### Fixed
+
+- `redundant-dict-get` no longer retains key-presence proofs across rebinding, context-manager exits, match fall-through, or mutating loop paths, and recognizes validated local key collections inside read-only loops.
+
 ## [0.2.2] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Individual checks are toggled with `--select`/`--ignore` (or the matching `pypro
 | [redundant-type-conversion](docs/rules/redundant-type-conversion.md) | TR6  | Flags a builtin type conversion that `ty` considers redundant given the argument's real type, including across files. Requires [`ty`](https://github.com/astral-sh/ty) on `PATH`. |
 | [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
 | [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; add it with `--extend-select=unused-pytriage`.                                                      |
-| [redundant-dict-get](docs/rules/redundant-dict-get.md)               | TR9  | Reports `dict.get()` calls where local code already proves the key exists.                                                                                                        |
+| [redundant-dict-get](docs/rules/redundant-dict-get.md)               | TR9  | Reports `dict.get()` calls where local control flow, containers, or required TypedDict fields prove the key exists.                                                               |
 
 ## Installation
 

--- a/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
+++ b/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
@@ -6,26 +6,28 @@
 
 `docs/audits/type-checker-coverage-for-redundant-dict-get.md` records that ty, Mypy, and Pyright do not report the supported proven-presence examples as redundant access.
 
-Required `TypedDict` keys were investigated as a type-backed proof source. `ty`'s hover response exposes an overload for both required and optional keys. Its return type separates a required `int` key from an optional `int` key, but cannot separate a required `int | None` key from an optional `int` key. Replacing `.get()` with subscription adds no `ty` diagnostic for an optional key, so diagnostic comparison cannot fill that gap. A local parser for TypedDict declarations, imports, inheritance, and requiredness would duplicate a partial type checker.
+Required `TypedDict` keys cannot be inferred from `ty` hover or diagnostic comparison: nullable required values and optional values remain indistinguishable. TR9 therefore reads only complete local declarations, where `Required`, `NotRequired`, and `total=False` are syntactic facts. Imported, inherited, or otherwise unresolved declarations remain unknown.
 
 ## Decision
 
 `redundant-dict-get` (TR9) is a report-only AST check. It reports only `.get(key)` calls with one positional argument where the receiver is a direct local name and the key is a string literal or the same local-name key used in a supported membership proof.
 
-The initial proof providers are deliberately independent:
+The proof providers are deliberately independent:
 
 - a direct local dict display with explicit string keys;
-- the true branch of `if key in mapping:` for a local dict display or a direct builtin `dict[...]` parameter annotation;
-- the path after `if key not in mapping:` for the same receiver forms, when its body terminates with `raise` or `return`.
+- required fields on a complete local `TypedDict` declaration;
+- direct aliases of known dictionaries and collections;
+- short-circuit Boolean membership guards, branch intersections, and paths after structural termination;
+- validated local key collections through `required <= mapping.keys()` and `all(key in mapping for key in required)`.
 
-Facts are confined to one lexical scope and discarded when a tracked name is rebound, mutated through a subscription, passed to an unknown call, stored through an unsupported construct, or crosses a loop, try, with, class, function, lambda, or comprehension boundary. Dictionary unpacking, comprehensions, aliases, non-string literal keys, boolean-combined predicates, branch merges, and alternative terminating forms are out of scope.
+Facts are confined to one lexical scope and discarded when a tracked name is rebound, mutated through a subscription, passed to an unknown call, stored through an unsupported construct, or crosses a suspension or comprehension boundary. Branch joins retain only facts shared by every normal path.
 
 TR9 is default-enabled in the dedicated `ruff-extra-rules-ty` hook and remains excluded from the normal hook. `# pytriage: TR9` is its only inline suppression. It never applies an autofix. The normal/ty-hook split is represented by an explicit check-id collection rather than a one-off class-identity exclusion, so future checks can join the dedicated hook without changing entrypoint architecture.
 
-Required TypedDict detection is deferred until a type checker exposes a stable requiredness query that handles nullable required values. The local proof protocol is the extension point for that provider and for future relational container proofs; neither is approximated meanwhile.
+The default `conservative` level accepts only built-in local dictionaries and collections plus complete local `TypedDict` declarations. `aggressive` additionally accepts direct builtin `dict[...]` parameter annotations; this is a deliberate heuristic because subclasses can customize mapping operations.
 
 ## Consequences
 
-TR9 catches local invariants without starting an external process or duplicating type-checker behavior. It intentionally leaves valid but more complex cases unreported to preserve false-positive safety.
+TR9 catches local invariants without starting an external process. It intentionally leaves unresolved type declarations and unbounded flow cases unreported at the default level to preserve false-positive safety.
 
-A future type-backed provider needs its own positive and negative compatibility controls, non-cacheable direct-input reconciliation, real-type-checker integration coverage, and a documented performance measurement before it can be enabled.
+An imported or inherited type-backed provider needs its own positive and negative compatibility controls, non-cacheable direct-input reconciliation, real-type-checker integration coverage, and a documented performance measurement before it can be enabled.

--- a/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
+++ b/docs/adr/0059-redundant-dict-get-local-presence-proofs.md
@@ -24,7 +24,7 @@ Facts are confined to one lexical scope and discarded when a tracked name is reb
 
 TR9 is default-enabled in the dedicated `ruff-extra-rules-ty` hook and remains excluded from the normal hook. `# pytriage: TR9` is its only inline suppression. It never applies an autofix. The normal/ty-hook split is represented by an explicit check-id collection rather than a one-off class-identity exclusion, so future checks can join the dedicated hook without changing entrypoint architecture.
 
-The default `conservative` level accepts only built-in local dictionaries and collections plus complete local `TypedDict` declarations. `aggressive` additionally accepts direct builtin `dict[...]` parameter annotations; this is a deliberate heuristic because subclasses can customize mapping operations.
+The default `conservative` level accepts only built-in local dictionaries and collections plus complete local `TypedDict` declarations. `aggressive` additionally accepts direct built-in `dict[...]` parameter annotations; this is a deliberate heuristic because subclasses can customize mapping operations.
 
 ## Consequences
 

--- a/docs/rules/redundant-dict-get.md
+++ b/docs/rules/redundant-dict-get.md
@@ -14,7 +14,7 @@ port = config.get("port")
 
 TR9 reports the access because the local dict display includes `"port"`. Write `config["port"]` to express the invariant directly.
 
-It also recognizes direct membership guards:
+It recognizes key-presence facts through direct aliases, branch joins, short-circuit Boolean guards, and structural exits:
 
 ```python
 if key not in config:
@@ -23,7 +23,39 @@ if key not in config:
 port = config.get(key)
 ```
 
-TR9 is conservative. It does not follow aliases, calls, mutations, loops, or complex control flow, and it never rewrites source automatically.
+TR9 also recognizes validated key collections when both the collection and dictionary are local built-ins:
+
+```python
+required = {"host", "port"}
+config = {"host": "localhost", "port": 5432}
+
+if required <= config.keys():
+    for key in required:
+        value = config.get(key)
+```
+
+Required `TypedDict` fields are key-presence facts, including fields whose values may be `None`:
+
+```python
+from typing import TypedDict
+
+
+class Settings(TypedDict):
+    port: int | None
+
+
+def read(settings: Settings) -> int | None:
+    return settings.get("port")
+```
+
+TR9 is report-only. It discards a proof after mutation, an unknown call, reassignment, or suspension, and it does not infer facts across comprehension scopes.
+
+## Reporting level
+
+`--redundant-dict-get-level={conservative,aggressive}` defaults to `conservative`.
+
+- `conservative` recognizes local built-in dictionaries and collections, local `TypedDict` declarations, and control-flow proofs.
+- `aggressive` additionally trusts a direct `dict[...]` parameter annotation. A subclass can customize mapping operations, so review these reports before changing code.
 
 ## Hook
 

--- a/src/pre_commit_hooks/ast_checks/_scope.py
+++ b/src/pre_commit_hooks/ast_checks/_scope.py
@@ -98,6 +98,8 @@ def collect_scope_names(scope: ast.AST) -> set[str]:
 def iter_binding_names(node: ast.AST) -> Iterator[str]:
     if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
         yield node.id
+    elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        yield node.name
     elif isinstance(node, ast.Import):
         yield from (alias.asname or alias.name.split(".")[0] for alias in node.names)
     elif isinstance(node, ast.ImportFrom):

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/__init__.py
@@ -14,8 +14,10 @@ from pre_commit_hooks.ast_checks._base import (
     find_suppression_usage,
     ignore_pattern_for,
 )
+from pre_commit_hooks.ast_checks._options import EnumOption
 
 from .candidates import find_candidates
+from .local import ProofLevel
 from .local import find_proofs as find_local_proofs
 
 if TYPE_CHECKING:
@@ -30,9 +32,23 @@ IGNORE_PATTERN = ignore_pattern_for(ERROR_CODE)
 
 
 class RedundantDictGetCheck(BaseCheck):
-    __slots__ = ()
+    __slots__ = ("_level",)
 
-    OPTIONS: ClassVar[tuple[CheckOption, ...]] = ()
+    OPTIONS: ClassVar[tuple[CheckOption, ...]] = (
+        EnumOption(
+            name="level",
+            values=ProofLevel,
+            default=ProofLevel.CONSERVATIVE,
+            help=(
+                "How broadly redundant-dict-get (TR9) recognizes key-presence proofs. "
+                "'conservative' (default) reports only built-in and TypedDict-backed proofs; "
+                "'aggressive' also trusts direct dict annotations."
+            ),
+        ),
+    )
+
+    def __init__(self, level: ProofLevel = ProofLevel.CONSERVATIVE) -> None:
+        self._level = level
 
     @property
     def check_id(self) -> str:
@@ -77,7 +93,7 @@ class RedundantDictGetCheck(BaseCheck):
         active = [candidate for candidate in candidates if candidate.call.lineno not in analysis_ignored_lines]
         if not active:
             return CheckResult()
-        local_proofs = {proof.candidate: proof.reason for proof in find_local_proofs(tree, active)}
+        local_proofs = {proof.candidate: proof.reason for proof in find_local_proofs(tree, active, level=self._level)}
         proofs = local_proofs
         violations = []
         usages = []

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -241,9 +241,12 @@ class _Analyzer:
             body_state.drop(target)
         if _loop_body_invalidates_state(statement.body, entry_state, self._candidates):
             body_state.clear()
-        if isinstance(statement.iter, ast.Name) and body_state.root(statement.iter.id) in body_state.collections:
-            for target in _target_names(statement.target):
-                body_state.add_collection_membership(statement.iter.id, target)
+        if (
+            isinstance(statement.iter, ast.Name)
+            and isinstance(statement.target, ast.Name)
+            and body_state.root(statement.iter.id) in body_state.collections
+        ):
+            body_state.add_collection_membership(statement.iter.id, statement.target.id)
         else:
             body_state.clear()
         normal_exit = self.visit_scope(statement.body, body_state)
@@ -659,6 +662,4 @@ def _is_irrefutable(pattern: ast.pattern) -> bool:
 
 
 def _binds_name(tree: ast.Module, name: str) -> bool:
-    return any(
-        isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store) and node.id == name for node in ast.walk(tree)
-    )
+    return any(name in iter_binding_names(node) for node in ast.walk(tree))

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -283,10 +283,11 @@ class _Analyzer:
         return _join(paths)
 
     def visit_try(self, statement: ast.Try | ast.TryStar, state: _State) -> _State | None:
-        paths = [self.visit_scope(statement.body, state.copy())]
+        body_state = self.visit_scope(statement.body, state.copy())
+        paths = [body_state]
         paths.extend(self.visit_scope(handler.body, _State()) for handler in statement.handlers)
         if statement.orelse:
-            paths.append(self.visit_scope(statement.orelse, state.copy()))
+            paths.append(self.visit_scope(statement.orelse, body_state.copy()) if body_state is not None else None)
         merged = _join(paths)
         if merged is None:
             return self.visit_scope(statement.finalbody, _State()) if statement.finalbody else None

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
-from pre_commit_hooks.ast_checks._scope import iter_within_scope
+from pre_commit_hooks.ast_checks._scope import iter_binding_names, iter_within_scope
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -53,6 +53,8 @@ class _State:
 
     def drop(self, name: str) -> None:
         root = self.aliases.pop(name, None)
+        for keys in self.present.values():
+            keys.discard(name)
         if root is None or root in self.aliases.values():
             return
         self.dictionaries.pop(root, None)
@@ -160,7 +162,11 @@ class _Analyzer:
             | ast.AsyncFunctionDef
             | ast.ClassDef
         )
-        if not isinstance(statement, compound) and not _has_unknown_call(statement, self._candidates):
+        if (
+            not isinstance(statement, compound)
+            and not _has_unknown_call(statement, self._candidates)
+            and not _contains_named_expression(statement)
+        ):
             self.report_candidates(statement, state)
         if isinstance(statement, ast.If):
             return self.visit_if(statement, state)
@@ -176,9 +182,10 @@ class _Analyzer:
         if isinstance(statement, ast.With | ast.AsyncWith):
             state.clear()
             self.visit_scope(statement.body, state)
+            state.clear()
             return state
         if isinstance(statement, ast.Match):
-            return _join([self.visit_scope(case.body, state.copy()) for case in statement.cases])
+            return self.visit_match(statement, state)
         if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
             self.visit_scope(statement.body, self.function_state(statement))
             state.clear()
@@ -195,6 +202,16 @@ class _Analyzer:
         if isinstance(statement, ast.AugAssign | ast.Delete):
             self.invalidate_mutation(statement, state)
             return state
+        if isinstance(statement, ast.Import | ast.ImportFrom):
+            if any(alias.name == "*" for alias in statement.names):
+                state.clear()
+            else:
+                for name in iter_binding_names(statement):
+                    state.drop(name)
+            return state
+        if _contains_named_expression(statement):
+            state.clear()
+            return state
         if _contains_suspension(statement) or _has_unknown_call(statement, self._candidates):
             state.clear()
         return state
@@ -209,21 +226,56 @@ class _Analyzer:
         )
 
     def visit_for(self, statement: ast.For | ast.AsyncFor, state: _State) -> _State:
+        entry_state = state.copy()
+        if _has_unknown_call(statement.iter, self._candidates) or _contains_suspension(statement.iter):
+            entry_state.clear()
         body_state = _State(
-            state.aliases.copy(),
-            {root: set() for root in state.dictionaries},
-            state.collections.copy(),
+            entry_state.aliases.copy(),
+            {root: set() for root in entry_state.dictionaries},
+            entry_state.collections.copy(),
+            entry_state.relations.copy(),
         )
+        for target in _target_names(statement.target):
+            body_state.drop(target)
+        if _loop_body_invalidates_state(statement.body, entry_state, self._candidates):
+            body_state.clear()
         if isinstance(statement.iter, ast.Name) and body_state.root(statement.iter.id) in body_state.collections:
             for target in _target_names(statement.target):
                 body_state.add_collection_membership(statement.iter.id, target)
         else:
             body_state.clear()
-        self.visit_scope(statement.body, body_state)
-        self.visit_scope(statement.orelse, state.copy())
-        if _has_unknown_call(statement.iter, self._candidates) or _contains_suspension(statement):
-            state.clear()
-        return state
+        normal_exit = self.visit_scope(statement.body, body_state)
+        if _contains_loop_control(statement.body):
+            if statement.orelse:
+                self.visit_scope(statement.orelse, _State())
+            return _State()
+        merged = _join([entry_state, normal_exit]) or _State()
+        if statement.orelse:
+            return self.visit_scope(statement.orelse, merged) or _State()
+        return merged
+
+    def visit_match(self, statement: ast.Match, state: _State) -> _State | None:
+        fallthrough = state.copy()
+        if _has_unknown_call(statement.subject, self._candidates) or _contains_suspension(statement.subject):
+            fallthrough.clear()
+        paths: list[_State | None] = []
+        for case in statement.cases:
+            bound_names = _pattern_names(case.pattern)
+            matched = fallthrough.copy()
+            for name in bound_names:
+                matched.drop(name)
+            if case.guard is not None:
+                matched, guard_fallthrough = self.condition_states(case.guard, matched)
+                fallthrough = guard_fallthrough
+            elif _is_irrefutable(case.pattern):
+                paths.append(self.visit_scope(case.body, matched))
+                return _join(paths)
+            else:
+                for name in bound_names:
+                    fallthrough.drop(name)
+            paths.append(self.visit_scope(case.body, matched))
+        paths.append(fallthrough)
+        return _join(paths)
 
     def visit_try(self, statement: ast.Try | ast.TryStar, state: _State) -> _State | None:
         paths = [self.visit_scope(statement.body, state.copy())]
@@ -302,10 +354,12 @@ class _Analyzer:
             state.clear()
 
     def invalidate_mutation(self, statement: ast.AugAssign | ast.Delete, state: _State) -> None:
-        if _mutation_targets(statement):
+        if _mutation_targets(statement) or isinstance(statement, ast.AugAssign):
             state.clear()
-        elif isinstance(statement, ast.AugAssign) and isinstance(statement.target, ast.Name):
-            state.drop(statement.target.id)
+        else:
+            for target in statement.targets:
+                for name in _target_names(target):
+                    state.drop(name)
         if _has_unknown_call(statement, self._candidates) or _contains_suspension(statement):
             state.clear()
 
@@ -503,8 +557,6 @@ def _is_typing_name(annotation: ast.expr | None, expected: str, names: dict[str,
 def _annotation_name(annotation: ast.expr | None) -> str | None:
     if isinstance(annotation, ast.Name):
         return annotation.id
-    if isinstance(annotation, ast.Attribute):
-        return annotation.attr
     return None
 
 
@@ -556,8 +608,60 @@ def _has_unknown_call(node: ast.AST, candidates: dict[int, Candidate]) -> bool:
     return any(isinstance(child, ast.Call) and id(child) not in candidates for child in ast.walk(node))
 
 
+def _contains_named_expression(node: ast.AST) -> bool:
+    return any(isinstance(child, ast.NamedExpr) for child in iter_within_scope(node))
+
+
 def _contains_suspension(node: ast.AST) -> bool:
     return any(isinstance(child, ast.Await | ast.Yield | ast.YieldFrom) for child in ast.walk(node))
+
+
+def _loop_body_invalidates_state(statements: list[ast.stmt], state: _State, candidates: dict[int, Candidate]) -> bool:
+    tracked_names = state.aliases.keys()
+    if not tracked_names:
+        return False
+    for statement in statements:
+        for node in [statement, *iter_within_scope(statement)]:
+            if isinstance(node, ast.Call) and id(node) not in candidates:
+                return True
+            if isinstance(node, ast.Await | ast.Yield | ast.YieldFrom):
+                return True
+            if isinstance(node, ast.AugAssign):
+                return True
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del) and node.id in tracked_names:
+                return True
+            if isinstance(node, ast.Import | ast.ImportFrom) and any(
+                name in tracked_names for name in iter_binding_names(node)
+            ):
+                return True
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) and node.name in tracked_names:
+                return True
+            if (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.ctx, ast.Store | ast.Del)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in tracked_names
+            ):
+                return True
+    return False
+
+
+def _contains_loop_control(statements: list[ast.stmt]) -> bool:
+    return any(
+        isinstance(node, ast.Break | ast.Continue)
+        for statement in statements
+        for node in [statement, *iter_within_scope(statement)]
+    )
+
+
+def _pattern_names(pattern: ast.pattern) -> set[str]:
+    return {name for node in ast.walk(pattern) for name in iter_binding_names(node)}
+
+
+def _is_irrefutable(pattern: ast.pattern) -> bool:
+    if isinstance(pattern, ast.MatchAs):
+        return pattern.pattern is None or _is_irrefutable(pattern.pattern)
+    return isinstance(pattern, ast.MatchOr) and any(_is_irrefutable(item) for item in pattern.patterns)
 
 
 def _binds_name(tree: ast.Module, name: str) -> bool:

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -88,9 +88,9 @@ class _State:
         self.aliases[name] = root
         return True
 
-    def add_present(self, dictionary: str, key: str) -> None:
+    def add_present(self, dictionary: str, variable_name: str) -> None:
         if (root := self.root(dictionary)) in self.dictionaries:
-            self.present.setdefault(root, set()).add(key)
+            self.present.setdefault(root, set()).add(variable_name)
 
     def add_relation(self, collection: str, dictionary: str) -> None:
         collection_root = self.root(collection)
@@ -98,9 +98,11 @@ class _State:
         if collection_root in self.collections and dictionary_root in self.dictionaries:
             self.relations.add((collection_root, dictionary_root))
 
-    def contains(self, dictionary: str, key: str) -> bool:
+    def contains(self, dictionary: str, key: str, *, literal: bool) -> bool:
         root = self.root(dictionary)
-        return root in self.dictionaries and (key in self.dictionaries[root] or key in self.present.get(root, set()))
+        if root not in self.dictionaries:
+            return False
+        return key in (self.dictionaries[root] if literal else self.present.get(root, set()))
 
     def add_collection_membership(self, collection: str, key: str) -> None:
         collection_root = self.root(collection)
@@ -386,7 +388,7 @@ class _Analyzer:
                 continue
             key = candidate.literal_key if candidate.literal_key is not None else candidate.name_key
             assert key is not None
-            if state.contains(candidate.receiver, key):
+            if state.contains(candidate.receiver, key, literal=candidate.literal_key is not None):
                 self._proof_ids.add(id(call))
                 reason = (
                     "key is present in a known dict"

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -337,6 +337,13 @@ class _Analyzer:
         if mutations:
             state.clear()
             return
+        if value is not None and (
+            any(isinstance(node, ast.NamedExpr) for node in ast.walk(value))
+            or _has_unknown_call(value, self._candidates)
+            or _contains_suspension(value)
+        ):
+            state.clear()
+            return
         if len(targets) != 1 or value is None:
             for target in targets:
                 state.drop(target)
@@ -344,9 +351,6 @@ class _Analyzer:
                 state.clear()
             return
         target = targets[0]
-        if any(isinstance(node, ast.NamedExpr) for node in ast.walk(value)):
-            state.clear()
-            return
         if isinstance(value, ast.Name) and state.bind_alias(target, value.id):
             return
         if (keys := _literal_dict_keys(value)) is not None:
@@ -356,8 +360,6 @@ class _Analyzer:
             state.bind_collection(target, collection_keys)
             return
         state.drop(target)
-        if _has_unknown_call(value, self._candidates) or _contains_suspension(value):
-            state.clear()
 
     def invalidate_mutation(self, statement: ast.AugAssign | ast.Delete, state: _State) -> None:
         if _mutation_targets(

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
-from pre_commit_hooks.ast_checks._scope import iter_binding_names, iter_within_scope
+from pre_commit_hooks.ast_checks._scope import iter_within_scope
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from .candidates import Candidate
+
+
+class ProofLevel(Enum):
+    CONSERVATIVE = auto()
+    AGGRESSIVE = auto()
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,121 +24,360 @@ class LocalProof:
     reason: str
 
 
-def find_proofs(tree: ast.Module, candidates: Iterable[Candidate]) -> list[LocalProof]:
-    candidate_by_call = {id(candidate.call): candidate for candidate in candidates}
-    proofs: list[LocalProof] = []
-    _visit_scope(tree.body, {}, candidate_by_call, proofs, builtin_dict_available=not _binds_dict(tree))
-    return proofs
+@dataclass(slots=True)
+class _State:
+    aliases: dict[str, str] = field(default_factory=dict)
+    dictionaries: dict[str, set[str]] = field(default_factory=dict)
+    collections: dict[str, frozenset[str]] = field(default_factory=dict)
+    relations: set[tuple[str, str]] = field(default_factory=set)
+    present: dict[str, set[str]] = field(default_factory=dict)
+
+    def copy(self) -> _State:
+        return _State(
+            self.aliases.copy(),
+            {key: value.copy() for key, value in self.dictionaries.items()},
+            self.collections.copy(),
+            self.relations.copy(),
+            {key: value.copy() for key, value in self.present.items()},
+        )
+
+    def root(self, name: str) -> str | None:
+        return self.aliases.get(name)
+
+    def clear(self) -> None:
+        self.aliases.clear()
+        self.dictionaries.clear()
+        self.collections.clear()
+        self.relations.clear()
+        self.present.clear()
+
+    def drop(self, name: str) -> None:
+        root = self.aliases.pop(name, None)
+        if root is None or root in self.aliases.values():
+            return
+        self.dictionaries.pop(root, None)
+        self.collections.pop(root, None)
+        self.present.pop(root, None)
+        self.relations = {relation for relation in self.relations if root not in relation}
+
+    def bind_dict(self, name: str, keys: set[str]) -> None:
+        self.drop(name)
+        self.aliases[name] = self.new_root(name)
+        self.dictionaries[self.aliases[name]] = keys
+
+    def bind_collection(self, name: str, keys: frozenset[str]) -> None:
+        self.drop(name)
+        self.aliases[name] = self.new_root(name)
+        self.collections[self.aliases[name]] = keys
+
+    def new_root(self, name: str) -> str:
+        root = name
+        suffix = 0
+        while root in self.dictionaries or root in self.collections:
+            suffix += 1
+            root = f"{name}:{suffix}"
+        return root
+
+    def bind_alias(self, name: str, source: str) -> bool:
+        root = self.root(source)
+        if root is None:
+            return False
+        self.drop(name)
+        self.aliases[name] = root
+        return True
+
+    def add_present(self, dictionary: str, key: str) -> None:
+        if (root := self.root(dictionary)) in self.dictionaries:
+            self.present.setdefault(root, set()).add(key)
+
+    def add_relation(self, collection: str, dictionary: str) -> None:
+        collection_root = self.root(collection)
+        dictionary_root = self.root(dictionary)
+        if collection_root in self.collections and dictionary_root in self.dictionaries:
+            self.relations.add((collection_root, dictionary_root))
+
+    def contains(self, dictionary: str, key: str) -> bool:
+        root = self.root(dictionary)
+        return root in self.dictionaries and (key in self.dictionaries[root] or key in self.present.get(root, set()))
+
+    def add_collection_membership(self, collection: str, key: str) -> None:
+        collection_root = self.root(collection)
+        if collection_root is None:
+            return
+        for related_collection, dictionary in self.relations:
+            if related_collection == collection_root:
+                self.present.setdefault(dictionary, set()).add(key)
 
 
-def _visit_scope(
-    statements: list[ast.stmt],
-    facts: dict[str, set[str]],
-    candidate_by_call: dict[int, Candidate],
-    proofs: list[LocalProof],
-    *,
-    builtin_dict_available: bool,
-) -> None:
-    for statement in statements:
+def find_proofs(
+    tree: ast.Module, candidates: Iterable[Candidate], *, level: ProofLevel = ProofLevel.CONSERVATIVE
+) -> list[LocalProof]:
+    analyzer = _Analyzer(tree, {id(candidate.call): candidate for candidate in candidates}, level)
+    analyzer.visit_scope(tree.body, _State())
+    return analyzer.proofs
+
+
+class _Analyzer:
+    __slots__ = (
+        "_builtin_all_available",
+        "_builtin_dict_available",
+        "_candidates",
+        "_level",
+        "_proof_ids",
+        "_typed_dicts",
+        "proofs",
+    )
+
+    def __init__(self, tree: ast.Module, candidates: dict[int, Candidate], level: ProofLevel) -> None:
+        self._candidates = candidates
+        self._level = level
+        self._builtin_all_available = not _binds_name(tree, "all")
+        self._builtin_dict_available = not _binds_name(tree, "dict")
+        self._proof_ids: set[int] = set()
+        self._typed_dicts = _typed_dicts(tree)
+        self.proofs: list[LocalProof] = []
+
+    def visit_scope(self, statements: list[ast.stmt], state: _State) -> _State | None:
+        for statement in statements:
+            next_state = self.visit_statement(statement, state)
+            if next_state is None:
+                return None
+            state = next_state
+        return state
+
+    def visit_statement(self, statement: ast.stmt, state: _State) -> _State | None:
+        compound = (
+            ast.If
+            | ast.For
+            | ast.AsyncFor
+            | ast.While
+            | ast.Try
+            | ast.TryStar
+            | ast.With
+            | ast.AsyncWith
+            | ast.Match
+            | ast.FunctionDef
+            | ast.AsyncFunctionDef
+            | ast.ClassDef
+        )
+        if not isinstance(statement, compound) and not _has_unknown_call(statement, self._candidates):
+            self.report_candidates(statement, state)
         if isinstance(statement, ast.If):
-            _visit_if(statement, facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-            continue
+            return self.visit_if(statement, state)
+        if isinstance(statement, ast.For | ast.AsyncFor):
+            return self.visit_for(statement, state)
+        if isinstance(statement, ast.While):
+            self.visit_scope(statement.body, _State())
+            self.visit_scope(statement.orelse, _State())
+            state.clear()
+            return state
+        if isinstance(statement, ast.Try | ast.TryStar):
+            return self.visit_try(statement, state)
+        if isinstance(statement, ast.With | ast.AsyncWith):
+            state.clear()
+            self.visit_scope(statement.body, state)
+            return state
+        if isinstance(statement, ast.Match):
+            return _join([self.visit_scope(case.body, state.copy()) for case in statement.cases])
         if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
-            facts.clear()
-            _visit_scope(
-                statement.body,
-                _dict_parameter_facts(statement, builtin_dict_available=builtin_dict_available),
-                candidate_by_call,
-                proofs,
-                builtin_dict_available=builtin_dict_available,
-            )
-            continue
+            self.visit_scope(statement.body, self.function_state(statement))
+            state.clear()
+            return state
         if isinstance(statement, ast.ClassDef):
-            facts.clear()
-            _visit_scope(statement.body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-            continue
-        if isinstance(
-            statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith | ast.Match
-        ):
-            _visit_compound_statement(
-                statement, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available
-            )
-            facts.clear()
-            continue
-        _visit_statement(statement, facts, candidate_by_call, proofs)
+            self.visit_scope(statement.body, _State())
+            state.clear()
+            return state
+        if isinstance(statement, ast.Return | ast.Raise | ast.Break | ast.Continue):
+            return None
+        if isinstance(statement, ast.Assign | ast.AnnAssign):
+            self.bind_assignment(statement, state)
+            return state
+        if isinstance(statement, ast.AugAssign | ast.Delete):
+            self.invalidate_mutation(statement, state)
+            return state
+        if _contains_suspension(statement) or _has_unknown_call(statement, self._candidates):
+            state.clear()
+        return state
 
+    def visit_if(self, statement: ast.If, state: _State) -> _State | None:
+        true_state, false_state = self.condition_states(statement.test, state)
+        return _join(
+            [
+                self.visit_scope(statement.body, true_state),
+                self.visit_scope(statement.orelse, false_state) if statement.orelse else false_state,
+            ]
+        )
 
-def _visit_if(
-    statement: ast.If,
-    facts: dict[str, set[str]],
-    candidate_by_call: dict[int, Candidate],
-    proofs: list[LocalProof],
-    *,
-    builtin_dict_available: bool,
-) -> None:
-    membership = _membership(statement.test)
-    if membership is None:
-        facts.clear()
-        _visit_scope(statement.body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-        _visit_scope(statement.orelse, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-        return
-    body_facts = _copy_facts(facts)
-    else_facts = _copy_facts(facts)
-    post_guard_facts: set[str] | None = None
-    receiver, key, positive = membership
-    if positive and _receiver_marker() in facts.get(receiver, set()):
-        body_facts.setdefault(receiver, set()).add(_flow_key(key))
-    elif not statement.orelse and _receiver_marker() in facts.get(receiver, set()) and _terminates(statement.body):
-        post_guard_facts = {*facts[receiver], _flow_key(key)}
-    _visit_scope(statement.body, body_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-    _visit_scope(statement.orelse, else_facts, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
-    facts.clear()
-    if post_guard_facts is not None:
-        facts[receiver] = post_guard_facts
-
-
-def _visit_statement(
-    statement: ast.stmt,
-    facts: dict[str, set[str]],
-    candidate_by_call: dict[int, Candidate],
-    proofs: list[LocalProof],
-) -> None:
-    _invalidate_statement_bindings(statement, facts)
-    _invalidate_escaped_facts(statement, facts, candidate_by_call)
-    for call in iter_within_scope(statement):
-        candidate = candidate_by_call.get(id(call))
-        if (
-            candidate is not None
-            and _receiver_marker() in facts.get(candidate.receiver, set())
-            and _candidate_fact(candidate) in facts.get(candidate.receiver, set())
-        ):
-            reason = (
-                "key is present in this dict literal"
-                if candidate.literal_key is not None
-                else "key is present on this control-flow path"
-            )
-            proofs.append(LocalProof(candidate, reason))
-    if isinstance(statement, ast.Assign | ast.AnnAssign):
-        target_names = _target_names(statement)
-        for name in target_names:
-            _drop_name(facts, name)
-        for name in _mutation_targets(statement):
-            _drop_name(facts, name)
-        value = statement.value
-        if len(target_names) == 1 and (keys := _literal_dict_keys(value)) is not None:
-            facts[target_names[0]] = {_receiver_marker(), *keys}
+    def visit_for(self, statement: ast.For | ast.AsyncFor, state: _State) -> _State:
+        body_state = _State(
+            state.aliases.copy(),
+            {root: set() for root in state.dictionaries},
+            state.collections.copy(),
+        )
+        if isinstance(statement.iter, ast.Name) and body_state.root(statement.iter.id) in body_state.collections:
+            for target in _target_names(statement.target):
+                body_state.add_collection_membership(statement.iter.id, target)
         else:
-            _invalidate_assigned_value_facts(value, facts)
-        return
-    if isinstance(statement, ast.AugAssign | ast.Delete):
-        for target in _mutation_targets(statement):
-            _drop_name(facts, target)
+            body_state.clear()
+        self.visit_scope(statement.body, body_state)
+        self.visit_scope(statement.orelse, state.copy())
+        if _has_unknown_call(statement.iter, self._candidates) or _contains_suspension(statement):
+            state.clear()
+        return state
+
+    def visit_try(self, statement: ast.Try | ast.TryStar, state: _State) -> _State | None:
+        paths = [self.visit_scope(statement.body, state.copy())]
+        paths.extend(self.visit_scope(handler.body, _State()) for handler in statement.handlers)
+        if statement.orelse:
+            paths.append(self.visit_scope(statement.orelse, state.copy()))
+        merged = _join(paths)
+        if merged is None:
+            return self.visit_scope(statement.finalbody, _State()) if statement.finalbody else None
+        return self.visit_scope(statement.finalbody, merged) if statement.finalbody else merged
+
+    def condition_states(self, test: ast.expr, state: _State) -> tuple[_State, _State]:
+        if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+            false_state, true_state = self.condition_states(test.operand, state)
+            return true_state, false_state
+        if isinstance(test, ast.BoolOp):
+            if isinstance(test.op, ast.And):
+                true_state = state.copy()
+                false_paths: list[_State | None] = []
+                for value in test.values:
+                    true_state, false_state = self.condition_states(value, true_state)
+                    false_paths.append(false_state)
+                return true_state, _join(false_paths) or _State()
+            false_state = state.copy()
+            true_paths: list[_State | None] = []
+            for value in test.values:
+                true_state, false_state = self.condition_states(value, false_state)
+                true_paths.append(true_state)
+            return _join(true_paths) or _State(), false_state
+        true_state = state.copy()
+        false_state = state.copy()
+        if (membership := _membership(test)) is not None:
+            container, key, positive = membership
+            present_state = true_state if positive else false_state
+            present_state.add_present(container, key)
+            present_state.add_collection_membership(container, key)
+            return true_state, false_state
+        if (relation := _relation(test)) is not None:
+            true_state.add_relation(*relation)
+            return true_state, false_state
+        if self._builtin_all_available and (relation := _all_relation(test)) is not None:
+            true_state.add_relation(*relation)
+            return true_state, false_state
+        if _has_unknown_call(test, self._candidates) or not isinstance(test, ast.Constant):
+            true_state.clear()
+            false_state.clear()
+        return true_state, false_state
+
+    def bind_assignment(self, statement: ast.Assign | ast.AnnAssign, state: _State) -> None:
+        targets = _assignment_targets(statement)
+        value = statement.value
+        mutations = _assignment_mutation_targets(statement)
+        if mutations:
+            state.clear()
+            return
+        if len(targets) != 1 or value is None:
+            for target in targets:
+                state.drop(target)
+            if not targets:
+                state.clear()
+            return
+        target = targets[0]
+        if any(isinstance(node, ast.NamedExpr) for node in ast.walk(value)):
+            state.clear()
+            return
+        if isinstance(value, ast.Name) and state.bind_alias(target, value.id):
+            return
+        if (keys := _literal_dict_keys(value)) is not None:
+            state.bind_dict(target, keys)
+            return
+        if (collection_keys := _literal_collection_keys(value)) is not None:
+            state.bind_collection(target, collection_keys)
+            return
+        state.drop(target)
+        if _has_unknown_call(value, self._candidates) or _contains_suspension(value):
+            state.clear()
+
+    def invalidate_mutation(self, statement: ast.AugAssign | ast.Delete, state: _State) -> None:
+        if _mutation_targets(statement):
+            state.clear()
+        elif isinstance(statement, ast.AugAssign) and isinstance(statement.target, ast.Name):
+            state.drop(statement.target.id)
+        if _has_unknown_call(statement, self._candidates) or _contains_suspension(statement):
+            state.clear()
+
+    def function_state(self, function: ast.FunctionDef | ast.AsyncFunctionDef) -> _State:
+        state = _State()
+        for argument in [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]:
+            annotation_name = _annotation_name(argument.annotation)
+            if annotation_name is not None and (keys := self._typed_dicts.get(annotation_name)) is not None:
+                state.bind_dict(argument.arg, set(keys))
+            elif (
+                self._level is ProofLevel.AGGRESSIVE
+                and self._builtin_dict_available
+                and _is_dict_annotation(argument.annotation)
+            ):
+                state.bind_dict(argument.arg, set())
+        return state
+
+    def report_candidates(self, node: ast.AST, state: _State) -> None:
+        for call in iter_within_scope(node):
+            candidate = self._candidates.get(id(call))
+            if candidate is None or id(call) in self._proof_ids:
+                continue
+            key = candidate.literal_key if candidate.literal_key is not None else candidate.name_key
+            assert key is not None
+            if state.contains(candidate.receiver, key):
+                self._proof_ids.add(id(call))
+                reason = (
+                    "key is present in a known dict"
+                    if candidate.literal_key is not None
+                    else "key is present on this control-flow path"
+                )
+                self.proofs.append(LocalProof(candidate, reason))
+
+
+def _join(paths: list[_State | None]) -> _State | None:
+    available = [path for path in paths if path is not None]
+    if not available:
+        return None
+    aliases = {
+        name: root
+        for name, root in available[0].aliases.items()
+        if all(path.aliases.get(name) == root for path in available[1:])
+    }
+    roots = set(aliases.values())
+    dictionaries = {
+        root: set.intersection(*(path.dictionaries[root] for path in available))
+        for root in roots
+        if all(root in path.dictionaries for path in available)
+    }
+    collections = {
+        root: available[0].collections[root]
+        for root in roots
+        if root in available[0].collections
+        and all(path.collections.get(root) == available[0].collections.get(root) for path in available)
+    }
+    return _State(
+        aliases,
+        dictionaries,
+        collections,
+        set.intersection(*(path.relations for path in available)),
+        {root: set.intersection(*(path.present.get(root, set()) for path in available)) for root in dictionaries},
+    )
 
 
 def _membership(test: ast.expr) -> tuple[str, str, bool] | None:
-    if not isinstance(test, ast.Compare) or len(test.ops) != 1 or len(test.comparators) != 1:
-        return None
-    if not isinstance(test.left, ast.Name) or not isinstance(test.comparators[0], ast.Name):
+    if (
+        not isinstance(test, ast.Compare)
+        or len(test.ops) != 1
+        or len(test.comparators) != 1
+        or not isinstance(test.left, ast.Name)
+        or not isinstance(test.comparators[0], ast.Name)
+    ):
         return None
     if isinstance(test.ops[0], ast.In):
         return test.comparators[0].id, test.left.id, True
@@ -141,100 +386,156 @@ def _membership(test: ast.expr) -> tuple[str, str, bool] | None:
     return None
 
 
-def _terminates(statements: list[ast.stmt]) -> bool:
-    return bool(statements) and isinstance(statements[-1], ast.Return | ast.Raise)
+def _relation(test: ast.expr) -> tuple[str, str] | None:
+    if (
+        not isinstance(test, ast.Compare)
+        or len(test.ops) != 1
+        or not isinstance(test.ops[0], ast.LtE)
+        or not isinstance(test.left, ast.Name)
+        or len(test.comparators) != 1
+    ):
+        return None
+    right = test.comparators[0]
+    if (
+        not isinstance(right, ast.Call)
+        or right.args
+        or right.keywords
+        or not isinstance(right.func, ast.Attribute)
+        or right.func.attr != "keys"
+        or not isinstance(right.func.value, ast.Name)
+    ):
+        return None
+    return test.left.id, right.func.value.id
 
 
-def _literal_dict_keys(value: ast.expr | None) -> set[str] | None:
+def _all_relation(test: ast.expr) -> tuple[str, str] | None:
+    if (
+        not isinstance(test, ast.Call)
+        or test.keywords
+        or len(test.args) != 1
+        or not isinstance(test.func, ast.Name)
+        or test.func.id != "all"
+        or not isinstance(test.args[0], ast.GeneratorExp)
+    ):
+        return None
+    generator = test.args[0]
+    if len(generator.generators) != 1 or generator.generators[0].ifs:
+        return None
+    clause = generator.generators[0]
+    if not isinstance(clause.target, ast.Name) or not isinstance(clause.iter, ast.Name):
+        return None
+    membership = _membership(generator.elt)
+    if membership is None or not membership[2] or membership[1] != clause.target.id:
+        return None
+    return clause.iter.id, membership[0]
+
+
+def _literal_dict_keys(value: ast.expr) -> set[str] | None:
     if not isinstance(value, ast.Dict) or any(key is None for key in value.keys):
         return None
-    keys = {
-        _literal_key(key.value) for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)
-    }
+    keys = {key.value for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
     return keys if len(keys) == len(value.keys) else None
 
 
-def _target_names(statement: ast.Assign | ast.AnnAssign) -> list[str]:
-    targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
-    return [name for target in targets for name in _target_names_from(target)]
+def _literal_collection_keys(value: ast.expr) -> frozenset[str] | None:
+    if not isinstance(value, ast.Set | ast.List | ast.Tuple):
+        return None
+    keys = frozenset(
+        element.value for element in value.elts if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    )
+    return keys if len(keys) == len(value.elts) else None
 
 
-def _invalidate_escaped_facts(
-    statement: ast.stmt,
-    facts: dict[str, set[str]],
-    candidate_by_call: dict[int, Candidate],
-) -> None:
-    for call in ast.walk(statement):
-        if isinstance(call, ast.Call) and id(call) not in candidate_by_call:
-            facts.clear()
-            return
-    for node in ast.walk(statement):
-        if isinstance(node, ast.NamedExpr | ast.Yield | ast.YieldFrom):
-            _invalidate_assigned_value_facts(node.value, facts)
+def _typed_dicts(tree: ast.Module) -> dict[str, frozenset[str]]:
+    typing_names = _typing_names(tree)
+    typed_dicts: dict[str, frozenset[str]] = {}
+    for statement in tree.body:
+        if not isinstance(statement, ast.ClassDef) or not any(
+            _is_typing_name(base, "TypedDict", typing_names) for base in statement.bases
+        ):
+            continue
+        total_values = [keyword.value for keyword in statement.keywords if keyword.arg == "total"]
+        if total_values and not all(
+            isinstance(value, ast.Constant) and isinstance(value.value, bool) for value in total_values
+        ):
+            continue
+        total = not any(isinstance(value, ast.Constant) and value.value is False for value in total_values)
+        typed_dicts[statement.name] = frozenset(
+            item.target.id
+            for item in statement.body
+            if isinstance(item, ast.AnnAssign)
+            and isinstance(item.target, ast.Name)
+            and (
+                (total and not _is_typing_name(item.annotation, "NotRequired", typing_names))
+                or _is_typing_name(item.annotation, "Required", typing_names)
+            )
+        )
+    return typed_dicts
 
 
-def _invalidate_assigned_value_facts(value: ast.expr | None, facts: dict[str, set[str]]) -> None:
-    if value is None:
-        return
-    for name in ast.walk(value):
-        if isinstance(name, ast.Name) and isinstance(name.ctx, ast.Load):
-            _drop_name(facts, name.id)
+def _typing_names(tree: ast.Module) -> dict[str, str]:
+    names: dict[str, str] = {}
+    for statement in tree.body:
+        if isinstance(statement, ast.Import):
+            for imported in statement.names:
+                if imported.name in {"typing", "typing_extensions"}:
+                    names[imported.asname or imported.name] = "module"
+        elif isinstance(statement, ast.ImportFrom) and statement.module in {"typing", "typing_extensions"}:
+            for imported in statement.names:
+                if imported.name in {"Required", "NotRequired", "TypedDict"}:
+                    names[imported.asname or imported.name] = imported.name
+    return names
 
 
-def _invalidate_statement_bindings(statement: ast.stmt, facts: dict[str, set[str]]) -> None:
-    for node in iter_within_scope(statement):
-        for name in iter_binding_names(node):
-            _drop_name(facts, name)
+def _is_typing_name(annotation: ast.expr | None, expected: str, names: dict[str, str]) -> bool:
+    if isinstance(annotation, ast.Subscript):
+        annotation = annotation.value
+    if isinstance(annotation, ast.Name):
+        return names.get(annotation.id) == expected
+    return (
+        isinstance(annotation, ast.Attribute)
+        and isinstance(annotation.value, ast.Name)
+        and names.get(annotation.value.id) == "module"
+        and annotation.attr == expected
+    )
 
 
-def _copy_facts(facts: dict[str, set[str]]) -> dict[str, set[str]]:
-    return {name: keys.copy() for name, keys in facts.items()}
+def _annotation_name(annotation: ast.expr | None) -> str | None:
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    return None
 
 
-def _visit_compound_statement(
-    statement: ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar | ast.With | ast.AsyncWith | ast.Match,
-    candidate_by_call: dict[int, Candidate],
-    proofs: list[LocalProof],
-    *,
-    builtin_dict_available: bool,
-) -> None:
-    bodies = [case.body for case in statement.cases] if isinstance(statement, ast.Match) else [statement.body]
-    if isinstance(statement, ast.For | ast.AsyncFor | ast.While | ast.Try | ast.TryStar):
-        bodies.append(statement.orelse)
-    if isinstance(statement, ast.Try | ast.TryStar):
-        bodies.extend(handler.body for handler in statement.handlers)
-        bodies.append(statement.finalbody)
-    for body in bodies:
-        _visit_scope(body, {}, candidate_by_call, proofs, builtin_dict_available=builtin_dict_available)
+def _is_dict_annotation(annotation: ast.expr | None) -> bool:
+    return (isinstance(annotation, ast.Name) and annotation.id == "dict") or (
+        isinstance(annotation, ast.Subscript)
+        and isinstance(annotation.value, ast.Name)
+        and annotation.value.id == "dict"
+    )
 
 
-def _literal_key(key: str) -> str:
-    return f"literal:{key}"
+def _assignment_targets(statement: ast.Assign | ast.AnnAssign) -> list[str]:
+    return [
+        name
+        for target in (statement.targets if isinstance(statement, ast.Assign) else [statement.target])
+        for name in _target_names(target)
+    ]
 
 
-def _receiver_marker() -> str:
-    return "receiver"
+def _target_names(target: ast.expr) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    if isinstance(target, ast.Tuple | ast.List):
+        return [name for element in target.elts for name in _target_names(element)]
+    return []
 
 
-def _flow_key(key: str) -> str:
-    return f"flow:{key}"
-
-
-def _candidate_fact(candidate: Candidate) -> str:
-    if candidate.literal_key is not None:
-        return _literal_key(candidate.literal_key)
-    assert candidate.name_key is not None
-    return _flow_key(candidate.name_key)
-
-
-def _drop_name(facts: dict[str, set[str]], name: str) -> None:
-    facts.pop(name, None)
-    for keys in facts.values():
-        keys.discard(_flow_key(name))
-
-
-def _mutation_targets(statement: ast.Assign | ast.AnnAssign | ast.AugAssign | ast.Delete) -> set[str]:
-    targets = statement.targets if isinstance(statement, ast.Assign | ast.Delete) else [statement.target]
+def _mutation_targets(statement: ast.AugAssign | ast.Delete) -> set[str]:
+    targets = statement.targets if isinstance(statement, ast.Delete) else [statement.target]
     return {
         target.value.id
         for target in targets
@@ -242,67 +543,24 @@ def _mutation_targets(statement: ast.Assign | ast.AnnAssign | ast.AugAssign | as
     }
 
 
-def _target_names_from(target: ast.expr) -> list[str]:
-    if isinstance(target, ast.Name):
-        return [target.id]
-    if isinstance(target, ast.Starred):
-        return _target_names_from(target.value)
-    if isinstance(target, ast.Tuple | ast.List):
-        return [name for element in target.elts for name in _target_names_from(element)]
-    return []
-
-
-def _dict_parameter_facts(
-    function: ast.FunctionDef | ast.AsyncFunctionDef, *, builtin_dict_available: bool
-) -> dict[str, set[str]]:
-    if not builtin_dict_available:
-        return {}
-    arguments = [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]
+def _assignment_mutation_targets(statement: ast.Assign | ast.AnnAssign) -> set[str]:
+    targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
     return {
-        argument.arg: {_receiver_marker()} for argument in arguments if _is_builtin_dict_annotation(argument.annotation)
+        target.value.id
+        for target in targets
+        if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name)
     }
 
 
-def _is_builtin_dict_annotation(annotation: ast.expr | None) -> bool:
-    if isinstance(annotation, ast.Name):
-        return annotation.id == "dict"
-    if not isinstance(annotation, ast.Subscript) or not isinstance(annotation.value, ast.Name):
-        return False
-    return annotation.value.id == "dict"
+def _has_unknown_call(node: ast.AST, candidates: dict[int, Candidate]) -> bool:
+    return any(isinstance(child, ast.Call) and id(child) not in candidates for child in ast.walk(node))
 
 
-def _binds_dict(tree: ast.Module) -> bool:
+def _contains_suspension(node: ast.AST) -> bool:
+    return any(isinstance(child, ast.Await | ast.Yield | ast.YieldFrom) for child in ast.walk(node))
+
+
+def _binds_name(tree: ast.Module, name: str) -> bool:
     return any(
-        name == "dict"
-        for node in ast.walk(tree)
-        for name in (
-            iter_binding_names(node)
-            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
-            else _definition_binding_names(node)
-        )
-    )
-
-
-def _definition_binding_names(
-    definition: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
-) -> tuple[str, ...]:
-    arguments = (
-        [
-            *definition.args.posonlyargs,
-            *definition.args.args,
-            *definition.args.kwonlyargs,
-            *([definition.args.vararg] if definition.args.vararg is not None else []),
-            *([definition.args.kwarg] if definition.args.kwarg is not None else []),
-        ]
-        if isinstance(definition, ast.FunctionDef | ast.AsyncFunctionDef)
-        else []
-    )
-    return (
-        definition.name,
-        *(argument.arg for argument in arguments),
-        *(
-            type_parameter.name
-            for type_parameter in definition.type_params
-            if isinstance(type_parameter, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
-        ),
+        isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store) and node.id == name for node in ast.walk(tree)
     )

--- a/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_dict_get/local.py
@@ -327,7 +327,7 @@ class _Analyzer:
     def bind_assignment(self, statement: ast.Assign | ast.AnnAssign, state: _State) -> None:
         targets = _assignment_targets(statement)
         value = statement.value
-        mutations = _assignment_mutation_targets(statement)
+        mutations = _mutation_targets(statement.targets if isinstance(statement, ast.Assign) else [statement.target])
         if mutations:
             state.clear()
             return
@@ -354,7 +354,9 @@ class _Analyzer:
             state.clear()
 
     def invalidate_mutation(self, statement: ast.AugAssign | ast.Delete, state: _State) -> None:
-        if _mutation_targets(statement) or isinstance(statement, ast.AugAssign):
+        if _mutation_targets(
+            statement.targets if isinstance(statement, ast.Delete) else [statement.target]
+        ) or isinstance(statement, ast.AugAssign):
             state.clear()
         else:
             for target in statement.targets:
@@ -586,17 +588,7 @@ def _target_names(target: ast.expr) -> list[str]:
     return []
 
 
-def _mutation_targets(statement: ast.AugAssign | ast.Delete) -> set[str]:
-    targets = statement.targets if isinstance(statement, ast.Delete) else [statement.target]
-    return {
-        target.value.id
-        for target in targets
-        if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name)
-    }
-
-
-def _assignment_mutation_targets(statement: ast.Assign | ast.AnnAssign) -> set[str]:
-    targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+def _mutation_targets(targets: Iterable[ast.expr]) -> set[str]:
     return {
         target.value.id
         for target in targets

--- a/tests/redundant_dict_get/test_check.py
+++ b/tests/redundant_dict_get/test_check.py
@@ -7,6 +7,7 @@ import pytest
 
 from pre_commit_hooks.ast_checks._base import FixOutcome, Violation
 from pre_commit_hooks.ast_checks.redundant_dict_get import RedundantDictGetCheck
+from pre_commit_hooks.ast_checks.redundant_dict_get.local import ProofLevel
 
 
 def _check(source: str) -> list[Violation]:
@@ -24,6 +25,20 @@ def test_identity_and_opt_in_properties() -> None:
     assert check.get_prefilter_pattern() == [".get("]
 
 
+def test_aggressive_level_retains_the_direct_dict_annotation_heuristic() -> None:
+    source = (
+        "def read(config: dict[str, int], key: str) -> int | None:\n"
+        "    if key in config:\n"
+        "        return config.get(key)\n"
+        "    return None\n"
+    )
+
+    aggressive = RedundantDictGetCheck(level=ProofLevel.AGGRESSIVE).check(Path("test.py"), ast.parse(source), source)
+
+    assert _check(source) == []
+    assert [violation.line for violation in aggressive] == [3]
+
+
 def test_check_reports_a_literal_dict_proof() -> None:
     source = "config = {'port': 5432}\nvalue = config.get('port')\n"
 
@@ -33,7 +48,7 @@ def test_check_reports_a_literal_dict_proof() -> None:
     assert violations[0].line == 2
     assert violations[0].col == 8
     assert violations[0].fixable is False
-    assert "dict literal" in violations[0].message
+    assert "known dict" in violations[0].message
     assert "config['port']" in violations[0].message
     assert "pytriage: TR9" in violations[0].message
 

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -392,6 +392,24 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
             "    value = config.get(key)\n"
         ),
         (
+            "config = {'port': 5432}\n"
+            "try:\n"
+            "    del config['port']\n"
+            "except KeyError:\n"
+            "    pass\n"
+            "else:\n"
+            "    value = config.get('port')\n"
+        ),
+        (
+            "config = {'port': 5432}\n"
+            "try:\n"
+            "    config = {'host': 'localhost'}\n"
+            "except OSError:\n"
+            "    pass\n"
+            "else:\n"
+            "    value = config.get('port')\n"
+        ),
+        (
             "first = {'first'}\n"
             "second = {'second'}\n"
             "config = {'first': 1, 'second': 2}\n"

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -201,6 +201,10 @@ def test_find_proofs_rejects_mutation_escape_alias_and_non_dominating_cases(sour
             [5],
         ),
         (
+            "config = {'port': 5432}\nif True:\n    pass\nvalue = config.get('port')\n",
+            [4],
+        ),
+        (
             (
                 "required = {'port'}\n"
                 "config = {'port': 5432}\n"
@@ -210,6 +214,16 @@ def test_find_proofs_rejects_mutation_escape_alias_and_non_dominating_cases(sour
                 "            value = config.get(key)\n"
             ),
             [6],
+        ),
+        (
+            (
+                "required = {'port'}\n"
+                "config = {'port': 5432}\n"
+                "if required <= config.keys():\n"
+                "    for key in required:\n"
+                "        value = config.get(key)\n"
+            ),
+            [5],
         ),
         (
             (
@@ -274,6 +288,68 @@ def test_alias_mutation_invalidates_every_alias() -> None:
             "    value = config.get(key)\n"
         ),
         "config = {'port': 5432}\nif 'port' in config and flag:\n    value = config.get('port')\n",
+        ("config = {'port': 5432}\nfor _ in items:\n    del config['port']\nvalue = config.get('port')\n"),
+        ("config = {'port': 5432}\nfor _ in items:\n    del config['port']\n    break\nvalue = config.get('port')\n"),
+        ("config = {}\nmatch subject:\n    case 1:\n        config = {'port': 5432}\nvalue = config.get('port')\n"),
+        ("config = {}\nwith manager:\n    config = {'port': 5432}\nvalue = config.get('port')\n"),
+        "config = {'port': 5432}\nfrom settings import config\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nfrom settings import *\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\ndel config\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nholder.value += config\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nvalue = (config := {}, config.get('port'))[1]\n",
+        "config = {'port': 5432}\n(config := {})\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\nif consume():\n    pass\nvalue = config.get('port')\n",
+        ("config = {'port': 5432}\nmatch consume():\n    case _:\n        pass\nvalue = config.get('port')\n"),
+        ("config = {'port': 5432}\nmatch subject:\n    case 1 as config:\n        pass\nvalue = config.get('port')\n"),
+        (
+            "config = {'port': 5432}\n"
+            "match subject:\n"
+            "    case _ as config if enabled:\n"
+            "        pass\n"
+            "value = config.get('port')\n"
+        ),
+        (
+            "config = {'port': 5432}\n"
+            "try:\n"
+            "    pass\n"
+            "except OSError:\n"
+            "    pass\n"
+            "else:\n"
+            "    pass\n"
+            "value = config.get('port')\n"
+        ),
+        "for _ in values:\n    break\nelse:\n    pass\n",
+        "def read():\n    for _ in values:\n        return\n",
+        "import os\n",
+        ("config = {'port': 5432}\nfor _ in values:\n    consume()\n    value = config.get('port')\n"),
+        ("config = {'port': 5432}\nfor _ in values:\n    other += 1\nvalue = config.get('port')\n"),
+        (
+            "def read():\n"
+            "    config = {'port': 5432}\n"
+            "    for _ in values:\n"
+            "        yield None\n"
+            "    return config.get('port')\n"
+        ),
+        ("config = {'port': 5432}\nfor _ in values:\n    config = {}\nvalue = config.get('port')\n"),
+        ("config = {'port': 5432}\nfor _ in values:\n    from settings import config\nvalue = config.get('port')\n"),
+        ("config = {'port': 5432}\nfor _ in values:\n    def config():\n        pass\nvalue = config.get('port')\n"),
+        (
+            "from typing import TypedDict\n"
+            "class Settings(TypedDict):\n"
+            "    port: int\n"
+            "def read(settings: other.Settings) -> int | None:\n"
+            "    return settings.get('port')\n"
+        ),
+        (
+            "required = {'port'}\n"
+            "alias = required\n"
+            "config = {'port': 5432}\n"
+            "if not required <= config.keys():\n"
+            "    raise ValueError\n"
+            "alias |= {'missing'}\n"
+            "if key in required:\n"
+            "    value = config.get(key)\n"
+        ),
     ],
 )
 def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -5,7 +5,7 @@ import ast
 import pytest
 
 from pre_commit_hooks.ast_checks.redundant_dict_get.candidates import find_candidates
-from pre_commit_hooks.ast_checks.redundant_dict_get.local import find_proofs
+from pre_commit_hooks.ast_checks.redundant_dict_get.local import ProofLevel, find_proofs
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ from pre_commit_hooks.ast_checks.redundant_dict_get.local import find_proofs
 def test_find_proofs_reports_the_supported_local_invariants(source: str, expected_lines: list[int]) -> None:
     tree = ast.parse(source)
 
-    proofs = find_proofs(tree, find_candidates(tree))
+    proofs = find_proofs(tree, find_candidates(tree), level=ProofLevel.AGGRESSIVE)
 
     assert [proof.candidate.call.lineno for proof in proofs] == expected_lines
 
@@ -73,7 +73,6 @@ def test_find_proofs_reports_the_supported_local_invariants(source: str, expecte
         "config = {'port': 5432}\nconfig['port'] += 1\nvalue = config.get('port')\n",
         "config = {'port': 5432}\ndel config['port']\nvalue = config.get('port')\n",
         "config = {'port': 5432}\nconsume(config)\nvalue = config.get('port')\n",
-        "config = {'port': 5432}\nalias = config\nvalue = alias.get('port')\n",
         "config = {'port': 5432}\nalias = config\nalias.pop('port')\nvalue = config.get('port')\n",
         "config = {'port': 5432}\nholder.config = config\nvalue = config.get('port')\n",
         "config = {'port': 5432}\nconfig, other = build()\nvalue = config.get('port')\n",
@@ -169,19 +168,169 @@ def test_find_proofs_reports_the_supported_local_invariants(source: str, expecte
             "    config = {'port': 5432}\n"
             "    return [config.get('port') for _ in range(1)]\n"
         ),
-        (
-            "def f() -> int | None:\n"
-            "    config = {'port': 5432}\n"
-            "    for _ in range(1):\n"
-            "        return config.get('port')\n"
-            "    return None\n"
-        ),
         ("def f(*config: dict[str, int]) -> int | None:\n    return config.get('port')\n"),
         ("def f(**config: dict[str, int]) -> int | None:\n    return config.get('port')\n"),
         "config = {'port': 5432}\nconfig, *other = build()\nvalue = config.get('port')\n",
     ],
 )
 def test_find_proofs_rejects_mutation_escape_alias_and_non_dominating_cases(source: str) -> None:
+    tree = ast.parse(source)
+
+    assert find_proofs(tree, find_candidates(tree)) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_lines"),
+    [
+        (
+            "config = {'port': 5432}\nalias = config\nvalue = alias.get('port')\n",
+            [3],
+        ),
+        (
+            "config = {'port': 5432}\nif key in config and other in config:\n    value = config.get(key)\n",
+            [3],
+        ),
+        (
+            (
+                "if enabled:\n"
+                "    config = {'port': 5432}\n"
+                "else:\n"
+                "    config = {'port': 5433}\n"
+                "value = config.get('port')\n"
+            ),
+            [5],
+        ),
+        (
+            (
+                "required = {'port'}\n"
+                "config = {'port': 5432}\n"
+                "if required <= config.keys():\n"
+                "    for key in required:\n"
+                "        if key in config:\n"
+                "            value = config.get(key)\n"
+            ),
+            [6],
+        ),
+        (
+            (
+                "required = {'port'}\n"
+                "config = {'port': 5432}\n"
+                "if not all(key in config for key in required):\n"
+                "    raise ValueError\n"
+                "for key in required:\n"
+                "    if key in config:\n"
+                "        value = config.get(key)\n"
+            ),
+            [7],
+        ),
+        (
+            (
+                "from typing import NotRequired, TypedDict\n"
+                "class Settings(TypedDict):\n"
+                "    present: int | None\n"
+                "    absent: NotRequired[int]\n"
+                "def read(settings: Settings) -> int | None:\n"
+                "    first = settings.get('present')\n"
+                "    second = settings.get('absent')\n"
+            ),
+            [6],
+        ),
+    ],
+)
+def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_lines: list[int]) -> None:
+    tree = ast.parse(source)
+
+    proofs = find_proofs(tree, find_candidates(tree))
+
+    assert [proof.candidate.call.lineno for proof in proofs] == expected_lines
+
+
+def test_alias_mutation_invalidates_every_alias() -> None:
+    source = "config = {'port': 5432}\nalias = config\ndel alias['port']\nvalue = config.get('port')\n"
+    tree = ast.parse(source)
+
+    assert find_proofs(tree, find_candidates(tree)) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "config = {'a': 1}\nalias = config\nconfig = {'b': 2}\nvalue = alias.get('b')\n",
+        (
+            "from typing import TypedDict\n"
+            "total = False\n"
+            "class Settings(TypedDict, total=total):\n"
+            "    port: int\n"
+            "def read(settings: Settings) -> int | None:\n"
+            "    return settings.get('port')\n"
+        ),
+        (
+            "required = {'port'}\n"
+            "config = {'port': 5432}\n"
+            "if not required <= config.keys():\n"
+            "    raise ValueError\n"
+            "required |= {'missing'}\n"
+            "for key in required:\n"
+            "    value = config.get(key)\n"
+        ),
+        "config = {'port': 5432}\nif 'port' in config and flag:\n    value = config.get('port')\n",
+    ],
+)
+def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:
+    tree = ast.parse(source)
+
+    assert find_proofs(tree, find_candidates(tree)) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "config = {'port': 5432}\nwhile enabled:\n    value = config.get('port')\n",
+        "config = {'port': 5432}\nfor key in unknown:\n    value = config.get('port')\nelse:\n    pass\n",
+        "config = {'port': 5432}\nfor key in range(1):\n    value = config.get('port')\n",
+        "config = {'port': 5432}\nconfig['port'] += 1\nvalue = config.get('port')\n",
+        "required = {'port'}\nconfig = {'port': 5432}\nif required <= config.values():\n    pass\n",
+        (
+            "required = {'port'}\n"
+            "config = {'port': 5432}\n"
+            "if all(key in config for key in required if enabled):\n"
+            "    pass\n"
+        ),
+        "import typing\nclass Settings(typing.TypedDict):\n    port: typing.Required[int]\n",
+        "def read(config: module.Settings) -> None:\n    pass\n",
+        "from typing import List\n",
+        "def read() -> None:\n    if enabled:\n        return\n    raise ValueError\n",
+        "def read() -> None:\n    if enabled:\n        return\n    else:\n        raise ValueError\n",
+        (
+            "def read() -> None:\n"
+            "    try:\n"
+            "        return\n"
+            "    except ValueError:\n"
+            "        return\n"
+            "    finally:\n"
+            "        pass\n"
+        ),
+        "counter = 0\ncounter += 1\n",
+        "config = {'port': 5432}\ndel config[consume()]\n",
+        "required = unknown\nconfig = {'port': 5432}\nif required <= config.keys():\n    pass\n",
+        "config = {'port': 5432}\nif key in config or enabled:\n    pass\n",
+        (
+            "first = {'first'}\n"
+            "second = {'second'}\n"
+            "config = {'first': 1, 'second': 2}\n"
+            "if not first <= config.keys():\n"
+            "    raise ValueError\n"
+            "if not second <= config.keys():\n"
+            "    raise ValueError\n"
+            "for key in first:\n"
+            "    pass\n"
+        ),
+        "config = {'port': 5432}\nif all((key in config for key, other in required)):\n    pass\n",
+        "config = {'port': 5432}\nif all(0 for key in required):\n    pass\n",
+        "pass\n" * 1_001,
+    ],
+)
+def test_find_proofs_handles_boundaries_without_reporting(source: str) -> None:
     tree = ast.parse(source)
 
     assert find_proofs(tree, find_candidates(tree)) == []

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -5,7 +5,7 @@ import ast
 import pytest
 
 from pre_commit_hooks.ast_checks.redundant_dict_get.candidates import find_candidates
-from pre_commit_hooks.ast_checks.redundant_dict_get.local import ProofLevel, find_proofs
+from pre_commit_hooks.ast_checks.redundant_dict_get.local import ProofLevel, _binds_name, find_proofs
 
 
 @pytest.mark.parametrize(
@@ -376,6 +376,22 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
         "required = unknown\nconfig = {'port': 5432}\nif required <= config.keys():\n    pass\n",
         "config = {'port': 5432}\nif key in config or enabled:\n    pass\n",
         (
+            "required = {'ab'}\n"
+            "config = {'ab': 1}\n"
+            "if required <= config.keys():\n"
+            "    for key, other in required:\n"
+            "        value = config.get(key)\n"
+        ),
+        (
+            "from alternate import all\n"
+            "required = {'port'}\n"
+            "config = {'port': 5432}\n"
+            "if not all(key in config for key in required):\n"
+            "    raise ValueError\n"
+            "for key in required:\n"
+            "    value = config.get(key)\n"
+        ),
+        (
             "first = {'first'}\n"
             "second = {'second'}\n"
             "config = {'first': 1, 'second': 2}\n"
@@ -395,3 +411,32 @@ def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:
     tree = ast.parse(source)
 
     assert find_proofs(tree, find_candidates(tree)) == []
+
+
+def test_find_proofs_rejects_aggressive_dict_proof_after_function_binding() -> None:
+    tree = ast.parse(
+        "def dict():\n"
+        "    pass\n"
+        "def read(config: dict[str, int], key: str) -> int | None:\n"
+        "    if key in config:\n"
+        "        return config.get(key)\n"
+        "    return None\n"
+    )
+
+    assert find_proofs(tree, find_candidates(tree), level=ProofLevel.AGGRESSIVE) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "name"),
+    [
+        ("all = replacement\n", "all"),
+        ("del dict\n", "dict"),
+        ("import replacement as all\n", "all"),
+        ("from replacement import dict\n", "dict"),
+        ("def all():\n    pass\n", "all"),
+        ("async def dict():\n    pass\n", "dict"),
+        ("class all:\n    pass\n", "all"),
+    ],
+)
+def test_binds_name_recognizes_all_binding_forms(source: str, name: str) -> None:
+    assert _binds_name(ast.parse(source), name)

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -409,6 +409,10 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
             "else:\n"
             "    value = config.get('port')\n"
         ),
+        "config = {'port': 5432}\na, b = mutate(config)\nvalue = config.get('port')\n",
+        "config = {'port': 5432}\na = b = mutate(config)\nvalue = config.get('port')\n",
+        ("def read():\n    config = {'port': 5432}\n    a, b = yield config\n    return config.get('port')\n"),
+        "config = {'port': 5432}\na, b = (config := {})\nvalue = config.get('port')\n",
         (
             "first = {'first'}\n"
             "second = {'second'}\n"

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -259,16 +259,10 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
     assert [proof.candidate.call.lineno for proof in proofs] == expected_lines
 
 
-def test_alias_mutation_invalidates_every_alias() -> None:
-    source = "config = {'port': 5432}\nalias = config\ndel alias['port']\nvalue = config.get('port')\n"
-    tree = ast.parse(source)
-
-    assert find_proofs(tree, find_candidates(tree)) == []
-
-
 @pytest.mark.parametrize(
     "source",
     [
+        "config = {'port': 5432}\nalias = config\ndel alias['port']\nvalue = config.get('port')\n",
         "config = {'a': 1}\nalias = config\nconfig = {'b': 2}\nvalue = alias.get('b')\n",
         (
             "from typing import TypedDict\n"
@@ -350,17 +344,6 @@ def test_alias_mutation_invalidates_every_alias() -> None:
             "if key in required:\n"
             "    value = config.get(key)\n"
         ),
-    ],
-)
-def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:
-    tree = ast.parse(source)
-
-    assert find_proofs(tree, find_candidates(tree)) == []
-
-
-@pytest.mark.parametrize(
-    "source",
-    [
         "config = {'port': 5432}\nwhile enabled:\n    value = config.get('port')\n",
         "config = {'port': 5432}\nfor key in unknown:\n    value = config.get('port')\nelse:\n    pass\n",
         "config = {'port': 5432}\nfor key in range(1):\n    value = config.get('port')\n",
@@ -406,7 +389,7 @@ def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:
         "pass\n" * 1_001,
     ],
 )
-def test_find_proofs_handles_boundaries_without_reporting(source: str) -> None:
+def test_find_proofs_rejects_reviewed_false_positive_paths(source: str) -> None:
     tree = ast.parse(source)
 
     assert find_proofs(tree, find_candidates(tree)) == []

--- a/tests/redundant_dict_get/test_local.py
+++ b/tests/redundant_dict_get/test_local.py
@@ -292,6 +292,8 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
         "config = {'port': 5432}\nholder.value += config\nvalue = config.get('port')\n",
         "config = {'port': 5432}\nvalue = (config := {}, config.get('port'))[1]\n",
         "config = {'port': 5432}\n(config := {})\nvalue = config.get('port')\n",
+        "config = {}\nif port in config:\n    value = config.get('port')\n",
+        "config = {'port': 5432}\nvalue = config.get(port)\n",
         "config = {'port': 5432}\nif consume():\n    pass\nvalue = config.get('port')\n",
         ("config = {'port': 5432}\nmatch consume():\n    case _:\n        pass\nvalue = config.get('port')\n"),
         ("config = {'port': 5432}\nmatch subject:\n    case 1 as config:\n        pass\nvalue = config.get('port')\n"),
@@ -312,9 +314,9 @@ def test_find_proofs_reports_extended_conservative_proofs(source: str, expected_
             "    pass\n"
             "value = config.get('port')\n"
         ),
-        "for _ in values:\n    break\nelse:\n    pass\n",
-        "def read():\n    for _ in values:\n        return\n",
-        "import os\n",
+        "config = {'port': 5432}\nfor _ in values:\n    break\nelse:\n    pass\nvalue = config.get('port')\n",
+        "def read():\n    config = {'port': 5432}\n    for _ in values:\n        return config.get('port')\n",
+        "import os\nconfig = {}\nvalue = config.get('port')\n",
         ("config = {'port': 5432}\nfor _ in values:\n    consume()\n    value = config.get('port')\n"),
         ("config = {'port': 5432}\nfor _ in values:\n    other += 1\nvalue = config.get('port')\n"),
         (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from pre_commit_hooks.ast_checks._config import discover, resolve
 from pre_commit_hooks.ast_checks._options import add_check_arguments
 from pre_commit_hooks.ast_checks.meaningless_vars import MeaninglessVarsLevel
 from pre_commit_hooks.ast_checks.redundant_assignment.semantic import AggressivenessLevel
+from pre_commit_hooks.ast_checks.redundant_dict_get.local import ProofLevel
 from pre_commit_hooks.ast_checks.redundant_type_conversion.confidence import ConfidenceLevel
 from tests._helpers import restricted_permissions
 
@@ -215,9 +216,10 @@ def test_unknown_field_error_lists_the_valid_ones(project: Path, capsys: pytest.
         ("meaningless-vars", "permissive", MeaninglessVarsLevel.PERMISSIVE),
         ("redundant-assignment", "permissive", AggressivenessLevel.PERMISSIVE),
         ("redundant-type-conversion", "permissive", ConfidenceLevel.PERMISSIVE),
+        ("redundant-dict-get", "aggressive", ProofLevel.AGGRESSIVE),
         ("meaningless-vars", "conservative", MeaninglessVarsLevel.CONSERVATIVE),
     ],
-    ids=["tr1", "tr5", "tr6", "explicit-default"],
+    ids=["tr1", "tr5", "tr6", "tr9", "explicit-default"],
 )
 def test_a_checks_option_reaches_its_constructor_from_the_config_file(
     project: Path, check_id: str, option_value: str, expected: object

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3884,7 +3884,8 @@ class _LevelFlagCase(NamedTuple):
     check_id: str
     level_flag: str
     source: str
-    permissive_needle: str
+    broader_level: str
+    broader_needle: str
 
 
 @pytest.mark.parametrize(
@@ -3894,18 +3895,32 @@ class _LevelFlagCase(NamedTuple):
             "redundant-assignment",
             "--redundant-assignment-level",
             'def example():\n    x: str = "foo"\n    func(x)\n',
+            "permissive",
             "'x'",
         ),
         _LevelFlagCase(
             "meaningless-vars",
             "--meaningless-vars-level",
             "def other():\n    result = 42\n    return result\n",
+            "permissive",
             "'result'",
         ),
+        _LevelFlagCase(
+            "redundant-dict-get",
+            "--redundant-dict-get-level",
+            (
+                "def read(config: dict[str, int], key: str) -> int | None:\n"
+                "    if key in config:\n"
+                "        return config.get(key)\n"
+                "    return None\n"
+            ),
+            "aggressive",
+            "Redundant `dict.get()`",
+        ),
     ],
-    ids=["redundant-assignment", "meaningless-vars"],
+    ids=["redundant-assignment", "meaningless-vars", "redundant-dict-get"],
 )
-def test_main_level_flag_switches_between_conservative_and_permissive_reporting(
+def test_main_level_flag_switches_between_conservative_and_broader_reporting(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], case: _LevelFlagCase
 ) -> None:
 
@@ -3918,9 +3933,9 @@ def test_main_level_flag_switches_between_conservative_and_permissive_reporting(
     conservative_exit_code = main([str(filepath), "--select", case.check_id, case.level_flag, "conservative"])
     assert conservative_exit_code == 0
 
-    permissive_exit_code = main([str(filepath), "--select", case.check_id, case.level_flag, "permissive"])
-    assert permissive_exit_code == 1
-    assert case.permissive_needle in capsys.readouterr().err
+    broader_exit_code = main([str(filepath), "--select", case.check_id, case.level_flag, case.broader_level])
+    assert broader_exit_code == 1
+    assert case.broader_needle in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced redundant `dict.get()` detection with control-flow analysis, aliases, validated key collections, and required `TypedDict` fields.
  - Added conservative and aggressive reporting levels, with conservative behavior enabled by default.

- **Bug Fixes**
  - Improved accuracy by discarding key-presence assumptions across mutations, reassignment, unknown calls, suspension, and other unsafe boundaries.
  - Distinguished literal dictionary keys from variable-name presence proofs.

- **Documentation**
  - Updated the README, changelog, and rule documentation with supported proof patterns and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->