### PR TITLE
feat(redundant-assignment): resolve same-file positional-argument echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 - `redundant-dict-get` (TR9) reports local `.get()` calls whose key presence is already proven. It is report-only.
 - `redundant-dict-get` recognizes bounded control-flow, aliases, relational containers, and required-`TypedDict` proofs. It keeps literal and variable-key facts distinct, accepts collection membership only from plain loop targets and trusted builtins, and discards facts after rebinding, mutation, unsafe assignments, context-manager exits, `try` `else` transitions, and match fall-through. Its `level` setting defaults to `conservative`; `aggressive` retains direct `dict[...]` annotation heuristics.
 
+### Changed
+
+- `redundant-assignment` now reports an assignment whose only use is `func(name)` — a positional argument echoing the variable's own name — at the default (conservative) level, when `name` binds to a same-named parameter of a `func` defined exactly once, undecorated, in the same file. Ambiguous, decorated, cross-file, or attribute-accessed callees are left alone, since resolving those isn't exact evidence. See [ADR-0060](docs/adr/0060-redundant-assignment-positional-argument-echo.md).
+
 ## [0.2.2] - 2026-08-22
 
 ### Changed

--- a/docs/adr/0060-redundant-assignment-positional-argument-echo.md
+++ b/docs/adr/0060-redundant-assignment-positional-argument-echo.md
@@ -1,0 +1,36 @@
+# TR5 resolves a same-file, unambiguous, undecorated positional-argument echo
+
+## Context
+
+[ADR-0056](0056-redundant-assignment-keyword-argument-echo.md) reports `func(name=name)` at the default level regardless of `name`'s descriptiveness, because the keyword itself states the callee's parameter name at the call site — no signature resolution needed. It explicitly left `func(name)` (positional) alone: "which parameter `name` binds to lives in the callee's signature, possibly in another file, and resolving that is a materially larger feature (defaults, `*args`/`**kwargs`, keyword-only parameters, decorators, overloads) than this decision covers."
+
+Issue [#174](https://github.com/alessio-locatelli/ruff-extra-rules/issues/174) asks for exactly that resolution, scoped to a callee defined in the same file, and lists the same complications ADR-0056 flagged as open questions: positional-only/keyword-only/`*args`/`**kwargs` slot-shifting, decorators/overloads changing the effective signature, and cross-file/aliased/reassigned callees (the last three the issue names as non-goals outright).
+
+## Decision
+
+`redundant-assignment` resolves a positional argument's callee only when doing so is exact, local evidence — never a best-effort guess. A use `func(name)` is treated as an argument echo, exactly like `func(name=name)`, only when **all** of the following hold:
+
+- `func` is a bare `Name` call (not `obj.method(...)` or `mod.func(...)`).
+- `func` names exactly one function, defined directly in the module body — not a method, not nested inside another function, and not redefined or overloaded anywhere else in the file. A method or nested function is only reachable from within its own enclosing scope; resolving those correctly would need real lexical-scope resolution, which this feature deliberately doesn't do, so TR5 doesn't guess and simply leaves the name unresolved.
+- That definition has no decorators, since a decorator can change the effective signature.
+- `func` is not bound to anything else anywhere in the file — not a parameter, local variable, import, `del` target, match-statement capture, generic type parameter, or class name. Any such binding means some scope in the file could make `func` refer to something other than the module-level function, and TR5 can't tell a shadowed call site apart from an unshadowed one without scope resolution, so the name is excluded everywhere, not just at the shadowing scope.
+- The file contains no `from module import *` anywhere, since a wildcard import can bind any name without saying which, making no name in the file trustworthy.
+- The call passes no unpacked (`*iterable`) argument, since that makes the mapping from position to parameter statically unknowable.
+- The variable's positional slot maps to a real, named parameter (not one absorbed by `*args`), and that parameter has the same name as the variable.
+
+A parameter's default value doesn't affect this: a positional argument at a given index always binds to the same parameter regardless of what follows it, so defaults don't disqualify a match.
+
+Once every check above passes, the remaining evidence is exact structural fact — this variable's value is bound to a specific, named parameter, not a heuristic judgment about whether the name looks descriptive. TR5 therefore reports it at the same conservative (default) level as the keyword-echo case, for the same reason ADR-0056 gives: this doesn't belong behind the flag that exists to gate heuristic-but-arguable reports.
+
+No new autofix logic is needed: this reuses [ADR-0032](0032-redundant-assignment-autofix-safety-criteria.md)'s existing pattern-independent autofix gate unchanged.
+
+## Considered Options
+
+- **Full signature resolution — cross-file, through imports/aliases/reassignment, honoring decorators and overloads**: rejected. This is exactly the "materially larger feature" ADR-0056 deferred, and issue #174 names cross-file/aliased/reassigned callees as explicit non-goals. Nothing in this codebase resolves an import graph or evaluates a decorator's effect on a signature, and building that machinery for one check's edge case is a different, much larger project.
+- **Report only at the `permissive` level**: rejected, for the same reason ADR-0056 rejected it for the keyword case — once the bail-outs above are satisfied, the evidence is exact, not an arguable heuristic, so it doesn't belong behind the flag reserved for heuristic-but-arguable reports.
+- **Resolve by nearest-enclosing-scope lookup instead of whole-module uniqueness** (so a nested `helper` shadowing an outer `helper` would still resolve to the correct one): rejected. It would require the same kind of scope-resolution machinery this check's analysis deliberately doesn't build (see [ADR-0002](0002-redundant-assignment-scope-tracker-not-unified.md)), for a case an author is unlikely to write deliberately. Requiring whole-module uniqueness is simpler and conservative: it silently declines to report rather than guessing wrong.
+
+## Consequences
+
+- `func(name)` now reports at the conservative (default) level when `func` is a module-level definition, unique across the whole module (including methods and nested functions), undecorated, unshadowed anywhere in the file, and its parameter at that position is also named `name` — previously silent regardless of level. This is a MINOR change per [docs/releases.md](../releases.md): a run that was previously clean on code matching this pattern can now report it.
+- A positional call to a callee that's ambiguous, decorated, defined elsewhere, a method, a nested function, accessed via attribute, shadowed by any other binding in the file, or reached through unpacking or a wildcard import is unaffected — TR5 does not attempt to resolve those, by design.

--- a/docs/rules/redundant-assignment.md
+++ b/docs/rules/redundant-assignment.md
@@ -19,6 +19,11 @@ Unnecessary intermediate variables add cognitive load without providing value. H
 x = "foo"
 func(x=x)
 
+# Redundant - same idea, positional: only recognized when `func` is defined
+# exactly once, undecorated, in this file, and its parameter at that
+# position is also named `x`:
+func(x)
+
 # Redundant - simple pass-through:
 result = get_value()
 return result

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/__init__.py
@@ -98,7 +98,7 @@ class RedundantAssignmentCheck(BaseCheck):
             comments,
         ) = find_ignored_lines_and_classify_comments_and_pytriage(source, IGNORE_PATTERN)
 
-        tracker = VariableTracker(source, comment_only_lines, trailing_comment_lines)
+        tracker = VariableTracker(source, comment_only_lines, trailing_comment_lines, tree)
         tracker.visit(tree)
         lifecycles = tracker.build_lifecycles()
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -167,24 +167,6 @@ def _call_precedes_target(
 
 
 def is_preceded_by_call(use: UsageInfo) -> bool:
-    """Check if a potentially effectful expression evaluates before `use`.
-
-    Lazily walks `use.enclosing_stmt` looking for `use.node` — deferred to
-    call time (rather than computed eagerly per Name-load during the AST
-    walk) since it's O(statement size); running it for every Name-load
-    would be quadratic for wide expressions (e.g. a large tuple/list/dict
-    literal with many names).
-
-    Used to decide whether inlining a call in place of `use` could reorder
-    side effects relative to a sibling expression — see
-    `redundant_assignment.semantic.should_autofix`'s zero-arg-call carve-out
-    for why this matters (e.g. inlining `value` into
-    `sink(side_effect(), value)` would run the inlined call *after*
-    `side_effect()`, reversed from the original assign-then-use order).
-
-    Returns True conservatively when `use.node`/`use.enclosing_stmt` is
-    unavailable, since safety can't be verified in that case.
-    """
     if use.node is None or use.enclosing_stmt is None:
         return True
     _found, effect_before, _ = _call_precedes_target(use.enclosing_stmt, use.node)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -232,23 +232,12 @@ def _index_unique_undecorated_functions(
 
 
 class VariableTracker(ast.NodeVisitor):
-    """Builds a map of variable lifecycles: where each variable is assigned and where it's used, across scopes."""
-
     def __init__(
         self, source: str, comment_only_lines: set[int], trailing_comment_lines: set[int], tree: ast.Module
     ) -> None:
         self.source = source
         self.source_lines = source.splitlines()
-        # For _get_source_segment only: split on the same line boundaries
-        # ast's own lineno/end_lineno use, unlike self.source_lines above
-        # (see split_lines_like_ast).
         self._ast_lines = split_lines_like_ast(source)
-        # Passed in by the caller rather than computed here — see
-        # AssignmentInfo.has_comment_above/has_inline_comment for why a
-        # tokenize-based classification is needed instead of a naive text
-        # scan, and RedundantAssignmentCheck.check() for why it's tokenized
-        # once there (shared with the ignored-lines lookup) instead of
-        # this constructor tokenizing `source` again on its own.
         self._comment_only_lines = comment_only_lines
         self._trailing_comment_lines = trailing_comment_lines
 
@@ -256,43 +245,30 @@ class VariableTracker(ast.NodeVisitor):
         self._call_positional_info: dict[int, tuple[bool, dict[int, int]]] = {}
 
         self.current_scope_id = 0
-        self.scope_stack: list[int] = [0]  # 0 = module scope
+        self.scope_stack: list[int] = [0]
         self.stmt_index_stack: list[int] = [0]
         self.assignments: dict[tuple[int, str], list[AssignmentInfo]] = {}
         self.uses: dict[tuple[int, str], list[UsageInfo]] = {}
-        # scope_id -> (line, stmt_index, col, enclosing_stmt) of each
-        # yield/yield from/await, in visit order — see
-        # _suspension_point_between.
         self.suspension_points: dict[int, list[tuple[int, int, int, ast.stmt | None]]] = {}
         self.global_vars: set[tuple[int, str]] = set()
         self.nonlocal_vars: set[tuple[int, str]] = set()
 
-        # So the LHS of an assignment is never itself treated as a use.
         self.currently_assigning: set[str] = set()
 
         self.loop_depth = 0
 
-        # if/try/with/match — excludes loops, tracked separately above.
         self.control_flow_depth = 0
 
         self.try_depth = 0
 
         self.comprehension_depth = 0
 
-        # A use inside a lambda body executes later (and possibly
-        # repeatedly, or never) at call time, not once at the point the
-        # lambda is defined.
         self.lambda_depth = 0
 
         self.parent_stack: list[ast.AST] = []
 
-        # Innermost enclosing statement of whatever node is currently being
-        # visited, updated in visit() below. Stored on each UsageInfo (not
-        # searched here) so is_preceded_by_call's evaluation-order walk can
-        # run lazily, later, only for the rare usages that need it.
         self.current_stmt: ast.stmt | None = None
 
-        # child_scope_id -> parent_scope_id, for closure detection.
         self.scope_parents: dict[int, int] = {}
 
     def _enter_scope(self) -> None:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -50,34 +50,12 @@ class UsageInfo:
     scope_id: int
     usage_has_await: bool = False
     in_control_flow: bool = False
-    # Independent of whether the *assignment* is in a loop — used to reject
-    # inlining a call whose single textual use would actually execute
-    # repeatedly.
     in_loop: bool = False
-    # A use inside a lambda body executes later (and possibly repeatedly, or
-    # never) at call time, not once at the point the lambda is defined.
     in_lambda: bool = False
     in_comprehension: bool = False
-    # Identity of the node for this use, not just its position. None for
-    # usage kinds that don't track it.
     node: ast.expr | None = None
-    # The statement containing `node`, for is_preceded_by_call below. Stored
-    # (not eagerly evaluated) so its O(statement size) evaluation-order walk
-    # only runs for the rare usages that actually need it (should_autofix's
-    # zero-arg-call carve-out) instead of every Name-load in the file.
     enclosing_stmt: ast.stmt | None = None
-    # Whether this use sits anywhere inside an f-string replacement field
-    # (`ast.FormattedValue`) — used to gate the naive text-substitution
-    # autofix, which would otherwise re-quote a string literal inside `{}`
-    # (issue #72).
     in_fstring_expression: bool = False
-    # Byte-offset (start, end) span of the *entire* enclosing
-    # `ast.FormattedValue` (braces, any conversion/format spec, all of it)
-    # when this use IS that field's whole expression (no conversion, no
-    # format spec, single line) — the one shape where a string literal can
-    # be safely spliced as raw text in place of the field. None otherwise,
-    # including when in_fstring_expression is True but the use is only
-    # part of a larger field expression (e.g. `{x.attr}`).
     fstring_field_span: tuple[int, int] | None = None
     is_keyword_argument_echo: bool = False
     is_positional_argument_echo: bool = False

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -370,13 +370,6 @@ class VariableTracker(ast.NodeVisitor):
         self.control_flow_depth -= 1
 
     def visit_If(self, node: ast.If) -> None:
-        """`node.test` always evaluates unconditionally when the `If`
-        statement itself is reached — only `body`/`orelse` run
-        conditionally. Visiting it outside the incremented
-        `control_flow_depth` keeps a later use in the condition itself
-        (e.g. a with-block assignment whose only use is `if that_var:`)
-        from being wrongly treated as "inside control flow" (issue #73).
-        """
         self.parent_stack.append(node)
         self.visit(node.test)
         self.control_flow_depth += 1

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -463,10 +463,6 @@ class VariableTracker(ast.NodeVisitor):
         self._visit_comprehension(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        """We skip class-level assignments as they're attributes, not local
-        variables. Decorators are evaluated in the outer scope before the
-        class body.
-        """
         for decorator in node.decorator_list:
             self.visit(decorator)
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -1,5 +1,3 @@
-"""Variable tracking and redundancy pattern detection for TR5."""
-
 from __future__ import annotations
 
 import ast
@@ -17,9 +15,9 @@ type UsageContext = Literal["attribute_or_subscript_assignment", "augmented_assi
 
 
 class PatternType(Enum):
-    IMMEDIATE_SINGLE_USE = auto()  # x = "foo"; func(x=x)
-    SINGLE_USE = auto()  # x = calc(); return x
-    LITERAL_IDENTITY = auto()  # foo = "foo"
+    IMMEDIATE_SINGLE_USE = auto()
+    SINGLE_USE = auto()
+    LITERAL_IDENTITY = auto()
 
 
 @dataclass(slots=True)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -642,14 +642,6 @@ class VariableTracker(ast.NodeVisitor):
         self.visit(node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
-        """`x := value` (walrus) evaluates `value`, then rebinds `x` to it —
-        the same reassignment hazard `visit_AugAssign` guards against for
-        `_rhs_reference_reassigned`'s snapshot-before-reassignment check
-        (issue #74), just spelled as an expression instead of a statement.
-        `old = x; return (x := 2, old)` must not be inlined into `return
-        (x := 2, x)`, which would read the just-rebound value instead of
-        the one captured at assignment time.
-        """
         self.parent_stack.append(node)
         self.visit(node.value)
         self.parent_stack.pop()

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -401,8 +401,6 @@ class VariableTracker(ast.NodeVisitor):
     visit_TryStar = visit_Try  # noqa: N815
 
     def visit_With(self, node: ast.With | ast.AsyncWith) -> None:
-        # Each item's optional_vars (`as target`) rebinds on entry, same
-        # hazard as a for-loop target above.
         self.control_flow_depth += 1
         stmt_index = self._get_current_stmt_index()
         for item in node.items:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -554,7 +554,6 @@ class VariableTracker(ast.NodeVisitor):
             self._track_attribute_or_subscript_base_usage(target, stmt_index)
 
     def _track_attribute_or_subscript_base_usage(self, node: ast.Attribute | ast.Subscript, stmt_index: int) -> None:
-        """In `obj.attr = value` or `obj[key] = value`, `obj` is being read, so it counts as a usage."""
         scope_id = self._get_current_scope_id()
 
         base = _unwind_to_base_name(node)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -37,7 +37,6 @@ class AssignmentInfo:
     has_comment_above: bool = False
     has_inline_comment: bool = False
     rhs_has_await: bool = False
-    # See _record_compound_target_rebindings.
     is_rebinding_marker: bool = False
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -671,15 +671,6 @@ class VariableTracker(ast.NodeVisitor):
         self.uses[key].append(usage)
 
     def visit(self, node: ast.AST) -> None:
-        """Dispatch to the type-specific visit_* method, tracking current_stmt.
-
-        Many statement visitors below (visit_Assign, visit_AnnAssign, ...)
-        don't call self.generic_visit(node) on themselves — they manually
-        visit only the parts they care about — so parent_stack alone can't
-        reconstruct "the enclosing statement" for an arbitrary node. This
-        override catches every ast.stmt as it's dispatched, regardless of
-        which visit_* method (or none) handles it next.
-        """
         if isinstance(node, ast.stmt):
             self.current_stmt = node
         super().visit(node)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -587,7 +587,7 @@ class VariableTracker(ast.NodeVisitor):
         stmt_index = self._get_current_stmt_index()
 
         if self._is_simple_name_target(node.target) and node.value is not None:
-            assert isinstance(node.target, ast.Name)  # Type narrowing
+            assert isinstance(node.target, ast.Name)
             var_name = node.target.id
 
             if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -286,8 +286,6 @@ class VariableTracker(ast.NodeVisitor):
         self.stmt_index_stack.pop()
 
     def _increment_stmt_index(self) -> None:
-        # stmt_index_stack is initialized with [0] and only ever grows/shrinks
-        # in balanced pairs via _enter_scope/_exit_scope, so it's never empty.
         self.stmt_index_stack[-1] += 1
 
     def _get_current_scope_id(self) -> int:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -359,8 +359,6 @@ class VariableTracker(ast.NodeVisitor):
     visit_AsyncFor = visit_For  # noqa: N815
 
     def visit_While(self, node: ast.While) -> None:
-        # node.test repeats every iteration, unlike node.orelse (see
-        # visit_For above for both).
         self.loop_depth += 1
         self.visit(node.test)
         for stmt in node.body:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -681,12 +681,9 @@ class VariableTracker(ast.NodeVisitor):
         self.parent_stack.pop()
 
     def visit_Name(self, node: ast.Name) -> None:
-        # Only track loads (uses), not stores (assignments)
         if not isinstance(node.ctx, ast.Load):
             return
 
-        # Skip if we're currently assigning to this variable
-        # (to avoid treating LHS as a use in `x = x + 1`)
         if node.id in self.currently_assigning:
             return
 
@@ -711,18 +708,12 @@ class VariableTracker(ast.NodeVisitor):
         is_keyword_argument_echo = isinstance(immediate_parent, ast.keyword) and immediate_parent.arg == node.id
         is_positional_argument_echo = self._is_positional_argument_echo(node, immediate_parent)
 
-        # Name-load context isn't resolved to anything more specific than
-        # "unknown" — that would need walking parent nodes with a real
-        # parent-tracking system. Only the other two UsageContext values
-        # (set by the assignment-visiting methods above) are ever compared.
-        context: UsageContext = "unknown"
-
         usage = UsageInfo(
             var_name=node.id,
             line=node.lineno,
             col=node.col_offset,
             stmt_index=stmt_index,
-            context=context,
+            context="unknown",
             scope_id=scope_id,
             usage_has_await=usage_has_await,
             in_control_flow=self.control_flow_depth > 0,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -119,34 +119,6 @@ _POTENTIALLY_EFFECTFUL_NODE_TYPES = (
 
 
 def _evaluation_order_children(node: ast.AST) -> Iterator[tuple[ast.AST, bool]]:
-    """Yield `node`'s children in Python's actual evaluation order.
-
-    Each child is paired with whether it's *conditionally* evaluated —
-    i.e. it might run zero times at runtime, unlike everything else here
-    which always runs exactly once if its parent does. Inlining a call into
-    a conditional position is just as unsafe as inlining it somewhere with
-    a preceding effect: both change whether/when the call actually fires
-    relative to the original, unconditional assignment.
-
-    `ast.iter_child_nodes` matches evaluation order and unconditional-ness
-    for most expression types, since their `_fields` are declared
-    left-to-right in evaluation order (BinOp.left before .right, Call.func
-    before .args before .keywords, etc.) and don't skip children at
-    runtime. The exceptions handled explicitly here:
-    - `ast.Dict`: `_fields` are `('keys', 'values')` — every key, then
-      every value — but Python evaluates each key/value *pair* together,
-      interleaved (e.g. `{"a": f(), x: 1}` evaluates "a", f(), x, 1 — not
-      "a", x, f(), 1). A `None` key marks `**unpacking`, which evaluates
-      only the paired value.
-    - `ast.Assign`: `_fields` are `('targets', 'value', ...)`, but Python
-      evaluates the RHS `value` *before* the target(s) (relevant when a
-      target is `obj.attr` or `obj[key]`, whose base expression `obj` is
-      itself evaluated then, after `value`).
-    - `ast.IfExp` (ternary): `test` always evaluates, but exactly one of
-      `body`/`orelse` does — never both, and never unconditionally.
-    - `ast.BoolOp` (`and`/`or`): short-circuits, so only the first operand
-      is guaranteed to evaluate; the rest are conditional on earlier ones.
-    """
     if isinstance(node, ast.Dict):
         for key, value in zip(node.keys, node.values, strict=True):
             if key is not None:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -623,23 +623,11 @@ class VariableTracker(ast.NodeVisitor):
             self.currently_assigning.clear()
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
-        """`x += 1` reads `x` (to get its current value) and then mutates it in
-        place, so the read is tracked as a usage — this prevents false
-        positives for patterns like:
-            if condition:
-                msg = "foo"
-            else:
-                msg = "bar"
-            msg += " suffix"  # This USES the conditional value
-
-        It's not tracked as a new assignment: it mutates an existing
-        variable rather than producing a fresh one that could be inlined.
-        """
         scope_id = self._get_current_scope_id()
         stmt_index = self._get_current_stmt_index()
 
         if self._is_simple_name_target(node.target):
-            assert isinstance(node.target, ast.Name)  # Type narrowing
+            assert isinstance(node.target, ast.Name)
             var_name = node.target.id
 
             if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
@@ -648,13 +636,7 @@ class VariableTracker(ast.NodeVisitor):
 
             self._track_rebinding_use(var_name, node.lineno, node.col_offset, scope_id, stmt_index)
         else:
-            # AugAssign.target is Name | Attribute | Subscript; the Name
-            # case is handled above.
-            assert isinstance(node.target, ast.Attribute | ast.Subscript)  # Type narrowing
-            # `obj.attr += 1` both reads and reassigns `obj.attr`, same as
-            # `obj.attr = value` — track it the same way so a snapshot
-            # taken via `old = obj.attr` (see _rhs_reference_reassigned)
-            # sees this as a reassignment of the reference it read from.
+            assert isinstance(node.target, ast.Attribute | ast.Subscript)
             self._track_attribute_or_subscript_base_usage(node.target, stmt_index)
 
         self.visit(node.value)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -103,14 +103,6 @@ def _has_await_expression(node: ast.expr) -> bool:
     return detector.has_await
 
 
-# Node types treated as "may run arbitrary user code, or suspend execution"
-# for evaluation-order purposes: an explicit call; attribute/subscript
-# access (`@property` getters and `__getitem__`/descriptors can execute
-# arbitrary code just as a call can); await/yield (suspension points where
-# other code can run and change state before control resumes); operators,
-# which can invoke arbitrary user code via dunder overloads (`__add__`,
-# `__eq__`, `__bool__`, etc.); and IfExp, whose `test` truthiness check
-# invokes `__bool__` the same way BoolOp's short-circuit check does.
 _POTENTIALLY_EFFECTFUL_NODE_TYPES = (
     ast.Call,
     ast.Attribute,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -524,14 +524,6 @@ class VariableTracker(ast.NodeVisitor):
         self.currently_assigning.clear()
 
     def _record_compound_target_rebindings(self, target: ast.expr, stmt_index: int) -> None:
-        """Registers every Name a compound target rebinds — tuple/list
-        unpacking, a chained assignment, a for-loop target, or a with-as
-        target — none of which visit_Assign's simple-name path tracks as a
-        real AssignmentInfo. Each is recorded via a marker
-        (AssignmentInfo.is_rebinding_marker), not a full candidate: its
-        line/col may point at a statement that also binds sibling names,
-        which apply_fixes has no business touching.
-        """
         scope_id = self._get_current_scope_id()
 
         if isinstance(target, ast.Name):

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -148,25 +148,6 @@ def _call_precedes_target(
     target: ast.AST,
     effect_types: tuple[type, ...] = _POTENTIALLY_EFFECTFUL_NODE_TYPES,
 ) -> tuple[bool, bool, bool]:
-    """Walk `node`'s children in evaluation order looking for `target`.
-
-    It's AST-based rather than text/line-based specifically so it stays
-    correct across multi-line statements, where a sibling operand's
-    physical line/column says nothing about evaluation order. `target` is
-    matched by identity, not structural equality.
-
-    Returns a (found, effect_before_target, node_is_or_contains_effect) triple:
-    - found: whether `target` is `node` itself or within its subtree
-    - effect_before_target: whether a node matching `effect_types` (see
-      `_POTENTIALLY_EFFECTFUL_NODE_TYPES`) fully evaluated before reaching
-      `target`, OR `target` is only conditionally reachable (see
-      `_evaluation_order_children`) — only meaningful when `found` is True
-    - node_is_or_contains_effect: whether `node` itself matches (or
-      contains a node matching) `effect_types` that has fully evaluated —
-      only meaningful when `found` is False, since a call containing
-      `target` among its own arguments doesn't fire until after `target`
-      (and everything else in it) is evaluated
-    """
     if node is target:
         return True, False, False
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -478,21 +478,15 @@ class VariableTracker(ast.NodeVisitor):
         scope_id = self._get_current_scope_id()
         stmt_index = self._get_current_stmt_index()
 
-        # Skip multiple assignments on a single line (e.g., a = b = c = value)
-        # as reportable candidates — these patterns often intentionally
-        # assign intermediate variables and avoid re-reading class
-        # attributes — but each target's Name(s) still rebind, so they're
-        # recorded via _record_compound_target_rebindings below.
         if len(node.targets) > 1:
             for target in node.targets:
                 self._record_compound_target_rebindings(target, stmt_index)
             self.visit(node.value)
             return
 
-        # Only track simple name assignments (not tuple unpacking, attributes, etc.)
         for target in node.targets:
             if self._is_simple_name_target(target):
-                assert isinstance(target, ast.Name)  # Type narrowing
+                assert isinstance(target, ast.Name)
                 var_name = target.id
 
                 if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
@@ -524,9 +518,6 @@ class VariableTracker(ast.NodeVisitor):
                     self.assignments[key] = []
                 self.assignments[key].append(assignment)
             else:
-                # Attribute/Subscript, or a compound target (tuple/list
-                # unpacking, possibly with a Starred element) —
-                # _record_compound_target_rebindings dispatches each shape.
                 self._record_compound_target_rebindings(target, stmt_index)
 
         self.visit(node.value)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -65,11 +65,6 @@ class UsageInfo:
 class VariableLifecycle:
     assignment: AssignmentInfo
     uses: list[UsageInfo]
-    # True when the RHS's underlying Name/Attribute reference is itself
-    # reassigned (or mutated via the same exact reference) somewhere
-    # between this assignment and its single use — see detect_redundancy
-    # for why that disqualifies "redundant assignment" entirely, not just
-    # its autofix (issue #74).
     rhs_reference_reassigned_before_use: bool = False
 
     @property
@@ -78,12 +73,6 @@ class VariableLifecycle:
 
     @property
     def is_immediate_use(self) -> bool:
-        """First use is 0-1 statements after the assignment.
-
-        Uses in different scopes (closures) are never considered immediate,
-        even if their statement index appears close, because they're in
-        nested functions and the variable is captured by the closure.
-        """
         if not self.uses:
             return False
         first_use = self.uses[0]

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -177,12 +177,6 @@ _SUSPENSION_NODE_TYPES = (ast.Yield, ast.YieldFrom, ast.Await)
 
 
 def _suspension_precedes_use(use: UsageInfo) -> bool:
-    """Same evaluation-order walk as `is_preceded_by_call`, filtered to
-    suspension points only — for a same-statement case like `return (await
-    refresh(), value)[1]`, `value`'s own stmt_index ties with the await's,
-    so the coarse per-statement check in `_suspension_point_between` can't
-    tell the two apart; this resolves it by real evaluation order instead.
-    """
     if use.node is None or use.enclosing_stmt is None:
         return True
     _found, effect_before, _ = _call_precedes_target(use.enclosing_stmt, use.node, _SUSPENSION_NODE_TYPES)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -944,18 +944,10 @@ def detect_redundancy(lifecycle: VariableLifecycle) -> PatternType | None:
     if not lifecycle.is_single_use:
         return None
 
-    # Variables captured by closures should NEVER be considered redundant.
     for use in lifecycle.uses:
         if use.scope_id != lifecycle.assignment.scope_id or use.in_lambda:
             return None
 
-    # A Call/Attribute RHS with its single textual use inside a loop the
-    # assignment itself isn't part of is reusing a value hoisted out of
-    # the loop, not merely forwarding it once — inlining would turn one
-    # evaluation into N (or zero). A Constant/Name RHS has no such risk
-    # (re-evaluating either gives the identical value every time), so it's
-    # excluded here the same way should_autofix already treats those two
-    # kinds as unconditionally safe to inline everywhere.
     if (
         isinstance(lifecycle.assignment.rhs_node, ast.Attribute | ast.Call)
         and lifecycle.uses[0].in_loop
@@ -963,42 +955,23 @@ def detect_redundancy(lifecycle: VariableLifecycle) -> PatternType | None:
     ):
         return None
 
-    # Augmented-assignment targets (x += 1) can never be inlined: the "use"
-    # IS an assignment target, and replacing it with the RHS expression
-    # produces invalid syntax (`x = 5; x += 1` -> `5 += 1`). This also isn't
-    # the read-then-pass-through pattern TR5 targets — the variable is
-    # being mutated, not merely forwarded.
     for use in lifecycle.uses:
         if use.context == "augmented_assignment":
             return None
 
-    # A "mutation-only" use (`state.attr = ...` or `state[key] = ...`) never
-    # reads the assigned value at all, so it isn't a redundant pass-through
-    # either — unlike the augmented-assignment case above, inlining it would
-    # stay syntactically valid (`me.state(State).attr = ...`), but silently
-    # change behavior whenever the RHS isn't guaranteed to return the same
-    # object on a second evaluation (e.g. a factory/accessor rather than a
-    # cached singleton) — something this tracker has no way to verify.
     for use in lifecycle.uses:
         if use.context == "attribute_or_subscript_assignment":
             return None
 
-    # "Snapshot the old value before reassigning it" (issue #74): the RHS's
-    # reference is itself reassigned/mutated between the assignment and its
-    # use, so the two accesses observe genuinely different states — this
-    # isn't a redundant assignment forwarding the same value at all.
     if lifecycle.rhs_reference_reassigned_before_use:
         return None
 
-    # Pattern 3: Literal identity (e.g., foo = "foo")
     if _is_literal_identity(lifecycle):
         return PatternType.LITERAL_IDENTITY
 
-    # Pattern 1: Immediate single use
     if lifecycle.is_immediate_use:
         return PatternType.IMMEDIATE_SINGLE_USE
 
-    # Pattern 2: Single use anywhere
     return PatternType.SINGLE_USE
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -83,6 +83,7 @@ class UsageInfo:
     # part of a larger field expression (e.g. `{x.attr}`).
     fstring_field_span: tuple[int, int] | None = None
     is_keyword_argument_echo: bool = False
+    is_positional_argument_echo: bool = False
 
 
 @dataclass(slots=True)
@@ -297,10 +298,60 @@ def _suspension_precedes_use(use: UsageInfo) -> bool:
     return effect_before
 
 
+def _collect_module_binding_facts(tree: ast.Module) -> tuple[bool, dict[str, int], set[str]]:
+    has_wildcard_import = False
+    function_name_counts: dict[str, int] = {}
+    shadowing: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            function_name_counts[node.name] = function_name_counts.get(node.name, 0) + 1
+        elif isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names):
+            has_wildcard_import = True
+        elif isinstance(node, ast.arg):
+            shadowing.add(node.arg)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
+            shadowing.add(node.id)
+        elif isinstance(node, ast.alias):
+            shadowing.add((node.asname or node.name).split(".")[0])
+        elif isinstance(node, ast.MatchAs | ast.MatchStar) and node.name is not None:
+            shadowing.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest is not None:
+            shadowing.add(node.rest)
+        elif isinstance(node, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple | ast.ClassDef):  # noqa: SIM114
+            shadowing.add(node.name)
+        elif isinstance(node, ast.ExceptHandler) and node.name is not None:
+            shadowing.add(node.name)
+    return has_wildcard_import, function_name_counts, shadowing
+
+
+def _index_unique_undecorated_functions(
+    tree: ast.Module,
+) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    has_wildcard_import, all_function_name_counts, shadowed = _collect_module_binding_facts(tree)
+    if has_wildcard_import:
+        return {}
+
+    top_level_by_name: dict[str, list[ast.FunctionDef | ast.AsyncFunctionDef]] = {}
+    for stmt in tree.body:
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef):
+            top_level_by_name.setdefault(stmt.name, []).append(stmt)
+
+    return {
+        name: nodes[0]
+        for name, nodes in top_level_by_name.items()
+        if len(nodes) == 1
+        and not nodes[0].decorator_list
+        and all_function_name_counts[name] == 1
+        and name not in shadowed
+    }
+
+
 class VariableTracker(ast.NodeVisitor):
     """Builds a map of variable lifecycles: where each variable is assigned and where it's used, across scopes."""
 
-    def __init__(self, source: str, comment_only_lines: set[int], trailing_comment_lines: set[int]) -> None:
+    def __init__(
+        self, source: str, comment_only_lines: set[int], trailing_comment_lines: set[int], tree: ast.Module
+    ) -> None:
         self.source = source
         self.source_lines = source.splitlines()
         # For _get_source_segment only: split on the same line boundaries
@@ -315,6 +366,9 @@ class VariableTracker(ast.NodeVisitor):
         # this constructor tokenizing `source` again on its own.
         self._comment_only_lines = comment_only_lines
         self._trailing_comment_lines = trailing_comment_lines
+
+        self.functions = _index_unique_undecorated_functions(tree)
+        self._call_positional_info: dict[int, tuple[bool, dict[int, int]]] = {}
 
         self.current_scope_id = 0
         self.scope_stack: list[int] = [0]  # 0 = module scope
@@ -897,6 +951,7 @@ class VariableTracker(ast.NodeVisitor):
             fstring_field_span = (immediate_parent.col_offset, immediate_parent.end_col_offset)
 
         is_keyword_argument_echo = isinstance(immediate_parent, ast.keyword) and immediate_parent.arg == node.id
+        is_positional_argument_echo = self._is_positional_argument_echo(node, immediate_parent)
 
         # Name-load context isn't resolved to anything more specific than
         # "unknown" — that would need walking parent nodes with a real
@@ -921,12 +976,48 @@ class VariableTracker(ast.NodeVisitor):
             in_fstring_expression=in_fstring_expression,
             fstring_field_span=fstring_field_span,
             is_keyword_argument_echo=is_keyword_argument_echo,
+            is_positional_argument_echo=is_positional_argument_echo,
         )
 
         key = (scope_id, node.id)
         if key not in self.uses:
             self.uses[key] = []
         self.uses[key].append(usage)
+
+    def _positional_info_for(self, call: ast.Call) -> tuple[bool, dict[int, int]]:
+        cached = self._call_positional_info.get(id(call))
+        if cached is None:
+            has_starred = any(isinstance(arg, ast.Starred) for arg in call.args)
+            index_by_id = {id(arg): index for index, arg in enumerate(call.args)}
+            cached = (has_starred, index_by_id)
+            self._call_positional_info[id(call)] = cached
+        return cached
+
+    def _is_positional_argument_echo(self, node: ast.Name, immediate_parent: ast.AST | None) -> bool:
+        if not isinstance(immediate_parent, ast.Call):
+            return False
+
+        call = immediate_parent
+        has_starred, index_by_id = self._positional_info_for(call)
+        if has_starred:
+            return False
+
+        if not isinstance(call.func, ast.Name):
+            return False
+
+        definition = self.functions.get(call.func.id)
+        if definition is None:
+            return False
+
+        index = index_by_id.get(id(node))
+        if index is None:
+            return False
+
+        positional_params = definition.args.posonlyargs + definition.args.args
+        if index >= len(positional_params):
+            return False
+
+        return positional_params[index].arg == node.id
 
     def build_lifecycles(self) -> list[VariableLifecycle]:
         lifecycles: list[VariableLifecycle] = []

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -656,12 +656,6 @@ class VariableTracker(ast.NodeVisitor):
         self._track_rebinding_use(var_name, node.target.lineno, node.target.col_offset, scope_id, stmt_index)
 
     def _track_rebinding_use(self, var_name: str, line: int, col: int, scope_id: int, stmt_index: int) -> None:
-        """Records that `var_name` was rebound (augmented-assignment or
-        walrus) at this point — not a fresh `AssignmentInfo` (neither is a
-        standalone statement TR5 could itself flag as redundant), but a
-        "use" `_rhs_reference_reassigned` recognizes as disqualifying a
-        snapshot taken from `var_name` earlier in the same scope.
-        """
         usage = UsageInfo(
             var_name=var_name,
             line=line,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -823,24 +823,6 @@ class VariableTracker(ast.NodeVisitor):
         use: UsageInfo,
         scope_id: int,
     ) -> bool:
-        """True when `assignment`'s RHS reads a Name/Attribute reference
-        that is itself reassigned (or augmented-assigned) between
-        `assignment` and `use` — the "snapshot the old value before
-        reassigning it" hazard from issue #74. Inlining the RHS text at
-        `use` in that case would read the reference's new state instead of
-        the one captured at assignment time, silently changing behavior.
-
-        For a Name RHS (`old = x`), only rebinding `x` itself is unsafe —
-        mutating the object `x` refers to (e.g. `x.attr = ...`) doesn't
-        create this hazard, since `old` and `x` still alias the same
-        object either way. For an Attribute RHS (`old = obj.attr`), both
-        rebinding `obj` itself and reassigning any attribute/subscript of
-        `obj` are treated as unsafe — the latter conservatively, since this
-        tracker doesn't record *which* attribute was reassigned.
-
-        See `_suspension_point_between` for the Call/Attribute suspension
-        hazard and the method-call branch below for the receiver hazard.
-        """
         rhs_node = assignment.rhs_node
 
         if isinstance(rhs_node, ast.Name):
@@ -875,10 +857,6 @@ class VariableTracker(ast.NodeVisitor):
         if isinstance(rhs_node, ast.Call) and isinstance(rhs_node.func, ast.Attribute):
             base = _unwind_to_base_name(rhs_node.func)
             if base is not None:
-                # Bisect from the RHS's own end line, not the assignment's
-                # start line, and exclude the use's own statement (see
-                # exclude_enclosing_stmt below) — both can reference `base`
-                # again without that being a mutation.
                 rhs_end_line = rhs_node.end_lineno if rhs_node.end_lineno is not None else assignment.line
                 return self._reference_reassigned_in_range(
                     base.id,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -880,49 +880,6 @@ class VariableTracker(ast.NodeVisitor):
         assign_col: int,
         use: UsageInfo,
     ) -> bool:
-        """True if a yield/yield from/await occurs strictly after the
-        assignment and before the use.
-
-        `stmt_index` alone can't order two entries that tie on it, and a tie
-        arises two different ways:
-
-        - The suspension point sits in the use's own statement (e.g.
-          `return (await refresh(), value)[1]`), where it could still
-          evaluate before or after the use within that one statement — that
-          case is resolved by `_suspension_precedes_use`'s real
-          evaluation-order walk instead of assumed safe.
-        - The suspension point sits in a *different*, known statement that's
-          merely nested in the same coarse block as the use (an if/with/try
-          body doesn't get its own stmt_index — see
-          VariableTracker.suspension_points), so `_suspension_precedes_use`
-          can't see it at all: that walk only looks inside the use's own
-          statement. Ordinary top-to-bottom source position (line, then
-          column) settles this instead — the point and the use are two
-          distinct, unconditionally-sequenced statements within the same
-          straight-line block, so whichever comes first textually also runs
-          first (loop bodies that could revisit this point on a later
-          iteration are excluded earlier, via `assignment.in_loop` in
-          `should_report_violation`).
-
-        A suspension point in a genuinely earlier statement (`stmt_index`
-        strictly less) needs neither check: unlike a tie, nothing about
-        *that* statement's evaluation order relative to the use is in
-        question. And when `use.enclosing_stmt` itself is unknown (some
-        UsageInfo variants, e.g. an augmented-assignment rebinding marker,
-        never record it), same-vs-different can't be told apart, nor can
-        source position stand in for it (the marker's own position is the
-        rebound name, not necessarily where the hazard actually occurs), so
-        this defers to `_suspension_precedes_use`'s own conservative
-        fallback rather than guessing.
-
-        The bisect boundary itself includes `assign_col`, not just
-        `(assign_line, assign_stmt_index)` — semicolon-separated statements
-        nested in the same coarse block (e.g. `cached = obj.attr; await
-        other(); return cached`) can share both line and stmt_index with
-        the assignment, and `bisect_right` would otherwise skip straight
-        past a point that ties on both, the same way `line` alone once hid
-        a same-line reassignment (see `_reference_reassigned_in_range`).
-        """
         points = self.suspension_points.get(scope_id)
         if not points:
             return False

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -777,12 +777,8 @@ class VariableTracker(ast.NodeVisitor):
                 all_uses = self.uses.get(key, [])
                 relevant_uses = [use for use in all_uses if use.stmt_index >= assignment.stmt_index]
 
-                # Variables captured by closures should not be marked as redundant.
                 child_scopes = self._get_child_scopes(scope_id)
 
-                # A child scope's `nonlocal` declaration means the closure
-                # captures and potentially modifies this variable, so the
-                # outer assignment must not be flagged as redundant.
                 is_captured_by_nonlocal = any(
                     (child_scope_id, var_name) in self.nonlocal_vars for child_scope_id in child_scopes
                 )
@@ -794,8 +790,6 @@ class VariableTracker(ast.NodeVisitor):
                     child_uses = self.uses.get(child_key, [])
                     relevant_uses.extend(child_uses)
 
-                # If there's a subsequent assignment to the same variable,
-                # only include uses up to that assignment
                 next_assignment = None
                 for other_assignment in assignment_list:
                     if other_assignment.stmt_index > assignment.stmt_index and (
@@ -804,8 +798,6 @@ class VariableTracker(ast.NodeVisitor):
                         next_assignment = other_assignment
 
                 if next_assignment:
-                    # Keep ALL child scope uses since they're closures, even
-                    # past the next assignment.
                     relevant_uses = [
                         use
                         for use in relevant_uses

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -910,49 +910,9 @@ class VariableTracker(ast.NodeVisitor):
         include_any_usage: bool = False,
         exclude_enclosing_stmt: ast.stmt | None = None,
     ) -> bool:
-        """`self.assignments[key]`/`self.uses[key]` are each built by a
-        single top-to-bottom AST walk within one scope, so entries for a
-        fixed `key` already arrive in non-decreasing `stmt_index` *and*
-        `line` order — bisecting to the range start avoids rescanning
-        every earlier assignment/use of `name`, which would otherwise make
-        a long chain of single-use aliases to the same shared name (e.g.
-        `v0 = shared` through `vN = shared`) quadratic in the number of
-        aliases.
-
-        The bisect start boundary is `(assign_line, assign_stmt_index)`,
-        not either alone — `line` and `stmt_index` can each tie while the
-        other still orders two entries correctly (see test_detect_redundancy's
-        "sharing-coarse-stmt-index" and "sharing-a-physical-line" cases), so
-        only the composite excludes exactly the assignment's own position
-        (and nothing genuinely later) regardless of which one ties.
-
-        `end_stmt_index` is still checked alongside `line` at the end of
-        the range, as before: it excludes a candidate in a later, unrelated
-        top-level statement even in the rare case `line` alone wouldn't.
-        This stays a heuristic (may under-report/under-fix, never
-        mis-fixes), not full control-flow analysis.
-
-        `include_any_usage` treats *any* in-range use of `name` — not just
-        an augmented-assignment or attribute/subscript-assignment context —
-        as disqualifying. Used for a method-call RHS (`buf.tell()`), where
-        the receiver can be mutated by another method call with no
-        assignment syntax at all.
-
-        `exclude_enclosing_stmt` skips a use belonging to that exact
-        statement — the use's own statement reads `name` again just to
-        reach the use (e.g. `obj` in `obj.consume(value)`, read to look up
-        `.consume`), the same way the assignment's own statement reads it
-        to reach the RHS. Neither is an intervening mutation.
-        """
         key = (scope_id, name)
         start_key = (assign_line, assign_stmt_index)
 
-        # Indexed iteration, not `some_list[start:]` — a slice eagerly
-        # copies the entire remaining tail before the loop even starts,
-        # which would silently reintroduce the O(N) cost per lookup (and
-        # O(N^2) overall across N aliases) that bisecting to `start` was
-        # meant to avoid, even though the loop itself `break`s almost
-        # immediately in the common case.
         assignments = self.assignments.get(key)
         if assignments:
             start = bisect.bisect_right(assignments, start_key, key=lambda a: (a.line, a.stmt_index))
@@ -962,12 +922,6 @@ class VariableTracker(ast.NodeVisitor):
                     break
                 return True
 
-        # Unlike `assignments` above, `uses` is never actually empty here:
-        # visiting the RHS expression that got us into this method always
-        # records at least a self-referential use of `name` (e.g. `value`
-        # in `old = value`, or `obj` in `old = obj.attr`) at the
-        # assignment's own line/stmt_index — bisected past below, but
-        # enough to guarantee the list itself is non-empty.
         uses = self.uses.get(key, [])
         start = bisect.bisect_right(uses, start_key, key=lambda u: (u.line, u.stmt_index))
         for i in range(start, len(uses)):

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -344,9 +344,6 @@ class VariableTracker(ast.NodeVisitor):
     visit_AsyncFunctionDef = visit_FunctionDef  # noqa: N815
 
     def visit_For(self, node: ast.For | ast.AsyncFor) -> None:
-        # node.iter runs once, not per-iteration; node.orelse runs only if
-        # the loop completes without `break` — conditional like an if/try
-        # branch, not unconditional like ordinary code after the loop.
         self._record_compound_target_rebindings(node.target, self._get_current_stmt_index())
         self.visit(node.iter)
         self.loop_depth += 1

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -295,9 +295,6 @@ class VariableTracker(ast.NodeVisitor):
         return self.stmt_index_stack[-1] if self.stmt_index_stack else 0
 
     def _get_child_scopes(self, scope_id: int) -> list[int]:
-        """All direct and indirect child scopes of `scope_id`, to detect closures —
-        variables assigned in an outer scope but used in nested function scopes.
-        """
         children = []
         for child_id, parent_id in self.scope_parents.items():
             if parent_id == scope_id:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -421,11 +421,6 @@ class VariableTracker(ast.NodeVisitor):
         self.parent_stack.pop()
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
-        """A lambda's body doesn't execute where it's defined — it executes
-        later, whenever (and however many times, including zero) the
-        lambda is called. Uses inside it must never be treated as
-        "the same execution point" as the surrounding statement.
-        """
         self.lambda_depth += 1
         self.generic_visit(node)
         self.lambda_depth -= 1

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -976,7 +976,6 @@ def detect_redundancy(lifecycle: VariableLifecycle) -> PatternType | None:
 
 
 def _is_literal_identity(lifecycle: VariableLifecycle) -> bool:
-    """True for a literal identity assignment, e.g. `foo = "foo"` (case- and underscore-insensitive)."""
     assignment = lifecycle.assignment
     rhs_node = assignment.rhs_node
 
@@ -987,7 +986,6 @@ def _is_literal_identity(lifecycle: VariableLifecycle) -> bool:
         if var_name == literal_value:
             return True
 
-        # Allow underscore differences too, e.g. variable FOO vs literal "foo"
         if var_name.replace("_", "") == literal_value.replace("_", ""):
             return True
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -412,13 +412,6 @@ class VariableTracker(ast.NodeVisitor):
     visit_AsyncWith = visit_With  # noqa: N815
 
     def visit_Match(self, node: ast.Match) -> None:
-        """`node.subject` always evaluates unconditionally when the `Match`
-        statement itself is reached — only each case's pattern/guard/body
-        runs conditionally (if its pattern/guard matches), same as an
-        if/elif branch. See visit_If's docstring (issue #73) for why the
-        subject must be visited outside the incremented
-        `control_flow_depth`.
-        """
         self.parent_stack.append(node)
         self.visit(node.subject)
         self.control_flow_depth += 1

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -326,9 +326,6 @@ class VariableTracker(ast.NodeVisitor):
                 self.visit(default)
 
     def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
-        """Decorators are evaluated in the outer (enclosing) scope before the
-        function body, so they must be visited before entering the new scope.
-        """
         for decorator in node.decorator_list:
             self.visit(decorator)
         self._visit_defaults(node.args)

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -303,12 +303,6 @@ class VariableTracker(ast.NodeVisitor):
         return children
 
     def _get_source_segment(self, node: ast.expr) -> str:
-        """Reuses self._ast_lines (computed once in __init__) via
-        fast_get_source_segment instead of ast.get_source_segment's own
-        per-call re-split of the whole file — called once per assignment
-        across the whole file, so the difference is O(source size) total
-        instead of O(assignments x source size).
-        """
         return fast_get_source_segment(self.source, self._ast_lines, node) or ""
 
     def _is_simple_name_target(self, target: ast.expr) -> bool:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -505,28 +505,6 @@ def _report_score_ceiling(level: AggressivenessLevel, pattern: PatternType) -> i
 
 
 def _effectful_rhs_use_is_safe_to_inline(use: UsageInfo) -> bool:
-    """True if inlining a Call or Attribute RHS at `use` won't change how
-    often, when, or relative to what else it executes.
-
-    Applies to both — not just Call — because attribute access can run
-    arbitrary code too (a `@property` getter or `__getattr__`/descriptor),
-    exactly like `_POTENTIALLY_EFFECTFUL_NODE_TYPES` already treats it for
-    evaluation-order purposes elsewhere in this package. A Name/Constant
-    RHS needs none of this: it gives the same value no matter when or how
-    many times it's evaluated, given the single-assignment invariant (and,
-    for Name, the "reference reassigned before use" exclusion) already
-    enforced elsewhere in this module.
-
-    Two independent risks:
-    - Repeated/deferred execution: a use inside a loop or lambda body runs
-      0, 1, or many times, at a different point than the original
-      assignment (once, immediately) — e.g. `x = make(); for _ in r: f(x)`
-      would turn one call into N, and `x = make(); return lambda: x` would
-      defer the call to whenever (if ever) the lambda is later invoked.
-    - Reordering: a sibling expression evaluated before `use` within its
-      statement (see `is_preceded_by_call`) could run before the inlined
-      expression, when it used to run after.
-    """
     return not use.in_loop and not use.in_lambda and not is_preceded_by_call(use)
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -512,37 +512,12 @@ _FSTRING_SPLICE_UNSAFE_CHARS = frozenset({"'", '"', "\\", "{", "}", "\n", "\r", 
 
 
 def is_safe_to_splice_into_fstring(value: str, encoding: str = "utf-8") -> bool:
-    """`encoding` defaults to "utf-8" — this codebase's overwhelmingly
-    common case, and the only option available at check() time, which
-    (unlike fix()) never learns a file's real PEP 263 declared encoding.
-    `autofix.apply_fixes` calls this again at fix time with the real
-    encoding, so a file declaring something narrower (e.g. `# -*- coding:
-    ascii -*-`) still gets this validated correctly before anything is
-    written — see exceeds_line_length_when_inlined's docstring for why
-    this module's checks are routinely re-validated a second time, against
-    real values, right before a fix is actually applied.
-    """
     if any(char in _FSTRING_SPLICE_UNSAFE_CHARS for char in value):
         return False
 
-    # A control character (e.g. "\x1b", the ANSI escape used in terminal
-    # color codes) is syntactically fine to splice as raw text — none of
-    # them are in the unsafe set above — but writing it as a literal,
-    # unescaped byte turns a readable `\x1b` into an invisible one: the
-    # resulting source line looks like the value vanished (a diff shows
-    # nothing where the field used to be) even though the byte is really
-    # there. str.isprintable() rejects every control character (plus
-    # unassigned/surrogate/other non-printable categories), matching the
-    # newline/NUL exclusions above but generalized instead of enumerated.
     if not value.isprintable():
         return False
 
-    # A str object can legally hold an unpaired surrogate (e.g. from a
-    # "\ud800" escape) even though no real text encoding can represent one
-    # — splicing it as raw source text would make atomic_write_text's
-    # compile()/write() crash with an uncaught UnicodeEncodeError instead
-    # of writing a fixed file, exactly like a NUL byte above but for a
-    # different underlying reason (unencodable rather than unparsable).
     try:
         value.encode(encoding)
     except UnicodeEncodeError:

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -381,106 +381,54 @@ def should_report_violation(
     assignment = lifecycle.assignment
     is_argument_echo = _is_argument_echo(lifecycle)
 
-    # Don't report assignments inside loops - they often accumulate/track state
-    # across iterations even if they appear to have single use per iteration
     if assignment.in_loop:
         return False
 
     if assignment.in_try:
         return False
 
-    # Skip if there's a comment right above the assignment (any scope)
-    # Comments above variables indicate documentation/explanation intent
     if assignment.has_comment_above:
         return False
 
-    # Skip if there's an inline comment on the assignment line
-    # Inline comments (e.g., type: ignore) indicate intentional code
     if assignment.has_inline_comment and not allow_inline_suppression:
         return False
 
-    # Rule 1: Don't report global scope variables unless prefixed with `_`
     if assignment.in_global_scope and not assignment.var_name.startswith("_"):
         return False
 
-    # Rule 1b: Never report dunder names (`__author__`, `__version__`, ...).
-    # Unlike an ordinary `_private` name, a dunder assignment's target is
-    # conventionally read via attribute access from outside the file
-    # (packaging metadata, doc generators, `importlib.metadata` fallbacks),
-    # so the assignment itself is the API surface even when this file only
-    # references the name once — inlining it would delete that surface.
     if assignment.var_name.startswith("__") and assignment.var_name.endswith("__"):
         return False
 
-    # Rule 2: Don't report if RHS has await expression
-    # Inlining await expressions requires parentheses which is bulky:
-    #   json_resp = await resp.json(); return json_resp['key']  # noqa: ERA001
-    # Would become: return (await resp.json())['key']  # ugly
     if assignment.rhs_has_await:
         return False
 
-    # Rule 3: Don't report if inlining would likely exceed the line length
     if _would_exceed_line_length(lifecycle):
         return False
 
-    # Rule 4: Don't report if-else ternary operators
     if isinstance(assignment.rhs_node, ast.IfExp):
         return False
 
-    # Rule 5: Don't report if inlining would require parentheses
-    # Example: len_prefix = len(x) + 1; arr[len_prefix:] would need arr[(len(x) + 1):]
     if _would_require_parentheses(assignment.rhs_node):
         return False
 
-    # Rule 6: Don't report if RHS contains non-deterministic function calls
-    # Functions like time.time(), random.random(), etc. return different values
-    # on each call, so inlining them can change program semantics
     if _contains_nondeterministic_call(assignment.rhs_node):
         return False
 
-    # Rule 7: Don't report "magic number" patterns - numeric/simple literals
-    # where the variable name provides semantic meaning
-    # Examples: max_search_depth = 10, line_spacing = 1.2, user_id = 101749141
     if not is_argument_echo and _is_named_constant_pattern(assignment.var_name, assignment.rhs_node):
         return False
 
-    # Rule 8: Don't report when assignment is outside control flow but usage is inside
-    # This handles pytest.raises pattern where setup is intentionally separated:
-    #   sample_class = SampleClass()  # setup outside  # noqa: ERA001
-    #   with pytest.raises(Error):     # usage inside
-    #       sample_class.method()  # noqa: ERA001
     if not assignment.in_control_flow and lifecycle.uses and all(use.in_control_flow for use in lifecycle.uses):
         return False
 
-    # Rule 9: Don't report when assignment is inside control flow but usage is outside
-    # This handles context manager pattern to reduce nesting:
-    #   with file.open() as f:
-    #       config = load(f)  # assignment inside  # noqa: ERA001
-    #   # Use config outside to avoid deep nesting
-    #   data = config.get(...)  # noqa: ERA001
     if assignment.in_control_flow and lifecycle.uses and all(not use.in_control_flow for use in lifecycle.uses):
         return False
 
-    # Rule 10: Don't report when all usages are inside a comprehension
-    # Inlining would re-evaluate the RHS expression on every iteration,
-    # causing a performance regression. For example:
-    #   iso_country = obj.iso_country          # cached once  # noqa: ERA001
-    #   result = [x for x in items if x.country == iso_country]  # O(1) lookup  # noqa: ERA001
-    # Inlining would become O(n) attribute lookups inside the comprehension.
     if lifecycle.uses and all(use.in_comprehension for use in lifecycle.uses):
         return False
 
     if is_argument_echo:
         return True
 
-    # Rule 11 (conservative level only): a Call RHS returns some domain
-    # object the tracker can't inspect, so a name that isn't a generic
-    # placeholder (`result`, `value`, ...) or a restatement of the callee
-    # itself (`check = MeaninglessVarsCheck()`) is presumed to be the author
-    # deliberately documenting what that call returns — e.g. `warning =
-    # conn.recv()` or `ci_headers = CIMultiDict(headers)` — rather than a
-    # redundant restatement of it. Doesn't apply to the permissive level,
-    # which instead falls through to the semantic-value ceiling below.
     if (
         level is AggressivenessLevel.CONSERVATIVE
         and isinstance(assignment.rhs_node, ast.Call)
@@ -488,14 +436,6 @@ def should_report_violation(
     ):
         return False
 
-    # Rule 12 (conservative level only): a module-level string constant
-    # named with the same convention Rule 7 already exempts for numeric
-    # values (`_GREY = "rgb(201, 203, 207)"`) reads as a deliberate,
-    # reusable declaration even when this file happens to use it only
-    # once — unlike a local `x = "foo"` used once, which is exactly the
-    # redundant pattern this check targets regardless of name shape.
-    # Doesn't apply to the permissive level, which still flags these like
-    # any other single-use string assignment.
     if (
         level is AggressivenessLevel.CONSERVATIVE
         and assignment.in_global_scope

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -538,37 +538,10 @@ def fstring_splice_is_safe(rhs_node: ast.expr, use: UsageInfo) -> bool | None:
 
 def should_autofix(
     lifecycle: VariableLifecycle,
-    # Source lines of the file being analyzed (no line endings), used to
-    # check the *actual* usage line's length so the `[FIXABLE]` label
-    # matches what `apply_fixes` will really do. When omitted (e.g. direct
-    # unit tests), falls back to the conservative RHS-length estimate.
     source_lines: list[str] | None = None,
 ) -> bool:
-    """Whether a *reported* violation (see `should_report_violation`) is
-    also mechanically safe to inline. This is the only gate on autofix
-    eligibility (issue #76) — pattern-independent, and with no separate,
-    softer semantic-score ceiling narrowing it further below whatever was
-    already reported. "Mechanically safe" means:
-    - NOT inside a loop or other control flow
-    - RHS is a single line, and inlining it doesn't exceed the line length
-      on the actual usage line
-    - RHS is a constant or name (always safe — see
-      `_effectful_rhs_use_is_safe_to_inline`), or an attribute (any chain
-      depth) or call whose use is the very next statement after the
-      assignment, runs exactly once at the point the assignment already
-      runs — never inside a loop/lambda, and with nothing effectful
-      evaluating before it within its statement (see
-      `_effectful_rhs_use_is_safe_to_inline`) — with a call additionally
-      capped at 2 positional args and no keywords, or vice versa, so
-      inlining doesn't turn the use site into a visually complex expression
-    - No f-string-splice hazard (issue #72); the RHS-aliasing hazard (issue
-      #74) is already ruled out upstream by `detect_redundancy` refusing to
-      report that pattern at all, so it never reaches this function
-    """
     assignment = lifecycle.assignment
 
-    # A loop body can accumulate/track state across iterations even with a
-    # single textual use; control flow means it's unclear which branch runs.
     if assignment.in_loop:
         return False
     if assignment.in_control_flow:
@@ -581,10 +554,6 @@ def should_autofix(
     if fstring_splice_is_safe(assignment.rhs_node, lifecycle.uses[0]) is False:
         return False
 
-    # Prefer the exact check against the real usage line; fall back to the
-    # conservative RHS-length estimate (stricter threshold than reporting,
-    # since a wrong autofix is more costly than a missed report) when the
-    # usage line isn't available.
     use_line_idx = lifecycle.uses[0].line - 1
     if source_lines is not None and 0 <= use_line_idx < len(source_lines):
         if exceeds_line_length_when_inlined(assignment.var_name, rhs_source, source_lines[use_line_idx]):
@@ -597,26 +566,12 @@ def should_autofix(
     if isinstance(rhs_node, ast.Constant | ast.Name):
         return True
 
-    # Attribute and Call RHS can both run arbitrary code when evaluated
-    # (see _effectful_rhs_use_is_safe_to_inline), so inlining either one is
-    # only safe when the use is the very next statement after the
-    # assignment (lifecycle.is_immediate_use) — otherwise an intervening
-    # statement's own effects could end up running before or after the
-    # inlined expression's, when they didn't originally. Example:
-    # `result_data = pop(queue); queue.clear(); return result_data` must
-    # not become `queue.clear(); return pop(queue)`, which pops after
-    # clearing instead of before.
     if not lifecycle.is_immediate_use:
         return False
 
     if isinstance(rhs_node, ast.Attribute):
         return _effectful_rhs_use_is_safe_to_inline(lifecycle.uses[0])
 
-    # Only when the use runs exactly once at the same point the call
-    # already runs (see _effectful_rhs_use_is_safe_to_inline) — otherwise
-    # inlining can change how often the call executes, e.g. moving it from
-    # once (at the assignment) into a loop body that runs N times.
-    # Example: datetime.now(UTC), str(value), len(items)
     if isinstance(rhs_node, ast.Call) and _effectful_rhs_use_is_safe_to_inline(lifecycle.uses[0]):
         if len(rhs_node.args) <= 2 and not rhs_node.keywords:
             return True

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -69,11 +69,6 @@ DESCRIPTIVE_SUFFIXES = {
 
 
 def _count_chained_operations(node: ast.expr) -> int:
-    """Examples:
-    foo.bar.baz -> 2 (two attribute accesses)
-    obj[x][y][z] -> 3 (three subscripts)
-    func()[key].attr -> 2 (subscript + attribute)
-    """
     count = 0
     current = node
 
@@ -82,12 +77,10 @@ def _count_chained_operations(node: ast.expr) -> int:
             count += 1
             current = current.value
         elif isinstance(current, ast.Call):
-            # Only count the call if it's chained with something else.
             if count > 0:
                 count += 1
             current = current.func
         else:
-            # Reached the base of the chain.
             break
 
     return count

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -508,17 +508,6 @@ def _effectful_rhs_use_is_safe_to_inline(use: UsageInfo) -> bool:
     return not use.in_loop and not use.in_lambda and not is_preceded_by_call(use)
 
 
-# Characters that make it unsafe to splice a string literal's raw value
-# directly into an f-string's surrounding text: the two quote characters
-# (would prematurely terminate — or ambiguously extend — the string,
-# without knowing the specific quote style the target f-string uses), a
-# backslash (would be reinterpreted as the start of an escape sequence
-# instead of a literal backslash), brace characters (would open/close a new
-# replacement field instead of appearing as literal text), newlines (would
-# break a single-line f-string), and a NUL byte (CPython's tokenizer
-# rejects any source file containing one, even though it's a perfectly
-# valid character *inside* a string literal like `"\x00"` — splicing it as
-# raw text would turn a fixable file into an unparsable one).
 _FSTRING_SPLICE_UNSAFE_CHARS = frozenset({"'", '"', "\\", "{", "}", "\n", "\r", "\x00"})
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -490,11 +490,6 @@ def _is_generic_call_result_name(var_name: str, rhs_node: ast.Call) -> bool:
     return callee_name is not None and var_lower in callee_name.lower()
 
 
-# Score ceiling a violation's `calculate_semantic_value` must be at or under
-# to be reported. At the conservative level, `should_autofix()` doesn't
-# narrow these further with a separate, stricter semantic-value ceiling of
-# its own — see ADR-0032. The permissive ceiling (49, i.e. score < 50)
-# reports every case up to that bar.
 _CONSERVATIVE_REPORT_CEILING = {
     PatternType.IMMEDIATE_SINGLE_USE: 10,
     PatternType.LITERAL_IDENTITY: 10,

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -474,8 +474,10 @@ def _is_named_string_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool
     return var_name.lstrip("_").isupper()
 
 
-def _is_keyword_argument_echo(lifecycle: VariableLifecycle) -> bool:
-    return lifecycle.is_single_use and lifecycle.uses[0].is_keyword_argument_echo
+def _is_argument_echo(lifecycle: VariableLifecycle) -> bool:
+    return lifecycle.is_single_use and (
+        lifecycle.uses[0].is_keyword_argument_echo or lifecycle.uses[0].is_positional_argument_echo
+    )
 
 
 def should_report_violation(
@@ -486,7 +488,7 @@ def should_report_violation(
     allow_inline_suppression: bool = False,
 ) -> bool:
     assignment = lifecycle.assignment
-    is_keyword_argument_echo = _is_keyword_argument_echo(lifecycle)
+    is_argument_echo = _is_argument_echo(lifecycle)
 
     # Don't report assignments inside loops - they often accumulate/track state
     # across iterations even if they appear to have single use per iteration
@@ -548,7 +550,7 @@ def should_report_violation(
     # Rule 7: Don't report "magic number" patterns - numeric/simple literals
     # where the variable name provides semantic meaning
     # Examples: max_search_depth = 10, line_spacing = 1.2, user_id = 101749141
-    if not is_keyword_argument_echo and _is_named_constant_pattern(assignment.var_name, assignment.rhs_node):
+    if not is_argument_echo and _is_named_constant_pattern(assignment.var_name, assignment.rhs_node):
         return False
 
     # Rule 8: Don't report when assignment is outside control flow but usage is inside
@@ -577,7 +579,7 @@ def should_report_violation(
     if lifecycle.uses and all(use.in_comprehension for use in lifecycle.uses):
         return False
 
-    if is_keyword_argument_echo:
+    if is_argument_echo:
         return True
 
     # Rule 11 (conservative level only): a Call RHS returns some domain

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -11,7 +11,6 @@ class AggressivenessLevel(Enum):
     PERMISSIVE = auto()
 
 
-# Transformative verbs that indicate semantic value
 TRANSFORMATIVE_VERBS = {
     "formatted",
     "parsed",
@@ -34,7 +33,6 @@ TRANSFORMATIVE_VERBS = {
     "deserialized",
 }
 
-# Boolean/descriptive prefixes that indicate semantic value
 DESCRIPTIVE_PREFIXES = {
     "has_",
     "is_",
@@ -48,7 +46,6 @@ DESCRIPTIVE_PREFIXES = {
     "does_",
 }
 
-# Descriptive suffixes that indicate semantic value
 DESCRIPTIVE_SUFFIXES = {
     "_count",
     "_flag",

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -246,24 +246,12 @@ def calculate_semantic_value(
 def _would_exceed_line_length(
     lifecycle: VariableLifecycle,
     *,
-    # RHS length (chars) above which inlining is considered risky regardless
-    # of the variable name's length.
     absolute_threshold: int = 25,
 ) -> bool:
-    """A conservative estimate based on RHS length and variable name, used
-    only when the actual usage line isn't available to the caller (see
-    `exceeds_line_length_when_inlined` for the exact check used when it is).
-    Two call sites use different thresholds: reporting a violation is
-    lenient (25 chars), while deciding whether to *auto-fix* is stricter (40
-    chars) since a wrong autofix is more costly than a missed report.
-    """
     assignment = lifecycle.assignment
     var_name = assignment.var_name
     rhs_source = assignment.rhs_source.strip()
 
-    # A long RHS (e.g. a tuple/list literal, a moderately complex
-    # expression) risks exceeding the line length even if the variable name
-    # is also long.
     if len(rhs_source) >= absolute_threshold:
         return True
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -527,21 +527,11 @@ def is_safe_to_splice_into_fstring(value: str, encoding: str = "utf-8") -> bool:
 
 
 def fstring_splice_is_safe(rhs_node: ast.expr, use: UsageInfo) -> bool | None:
-    """None when this isn't the f-string-splice scenario at all — RHS isn't
-    a string literal, or the use isn't inside an f-string replacement field
-    — so callers should fall through to the ordinary autofix rules
-    unchanged. True/False when it is: whether the literal's raw value can
-    be spliced directly into the surrounding f-string text instead of
-    being naively re-quoted inside `{}` (issue #72).
-    """
     if not (isinstance(rhs_node, ast.Constant) and isinstance(rhs_node.value, str)):
         return None
     if not use.in_fstring_expression:
         return None
     if use.fstring_field_span is None:
-        # Inside an f-string field, but not as its whole expression (e.g.
-        # `{x.attr}` or `{x!r}`) — no safe way to remove the braces and
-        # splice raw text without changing what the field expression does.
         return False
     return is_safe_to_splice_into_fstring(rhs_node.value)
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -7,8 +7,6 @@ from .analysis import PatternType, UsageInfo, VariableLifecycle, is_preceded_by_
 
 
 class AggressivenessLevel(Enum):
-    """See `should_report_violation`."""
-
     CONSERVATIVE = auto()
     PERMISSIVE = auto()
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -1,5 +1,3 @@
-"""Semantic value analysis for variable names in TR5."""
-
 from __future__ import annotations
 
 import ast

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -356,16 +356,6 @@ def _is_named_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool:
 
 
 def _is_named_string_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool:
-    """A module-level SCREAMING_SNAKE_CASE name (PEP 8's constant
-    convention, leading underscores stripped first) reads as a deliberate,
-    reusable declaration even for a string RHS. Unlike
-    `_is_named_constant_pattern` above, this can't reuse its
-    "underscore-separated part count" check: every candidate reaching here
-    already has a leading underscore (Rule 1 in `should_report_violation`),
-    which alone satisfies that test regardless of casing. Requiring the
-    stripped name to be all-uppercase is what actually distinguishes a
-    constant from an ordinary private variable.
-    """
     if not isinstance(rhs_node, ast.Constant):
         return False
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -272,26 +272,12 @@ def exceeds_line_length_when_inlined(
 
 
 def _would_require_parentheses(rhs_node: ast.expr) -> bool:
-    """True when the RHS contains operations that would need parentheses if
-    inlined into a subscript, attribute access, or other typical usage
-    context.
-
-    Examples that need parentheses:
-        len_prefix = len(x) + 1  # Used in subscript: arr[len(x) + 1]
-        result = a or b          # Used in subscript: dict[a or b]
-        value = x and y          # Used in call: func(x and y)
-    """
-    # Binary operations (+, -, *, /, //, %, **, <<, >>, |, ^, &, @)
-    # Need parentheses when used in subscripts, attribute access, or calls
     if isinstance(rhs_node, ast.BinOp):
         return True
 
-    # Boolean operations (and, or) need parentheses in most contexts
     if isinstance(rhs_node, ast.BoolOp):
         return True
 
-    # Comparison operations (==, !=, <, >, <=, >=, is, is not, in, not in)
-    # Need parentheses in most contexts
     return isinstance(rhs_node, ast.Compare)
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -333,12 +333,6 @@ def _contains_nondeterministic_call(node: ast.expr) -> bool:
 
 
 def _is_named_constant_pattern(var_name: str, rhs_node: ast.expr) -> bool:
-    """A "named constant" pattern gives semantic meaning to an otherwise-magic
-    numeric literal, and should not be flagged:
-        max_search_depth = 10  # explains what 10 means
-        line_spacing = 1.2  # explains what 1.2 represents
-        user_id = 101749141  # gives meaning to the ID
-    """
     if not isinstance(rhs_node, ast.Constant):
         return False
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -187,14 +187,8 @@ def calculate_semantic_value(
     *,
     has_type_annotation: bool = False,
 ) -> int:
-    """The score ranges from 0-100:
-    - 0-20: No semantic value (redundant assignment, can auto-fix)
-    - 21-49: Marginal value (report but don't auto-fix)
-    - 50-100: Clear value (skip entirely)
-    """
     score = 0
 
-    # e.g. "raw_headers = kwargs.get('headers')".
     if _adds_verbosity_or_context(var_name, rhs_source, rhs_node):
         score += 50
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -282,13 +282,7 @@ def _would_require_parentheses(rhs_node: ast.expr) -> bool:
 
 
 def _contains_nondeterministic_call(node: ast.expr) -> bool:
-    """Non-deterministic functions (time-related, random, UUID, etc.) return
-    different values on each call, so inlining them can change program
-    semantics.
-    """
-    # Known non-deterministic function/method names
     nondeterministic_names = {
-        # time module functions
         "time",
         "perf_counter",
         "perf_counter_ns",
@@ -298,11 +292,9 @@ def _contains_nondeterministic_call(node: ast.expr) -> bool:
         "process_time_ns",
         "thread_time",
         "thread_time_ns",
-        # datetime functions
         "now",
         "today",
         "utcnow",
-        # random module functions
         "random",
         "randint",
         "choice",
@@ -311,11 +303,9 @@ def _contains_nondeterministic_call(node: ast.expr) -> bool:
         "randrange",
         "uniform",
         "gauss",
-        # uuid functions
         "uuid",
         "uuid1",
         "uuid4",
-        # system functions
         "getpid",
         "getppid",
     }

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -264,16 +264,8 @@ def exceeds_line_length_when_inlined(
     rhs_source: str,
     use_line: str,
     *,
-    max_length: int = 79,  # PEP 8 default
+    max_length: int = 79,
 ) -> bool:
-    """True if replacing `var_name` with `rhs_source` on `use_line` would exceed `max_length`.
-
-    This is the exact check (given the real usage line) shared by
-    `should_autofix` (deciding whether to report `[FIXABLE]`) and
-    `autofix.apply_fixes`'s `_can_safely_inline` (deciding whether to actually
-    apply the fix). Both must agree, or a violation can be reported fixable
-    and then silently skipped by `--fix`.
-    """
     len_diff = len(rhs_source) - len(var_name)
     new_line_len = len(use_line.rstrip("\n\r")) + len_diff
     return new_line_len > max_length

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -87,20 +87,9 @@ def _count_chained_operations(node: ast.expr) -> int:
 
 
 def _adds_verbosity_or_context(var_name: str, rhs_source: str, rhs_node: ast.expr) -> bool:
-    """True when the variable name provides more descriptive or domain-specific
-    information than the RHS expression conveys on its own.
-
-    Examples that add verbosity/context:
-        raw_headers = kwargs.get("headers")  # "raw_" prefix adds meaning
-        translations = orjson.loads(f.read())  # describes what data is
-        firestore_client = db.client()  # more specific than "client"
-        user_email = data["email"]  # more verbose than just "email"
-    """
     var_lower = var_name.lower()
     rhs_lower = rhs_source.lower()
 
-    # Pattern 1: Variable has descriptive prefix not in RHS
-    # Examples: raw_headers, parsed_data, validated_input
     descriptive_word_prefixes = {
         "raw",
         "parsed",
@@ -136,30 +125,20 @@ def _adds_verbosity_or_context(var_name: str, rhs_source: str, rhs_node: ast.exp
         if first_part in descriptive_word_prefixes and first_part not in rhs_lower:
             return True
 
-    # Pattern 2: Variable name is more verbose/explicit than dict/kwargs access
-    # Examples:
-    #   raw_headers = kwargs.get("headers")  # adds "raw_" prefix  # noqa: ERA001
-    #   user_email = data["email"]  # adds "user_" prefix  # noqa: ERA001
-    #   firestore_client = db.client()  # more specific type name  # noqa: ERA001
     if isinstance(rhs_node, ast.Subscript | ast.Call):
         rhs_key_or_method = None
 
         if isinstance(rhs_node, ast.Subscript):
             if isinstance(rhs_node.slice, ast.Constant):
                 rhs_key_or_method = str(rhs_node.slice.value).lower()
-        # Must be ast.Call — the outer guard ensures Subscript | Call.
         elif isinstance(rhs_node.func, ast.Attribute):
             rhs_key_or_method = rhs_node.func.attr.lower()
         elif isinstance(rhs_node.func, ast.Name):
             rhs_key_or_method = rhs_node.func.id.lower()
 
-        # Example: "raw_headers" contains "headers" but adds "raw_"
-        # Example: "firestore_client" contains "client" but adds "firestore_"
         if rhs_key_or_method and rhs_key_or_method in var_lower and var_lower != rhs_key_or_method:
             return True
 
-    # Pattern 3: Variable name is a .get() call with more context
-    # Example: raw_headers = kwargs.get("headers")  # noqa: ERA001
     if (
         isinstance(rhs_node, ast.Call)
         and isinstance(rhs_node.func, ast.Attribute)
@@ -167,16 +146,10 @@ def _adds_verbosity_or_context(var_name: str, rhs_source: str, rhs_node: ast.exp
         and rhs_node.args
         and isinstance(rhs_node.args[0], ast.Constant)
     ):
-        # Likely kwargs.get() or dict.get().
         key_name = str(rhs_node.args[0].value).lower()
-        # If var name contains the key but is longer/different, it adds context.
         if key_name in var_lower and len(var_name) > len(key_name):
             return True
 
-    # Pattern 4: Generic parsing/loading functions with descriptive variable names
-    # Examples: translations = orjson.loads(...), config = json.load(...)
-    # The variable name describes WHAT the data is (domain/semantics)
-    # while the RHS just shows HOW it's loaded (generic operation)
     if isinstance(rhs_node, ast.Call):
         generic_parse_functions = {
             "loads",
@@ -196,8 +169,6 @@ def _adds_verbosity_or_context(var_name: str, rhs_source: str, rhs_node: ast.exp
         elif isinstance(rhs_node.func, ast.Name):
             func_name = rhs_node.func.id.lower()
 
-        # If it's a generic parse function and variable name is multi-part or long,
-        # and not a generic placeholder name like "data" or "result"
         generic_names = {"data", "result", "value", "output", "obj", "dict"}
         if (
             func_name in generic_parse_functions

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -453,13 +453,6 @@ def should_report_violation(
     return semantic_score <= _report_score_ceiling(level, pattern)
 
 
-# Placeholder names that add no descriptive value of their own — matching
-# the generic-name sets already used elsewhere in this module (Pattern 4 of
-# `_adds_verbosity_or_context`, `_is_named_constant_pattern`) plus a handful
-# of common synonyms, including `tree` (an `ast.parse()`-style result has no
-# more specific conventional name). A name this short (<=2 characters, e.g.
-# `x`) is treated as equally generic — too short to carry any domain
-# meaning either way.
 _GENERIC_CALL_RESULT_NAMES = frozenset(
     {
         "data",
@@ -481,13 +474,6 @@ _GENERIC_CALL_RESULT_NAMES = frozenset(
 
 
 def _is_generic_call_result_name(var_name: str, rhs_node: ast.Call) -> bool:
-    """True when `var_name` adds no descriptive value beyond what
-    `rhs_node`'s call already conveys — either a placeholder generic enough
-    to carry no domain meaning on its own, or a name that just restates the
-    callee it's assigned from (`check = MeaninglessVarsCheck()`, `state =
-    me.state(...)`) rather than describing the domain value the call
-    returns (`warning = conn.recv()`).
-    """
     if len(var_name) <= 2:
         return True
 

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -20,7 +20,7 @@ from tests.redundant_assignment._helpers import _check
 
 
 def _tracker(source: str) -> VariableTracker:
-    return VariableTracker(source, *classify_comment_lines(source))
+    return VariableTracker(source, *classify_comment_lines(source), ast.parse(source))
 
 
 def _lifecycle_for(source: str, var_name: str) -> VariableLifecycle:
@@ -426,6 +426,252 @@ def caller():
 def test_is_keyword_argument_echo(source: str, var_name: str, *, expected: bool) -> None:
     lifecycle = _lifecycle_for(source, var_name)
     assert lifecycle.uses[0].is_keyword_argument_echo is expected
+
+
+@pytest.mark.parametrize(
+    ("source", "var_name", "expected"),
+    [
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            True,
+        ),
+        (
+            """
+def caller():
+    x = 42
+    return func(x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def func(x):
+    return x
+
+
+def func(x):
+    return x
+
+
+def caller():
+    x = 42
+    return func(x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+@decorator
+def func(x):
+    return x
+
+
+def caller():
+    x = 42
+    return func(x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def caller(obj):
+    x = 42
+    return obj.func(x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def func(x, y):
+    return x, y
+
+
+def caller(items):
+    x = 42
+    return func(*items, x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def func(*args):
+    return args
+
+
+def caller():
+    x = 42
+    return func(1, 2, x)
+""",
+            "x",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller(func):
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller():
+    func = other_func
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def outer():
+    def helper(days_with_routes_in_a_row):
+        return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    return helper(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+class Foo:
+    def helper(self, days_with_routes_in_a_row):
+        return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    return helper(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    del func
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller(value):
+    days_with_routes_in_a_row = 42
+    match value:
+        case _ as func:
+            return func(days_with_routes_in_a_row)
+    return None
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+from other_module import *
+
+
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller():
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller(value):
+    days_with_routes_in_a_row = 42
+    match value:
+        case {"key": _, **func}:
+            return func(days_with_routes_in_a_row)
+    return None
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row):
+    return days_with_routes_in_a_row
+
+
+def caller[func]():
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+    ],
+    ids=[
+        "positional-echo",
+        "undefined-callee-not-echo",
+        "ambiguous-name-not-echo",
+        "decorated-callee-not-echo",
+        "attribute-call-not-echo",
+        "preceding-starred-arg-not-echo",
+        "index-consumed-by-vararg-not-echo",
+        "callee-shadowed-by-parameter-not-echo",
+        "callee-shadowed-by-local-reassignment-not-echo",
+        "callee-is-nested-function-not-echo",
+        "callee-is-method-not-echo",
+        "callee-shadowed-by-del-not-echo",
+        "callee-shadowed-by-match-capture-not-echo",
+        "wildcard-import-not-echo",
+        "callee-shadowed-by-match-mapping-rest-not-echo",
+        "callee-shadowed-by-type-parameter-not-echo",
+    ],
+)
+def test_is_positional_argument_echo(source: str, var_name: str, *, expected: bool) -> None:
+    lifecycle = _lifecycle_for(source, var_name)
+    assert lifecycle.uses[0].is_positional_argument_echo is expected
 
 
 def test_for_iterator_use_is_not_in_loop() -> None:

--- a/tests/redundant_assignment/test_autofix.py
+++ b/tests/redundant_assignment/test_autofix.py
@@ -257,6 +257,18 @@ def caller() -> int:
             "func(days_with_routes_in_a_row=42)",
         ),
         (
+            """def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row = 42",
+            "func(42)",
+        ),
+        (
             """def f():
     v = obj.attr
     use(v)
@@ -304,6 +316,7 @@ def caller() -> int:
     ids=[
         "simple-constant",
         "keyword-argument-echo",
+        "positional-argument-echo",
         "simple-attribute",
         "fstring-field-non-string-rhs",
         "fstring-field-name-rhs",

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -1400,6 +1400,46 @@ def caller() -> int:
     return func(days_with_routes_in_a_row)
 """,
             "days_with_routes_in_a_row",
+            True,
+        ),
+        (
+            """
+def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def func(days_with_routes_in_a_row: str) -> str:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+@decorator
+def func(days_with_routes_in_a_row: int) -> int:
+    return days_with_routes_in_a_row
+
+
+def caller() -> int:
+    days_with_routes_in_a_row = 42
+    return func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
+            False,
+        ),
+        (
+            """
+def caller(obj) -> int:
+    days_with_routes_in_a_row = 42
+    return obj.func(days_with_routes_in_a_row)
+""",
+            "days_with_routes_in_a_row",
             False,
         ),
     ],
@@ -1409,10 +1449,13 @@ def caller() -> int:
         "descriptive-prefix-call-rhs-echo",
         "different-keyword-not-echo",
         "call-rhs-positional-not-echo",
-        "positional-argument-not-echo",
+        "positional-argument-echo",
+        "positional-argument-ambiguous-not-echo",
+        "positional-argument-decorated-not-echo",
+        "positional-argument-attribute-call-not-echo",
     ],
 )
-def test_keyword_argument_echo_reporting(source: str, var_name: str, *, reported: bool) -> None:
+def test_argument_echo_reporting(source: str, var_name: str, *, reported: bool) -> None:
     violations = _check(source)
     if reported:
         assert any(var_name in v.message for v in violations)


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `redundant-assignment` check now detects redundant assignments when a variable is passed positionally to a same-named parameter in eligible local functions.
  - Matching assignments can be automatically inlined.

- **Documentation**
  - Added guidance, examples, and release notes describing positional argument echo detection and its conservative limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->