### PR TITLE
Detect redundant `.value` access on enum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,15 +105,15 @@ repos:
           ]
 
   - repo: https://github.com/alessio-locatelli/ruff-extra-rules
-    rev: v0.2.2
+    rev: v0.3.0
     hooks:
       - id: ruff-extra-rules
         exclude: ^tests/fixtures/
         args:
           [
             --fix,
-            --meaningless-vars-level=permissive,
-            --redundant-assignment-level=permissive,
+            --meaningless-vars-level=aggressive,
+            --redundant-assignment-level=aggressive,
           ]
 
   - repo: https://github.com/Yelp/detect-secrets

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: ruff-extra-rules
   name: Extra Python rule checks (ruff-extra-rules)
-  description: Run multiple AST-based checks in a single pass for improved performance. Excludes redundant-type-conversion (TR6) and redundant-dict-get (TR9) -- see the ruff-extra-rules-ty hook.
+  description: Run multiple AST-based checks in a single pass, including redundant-enum-value (TR10). Excludes redundant-type-conversion (TR6) and redundant-dict-get (TR9); see the ruff-extra-rules-ty hook.
   entry: python -m pre_commit_hooks.ruff_extra_rules
   language: python
   types: [python]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ _Note that ignore comments that suppress false-positives (e.g., `# noqa`, `# typ
 - **No historical/postmortem framing.** Phrases like "the old default", "before this flag existed", "used to qualify for X" are meaningless to a reader who only has the current codebase — they imply a diff against a history the reader can't see and doesn't care about. Describe what the feature does today, full stop.
 - Non-recoverable persistent failures (such as missing files, missing dependencies, permission or access errors, etc.) must not go unreported. At minimum, produce a visible error message so users can either take corrective action or report the issue.
 - **Do not compete with official documentation:** Do not teach users how to install third-party tools, how to debug or configure their environment, etc. Use a short hint and a reference to the official resource.
+- In the "unreleased" section, a changelog entry should describe the final behavior once, not accumulate review history.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
-  local `StrEnum` and `IntEnum` classes without mixins, custom `.value`/`__new__`, or unproven member values.
+  local `StrEnum` and `IntEnum` classes without mixins, custom construction, later `.value` rebindings, or unproven
+  member values.
 
 ## [0.3.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ### Added
 
-- Add TR10, `redundant-enum-value`, which reports `.value` accesses on directly declared members of local `StrEnum` and `IntEnum` classes that do not override `.value`.
+- Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
+  local `StrEnum` and `IntEnum` classes that do not override `.value` or define `__new__`.
 
 ## [0.3.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Added
+
+- Add TR10, `redundant-enum-value`, which reports `.value` accesses on directly declared members of local `StrEnum` and `IntEnum` classes.
+
 ## [0.3.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
-  local `StrEnum` and `IntEnum` classes without mixins, custom construction, later `.value` or member `_value_`
-  rebindings, or unproven member values.
+  local `StrEnum` and `IntEnum` classes without mixins, custom `__getattribute__` behavior or construction, later `.value` or
+  member `_value_` rebindings, ambiguous name resolution, or unproven member values.
 
 ## [0.3.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
-  local `StrEnum` and `IntEnum` classes that do not override `.value` or define `__new__`.
+  local `StrEnum` and `IntEnum` classes without mixins, custom `.value`/`__new__`, or unproven member values.
 
 ## [0.3.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
-  local `StrEnum` and `IntEnum` classes without mixins, custom construction, later `.value` rebindings, or unproven
-  member values.
+  local `StrEnum` and `IntEnum` classes without mixins, custom construction, later `.value` or member `_value_`
+  rebindings, or unproven member values.
 
 ## [0.3.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Added
 
 - Add TR10, `redundant-enum-value`, which reports direct runtime `.value` accesses on directly declared members of
-  local `StrEnum` and `IntEnum` classes without mixins, custom `__getattribute__` behavior or construction, later `.value` or
+  local `StrEnum` and `IntEnum` classes without mixins, custom `__getattribute__` or `__str__` behavior or construction, later `.value` or
   member `_value_` rebindings, ambiguous name resolution, or unproven member values.
 
 ## [0.3.0] - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ### Added
 
-- Add TR10, `redundant-enum-value`, which reports `.value` accesses on directly declared members of local `StrEnum` and `IntEnum` classes.
+- Add TR10, `redundant-enum-value`, which reports `.value` accesses on directly declared members of local `StrEnum` and `IntEnum` classes that do not override `.value`.
 
 ## [0.3.0] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Individual checks are toggled with `--select`/`--ignore` (or the matching `pypro
 | [misplaced-comment](docs/rules/misplaced-comment.md)                 | TR7  | Moves a trailing comment off a closing bracket onto the expression line.                                                                                                          |
 | [unused-pytriage](docs/rules/unused-pytriage.md)                     | TR8  | Reports known `# pytriage` codes that no longer suppress an active violation; add it with `--extend-select=unused-pytriage`.                                                      |
 | [redundant-dict-get](docs/rules/redundant-dict-get.md)               | TR9  | Reports `dict.get()` calls where local control flow, containers, or required TypedDict fields prove the key exists.                                                               |
+| [redundant-enum-value](docs/rules/redundant-enum-value.md)           | TR10 | Reports direct `.value` access on members of local `StrEnum` and `IntEnum` declarations.                                                                                          |
 
 ## Installation
 

--- a/docs/adding-a-check.md
+++ b/docs/adding-a-check.md
@@ -8,6 +8,7 @@ Checks live under `src/pre_commit_hooks/ast_checks/` and plug into the grouped `
 - Check id: kebab-case (e.g. `no-bare-except`).
 - Error code: `TR<N>` (next unused number). `test_all_checks_have_unique_check_ids_and_error_codes` (`tests/test_orchestrator.py`) fails loudly if a new check's id or code collides with an existing one — see `docs/adr/0021-behavioral-contract-audit-rule-isolation-python-compat.md`.
 - Violation message format and whether the check needs an autofix mode.
+- False-positive analysis: before implementation, identify valid binding, scope, runtime-customization, and type-expression boundaries that could make a candidate nonredundant. A default-enabled check must cover those boundaries with regressions and report only when local syntax proves the condition. Leave unknown or dynamic cases unreported, or make an explicitly heuristic rule opt-in.
 
 For the general prefilter-then-parse pipeline shape, see AGENTS.md's "Suggested Check Architecture". Concretely for this repo: almost nothing qualifies for a grep-only check, because every existing check needs to distinguish syntax context that only an AST gives you — e.g. `meaningless-vars` must tell `data = 1` (violation) apart from `obj.data = 1` (attribute, fine) and `"data = 1"` (inside a string, fine), and must catch `def foo(data):` (a parameter, not an assignment) that grep would miss entirely. Use `get_prefilter_pattern()` for a cheap `git grep` pass to skip files that can't possibly match, then do the real detection with `ast`.
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -24,7 +24,7 @@ send_status(Status.READY)
 ```
 
 TR10 only reports direct local declarations with one `StrEnum` or `IntEnum` base, whose members use literals or
-`enum.auto()` and whose class does not customize `.value` access or `__getattribute__`, `__new__`, or `__init__`. It leaves
+`enum.auto()` and whose class does not customize `.value` access, `__getattribute__`, `__str__`, `__new__`, or `__init__`. It leaves
 mixins, imported enum bases, indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type
 annotations, custom enum construction or metaclasses, later `.value` or member `_value_` rebindings, ambiguous name
 resolution, and other `.value` attributes unchanged.

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -1,0 +1,37 @@
+# redundant-enum-value (TR10)
+
+Reports `.value` on a directly declared member of a same-file `StrEnum` or `IntEnum`. Those members already
+behave as `str` or `int` values, so passing the member preserves its enum identity while satisfying ordinary
+string or integer APIs.
+
+## Example
+
+```python
+from enum import StrEnum
+
+
+class Status(StrEnum):
+    READY = "ready"
+
+
+send_status(Status.READY.value)
+```
+
+Write the member directly instead:
+
+```python
+send_status(Status.READY)
+```
+
+TR10 only reports direct local declarations and members. It leaves imported enum bases, indirect inheritance,
+aliases, rebindings, unknown members, and other `.value` attributes unchanged.
+
+## Suppression
+
+Use an inline suppression when an API requires the exact built-in value rather than the enum member:
+
+```python
+send_exact_string(Status.READY.value)  # pytriage: TR10
+```
+
+TR10 is report-only.

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -24,9 +24,9 @@ send_status(Status.READY)
 ```
 
 TR10 only reports direct local declarations with one `StrEnum` or `IntEnum` base, whose members use literals or
-`enum.auto()` and whose class does not override `.value` or define `__new__`. It leaves mixins, imported enum bases,
+`enum.auto()` and whose class does not override `.value` or define `__new__`/`__init__`. It leaves mixins, imported enum bases,
 indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type annotations, custom enum
-construction or metaclasses, later `.value` rebindings, and other `.value` attributes unchanged.
+construction or metaclasses, later `.value` or member `_value_` rebindings, and other `.value` attributes unchanged.
 
 ## Suppression
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -23,9 +23,10 @@ Write the member directly instead:
 send_status(Status.READY)
 ```
 
-TR10 only reports direct local declarations and members whose class does not override `.value` or define `__new__`.
-It leaves imported enum bases, indirect inheritance, aliases, rebindings, unknown members, type annotations,
-overridden `.value` properties, custom enum construction, and other `.value` attributes unchanged.
+TR10 only reports direct local declarations with one `StrEnum` or `IntEnum` base, whose members use literals or
+`enum.auto()` and whose class does not override `.value` or define `__new__`. It leaves mixins, imported enum bases,
+indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type annotations, custom enum
+construction, and other `.value` attributes unchanged.
 
 ## Suppression
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -26,7 +26,7 @@ send_status(Status.READY)
 TR10 only reports direct local declarations with one `StrEnum` or `IntEnum` base, whose members use literals or
 `enum.auto()` and whose class does not override `.value` or define `__new__`. It leaves mixins, imported enum bases,
 indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type annotations, custom enum
-construction, and other `.value` attributes unchanged.
+construction or metaclasses, later `.value` rebindings, and other `.value` attributes unchanged.
 
 ## Suppression
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -24,9 +24,10 @@ send_status(Status.READY)
 ```
 
 TR10 only reports direct local declarations with one `StrEnum` or `IntEnum` base, whose members use literals or
-`enum.auto()` and whose class does not override `.value` or define `__new__`/`__init__`. It leaves mixins, imported enum bases,
-indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type annotations, custom enum
-construction or metaclasses, later `.value` or member `_value_` rebindings, and other `.value` attributes unchanged.
+`enum.auto()` and whose class does not customize `.value` access or `__getattribute__`, `__new__`, or `__init__`. It leaves
+mixins, imported enum bases, indirect inheritance, aliases, rebindings, unknown or descriptor-backed members, type
+annotations, custom enum construction or metaclasses, later `.value` or member `_value_` rebindings, ambiguous name
+resolution, and other `.value` attributes unchanged.
 
 ## Suppression
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -23,8 +23,9 @@ Write the member directly instead:
 send_status(Status.READY)
 ```
 
-TR10 only reports direct local declarations and members. It leaves imported enum bases, indirect inheritance,
-aliases, rebindings, unknown members, and other `.value` attributes unchanged.
+TR10 only reports direct local declarations and members whose class does not override `.value`. It leaves imported
+enum bases, indirect inheritance, aliases, rebindings, unknown members, overridden `.value` properties, and other
+`.value` attributes unchanged.
 
 ## Suppression
 

--- a/docs/rules/redundant-enum-value.md
+++ b/docs/rules/redundant-enum-value.md
@@ -23,9 +23,9 @@ Write the member directly instead:
 send_status(Status.READY)
 ```
 
-TR10 only reports direct local declarations and members whose class does not override `.value`. It leaves imported
-enum bases, indirect inheritance, aliases, rebindings, unknown members, overridden `.value` properties, and other
-`.value` attributes unchanged.
+TR10 only reports direct local declarations and members whose class does not override `.value` or define `__new__`.
+It leaves imported enum bases, indirect inheritance, aliases, rebindings, unknown members, type annotations,
+overridden `.value` properties, custom enum construction, and other `.value` attributes unchanged.
 
 ## Suppression
 

--- a/src/pre_commit_hooks/ast_checks/__init__.py
+++ b/src/pre_commit_hooks/ast_checks/__init__.py
@@ -7,6 +7,7 @@ from .meaningless_vars import MeaninglessVarsCheck
 from .misplaced_comment import MisplacedCommentCheck
 from .redundant_assignment import RedundantAssignmentCheck
 from .redundant_dict_get import RedundantDictGetCheck
+from .redundant_enum_value import RedundantEnumValueCheck
 from .redundant_super_init import RedundantSuperInitCheck
 from .redundant_type_conversion import RedundantTypeConversionCheck
 from .unused_pytriage import UnusedPytriageCheck
@@ -25,4 +26,5 @@ ALL_CHECKS: list[type[ASTCheck]] = [
     RedundantTypeConversionCheck,
     UnusedPytriageCheck,
     RedundantDictGetCheck,
+    RedundantEnumValueCheck,
 ]

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -48,6 +48,17 @@ def _names_bound_by(statements: list[ast.stmt]) -> set[str]:
     return names
 
 
+def _value_rebinding_names(statement: ast.stmt) -> set[str]:
+    return {
+        node.value.id
+        for node in iter_within_scope(statement)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.ctx, ast.Store | ast.Del)
+        and isinstance(node.value, ast.Name)
+        and node.attr == "value"
+    }
+
+
 def _direct_enum_base(base: ast.expr, enum_type_names: set[str], enum_module_names: set[str]) -> bool:
     if isinstance(base, ast.Name):
         return base.id in enum_type_names
@@ -203,6 +214,8 @@ def _local_enum_classes(
             auto_names.difference_update(bindings)
             for name in bindings:
                 enum_classes.pop(name, None)
+            for name in _value_rebinding_names(statement):
+                enum_classes.pop(name, None)
             match statement:
                 case ast.Import():
                     for alias in statement.names:
@@ -224,6 +237,7 @@ def _local_enum_classes(
                         and "value" not in class_bindings
                         and "__new__" not in class_bindings
                         and not statement.decorator_list
+                        and not any(keyword.arg in (None, "metaclass") for keyword in statement.keywords)
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)
                     ):
                         enum_classes[statement.name] = _EnumClass(

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -27,6 +27,7 @@ ERROR_CODE = "TR10"
 IGNORE_PATTERN = ignore_pattern_for(ERROR_CODE)
 _ENUM_TYPE_NAMES = frozenset({"StrEnum", "IntEnum"})
 _NONMEMBER_NAME = "nonmember"
+_AUTO_NAME = "auto"
 
 
 class _EnumClass:
@@ -67,7 +68,25 @@ def _is_nonmember_call(value: ast.expr, nonmember_names: set[str], enum_module_n
     return False
 
 
-def _member_names(class_node: ast.ClassDef, nonmember_names: set[str], enum_module_names: set[str]) -> frozenset[str]:
+def _is_auto_call(value: ast.expr, auto_names: set[str], enum_module_names: set[str]) -> bool:
+    match value:
+        case ast.Call(func=ast.Name(id=name)):
+            return name in auto_names
+        case ast.Call(func=ast.Attribute(value=ast.Name(id=name), attr=attr)) if attr == _AUTO_NAME:
+            return name in enum_module_names
+    return False
+
+
+def _is_proven_member_value(value: ast.expr, auto_names: set[str], enum_module_names: set[str]) -> bool:
+    return isinstance(value, ast.Constant) or _is_auto_call(value, auto_names, enum_module_names)
+
+
+def _member_names(
+    class_node: ast.ClassDef,
+    nonmember_names: set[str],
+    auto_names: set[str],
+    enum_module_names: set[str],
+) -> frozenset[str]:
     members: set[str] = set()
     aliases: set[str] = set()
     for statement in class_node.body:
@@ -90,6 +109,9 @@ def _member_names(class_node: ast.ClassDef, nonmember_names: set[str], enum_modu
             if isinstance(value, ast.Name) and value.id in members:
                 members.discard(name)
                 aliases.add(name)
+            elif not _is_proven_member_value(value, auto_names, enum_module_names):
+                members.discard(name)
+                aliases.discard(name)
             else:
                 aliases.discard(name)
                 members.add(name)
@@ -165,17 +187,20 @@ def _local_enum_classes(
         inherited_enum_type_names: set[str],
         inherited_enum_module_names: set[str],
         inherited_nonmember_names: set[str],
+        inherited_auto_names: set[str],
     ) -> None:
         bound_names = _scope_bindings(scope)
         enum_type_names = inherited_enum_type_names - bound_names
         enum_module_names = inherited_enum_module_names - bound_names
         nonmember_names = inherited_nonmember_names - bound_names
+        auto_names = inherited_auto_names - bound_names
         enum_classes: dict[str, _EnumClass] = {}
         for statement in scope.body:
             bindings = _names_bound_by([statement])
             enum_type_names.difference_update(bindings)
             enum_module_names.difference_update(bindings)
             nonmember_names.difference_update(bindings)
+            auto_names.difference_update(bindings)
             for name in bindings:
                 enum_classes.pop(name, None)
             match statement:
@@ -190,21 +215,25 @@ def _local_enum_classes(
                             enum_type_names.add(imported_name)
                         elif alias.name == _NONMEMBER_NAME:
                             nonmember_names.add(imported_name)
+                        elif alias.name == _AUTO_NAME:
+                            auto_names.add(imported_name)
                 case ast.ClassDef():
+                    class_bindings = class_scope_binding_names(statement)
                     if (
-                        "value" not in class_scope_binding_names(statement)
-                        and "__new__" not in class_scope_binding_names(statement)
+                        len(statement.bases) == 1
+                        and "value" not in class_bindings
+                        and "__new__" not in class_bindings
                         and not statement.decorator_list
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)
                     ):
                         enum_classes[statement.name] = _EnumClass(
-                            _member_names(statement, nonmember_names, enum_module_names)
+                            _member_names(statement, nonmember_names, auto_names, enum_module_names)
                         )
             for nested_scope in _nested_scopes([statement]):
-                collect(nested_scope, enum_type_names, enum_module_names, nonmember_names)
+                collect(nested_scope, enum_type_names, enum_module_names, nonmember_names, auto_names)
         scope_classes[id(scope)] = enum_classes
 
-    collect(tree, set(), set(), set())
+    collect(tree, set(), set(), set(), set())
     return scope_classes
 
 

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -15,7 +15,12 @@ from ._base import (
     ignore_pattern_for,
     record_suppression_usage_if_ignored,
 )
-from ._scope import class_scope_binding_names, iter_binding_names, iter_within_scope
+from ._scope import (
+    class_scope_binding_names,
+    class_scope_global_or_nonlocal_names,
+    iter_binding_names,
+    iter_within_scope,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -41,6 +46,8 @@ def _names_bound_by(statements: list[ast.stmt]) -> set[str]:
     names: set[str] = set()
     for statement in statements:
         names.update(iter_binding_names(statement))
+        if isinstance(statement, ast.ClassDef):
+            names.update(class_scope_global_or_nonlocal_names(statement))
         if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
             continue
         for node in iter_within_scope(statement):
@@ -159,7 +166,10 @@ def _function_bindings(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda
         for type_param in node.type_params
         if isinstance(type_param, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
     )
-    return names | _names_bound_by(node.body)
+    global_names = {
+        name for statement in iter_within_scope(node) if isinstance(statement, ast.Global) for name in statement.names
+    }
+    return names | global_names | _names_bound_by(node.body)
 
 
 def _comprehension_bindings(node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp) -> set[str]:
@@ -252,6 +262,7 @@ def _local_enum_classes(
                         and "value" not in class_bindings
                         and "__new__" not in class_bindings
                         and "__init__" not in class_bindings
+                        and "__getattribute__" not in class_bindings
                         and not statement.decorator_list
                         and not any(keyword.arg in (None, "metaclass") for keyword in statement.keywords)
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -191,8 +191,10 @@ def _local_enum_classes(
                         elif alias.name == _NONMEMBER_NAME:
                             nonmember_names.add(imported_name)
                 case ast.ClassDef():
-                    if not statement.decorator_list and any(
-                        _direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases
+                    if (
+                        "value" not in class_scope_binding_names(statement)
+                        and not statement.decorator_list
+                        and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)
                     ):
                         enum_classes[statement.name] = _EnumClass(
                             _member_names(statement, nonmember_names, enum_module_names)

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -193,6 +193,7 @@ def _local_enum_classes(
                 case ast.ClassDef():
                     if (
                         "value" not in class_scope_binding_names(statement)
+                        and "__new__" not in class_scope_binding_names(statement)
                         and not statement.decorator_list
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)
                     ):
@@ -222,11 +223,14 @@ class _ValueVisitor(ast.NodeVisitor):
 
     def _enum_class(self, class_name: str) -> _EnumClass | None:
         inside_function = False
+        inside_class = False
         for scope, bindings, enum_classes in reversed(self._scope_stack):
             if isinstance(scope, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
                 inside_function = True
-            if inside_function and isinstance(scope, ast.ClassDef):
-                continue
+            if isinstance(scope, ast.ClassDef):
+                if inside_function or inside_class:
+                    continue
+                inside_class = True
             if class_name in bindings:
                 return None
             if enum_class := enum_classes.get(class_name):
@@ -237,7 +241,7 @@ class _ValueVisitor(ast.NodeVisitor):
         self._visit_scope(node, set(), node.body)
 
     def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
-        for child in [*node.decorator_list, *node.args.defaults, *node.args.kw_defaults, node.returns]:
+        for child in [*node.decorator_list, *node.args.defaults, *node.args.kw_defaults]:
             if child is not None:
                 self.visit(child)
         self._visit_scope(node, _function_bindings(node), node.body)
@@ -253,6 +257,13 @@ class _ValueVisitor(ast.NodeVisitor):
             if child is not None:
                 self.visit(child)
         self._visit_scope(node, _function_bindings(node), [node.body])
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+
+    def visit_TypeAlias(self, _node: ast.TypeAlias) -> None:
+        return
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for child in [*node.decorator_list, *node.bases, *(keyword.value for keyword in node.keywords)]:

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+from ._base import (
+    BaseCheck,
+    CheckResult,
+    FixOutcome,
+    FixResult,
+    SuppressionUsage,
+    Violation,
+    byte_col_to_char_col,
+    find_ignored_lines_and_pytriage_comments,
+    ignore_pattern_for,
+    record_suppression_usage_if_ignored,
+)
+from ._scope import class_scope_binding_names, iter_binding_names, iter_within_scope
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+
+CHECK_ID = "redundant-enum-value"
+ERROR_CODE = "TR10"
+IGNORE_PATTERN = ignore_pattern_for(ERROR_CODE)
+_ENUM_TYPE_NAMES = frozenset({"StrEnum", "IntEnum"})
+_NONMEMBER_NAME = "nonmember"
+
+
+class _EnumClass:
+    __slots__ = ("members",)
+
+    def __init__(self, members: frozenset[str]) -> None:
+        self.members = members
+
+
+def _names_bound_by(statements: list[ast.stmt]) -> set[str]:
+    names: set[str] = set()
+    for statement in statements:
+        names.update(iter_binding_names(statement))
+        if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        for node in iter_within_scope(statement):
+            names.update(iter_binding_names(node))
+    return names
+
+
+def _direct_enum_base(base: ast.expr, enum_type_names: set[str], enum_module_names: set[str]) -> bool:
+    if isinstance(base, ast.Name):
+        return base.id in enum_type_names
+    return (
+        isinstance(base, ast.Attribute)
+        and base.attr in _ENUM_TYPE_NAMES
+        and isinstance(base.value, ast.Name)
+        and base.value.id in enum_module_names
+    )
+
+
+def _is_nonmember_call(value: ast.expr, nonmember_names: set[str], enum_module_names: set[str]) -> bool:
+    match value:
+        case ast.Call(func=ast.Name(id=name)):
+            return name in nonmember_names
+        case ast.Call(func=ast.Attribute(value=ast.Name(id=name), attr=attr)) if attr == _NONMEMBER_NAME:
+            return name in enum_module_names
+    return False
+
+
+def _member_names(class_node: ast.ClassDef, nonmember_names: set[str], enum_module_names: set[str]) -> frozenset[str]:
+    members: set[str] = set()
+    aliases: set[str] = set()
+    for statement in class_node.body:
+        match statement:
+            case ast.Assign(targets=[ast.Name(id=name)], value=value):
+                names = (name,)
+            case ast.AnnAssign(target=ast.Name(id=name), value=value):
+                names = (name,)
+            case _:
+                continue
+        if value is None:
+            continue
+        for name in names:
+            if name.startswith("_"):
+                continue
+            if _is_nonmember_call(value, nonmember_names, enum_module_names):
+                members.discard(name)
+                aliases.discard(name)
+                continue
+            if isinstance(value, ast.Name) and value.id in members:
+                members.discard(name)
+                aliases.add(name)
+            else:
+                aliases.discard(name)
+                members.add(name)
+    return frozenset(members - aliases)
+
+
+def _function_bindings(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda) -> set[str]:
+    names = {
+        argument.arg
+        for argument in [
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+            *([node.args.vararg] if node.args.vararg else []),
+            *([node.args.kwarg] if node.args.kwarg else []),
+        ]
+    }
+    if isinstance(node, ast.Lambda):
+        return names
+    names.update(
+        type_param.name
+        for type_param in node.type_params
+        if isinstance(type_param, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
+    )
+    return names | _names_bound_by(node.body)
+
+
+def _comprehension_bindings(node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp) -> set[str]:
+    names: set[str] = set()
+    for generator in node.generators:
+        names.update(
+            name.id
+            for name in ast.walk(generator.target)
+            if isinstance(name, ast.Name) and isinstance(name.ctx, ast.Store)
+        )
+    return names
+
+
+def _scope_bindings(node: ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> set[str]:
+    if isinstance(node, ast.Module):
+        return set()
+    if isinstance(node, ast.ClassDef):
+        return class_scope_binding_names(node)
+    return _function_bindings(node)
+
+
+def _nested_scopes(statements: list[ast.stmt]) -> list[ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef]:
+    scopes: list[ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            scopes.append(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            scopes.append(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            scopes.append(node)
+
+    visitor = Visitor()
+    for statement in statements:
+        visitor.visit(statement)
+    return scopes
+
+
+def _local_enum_classes(
+    tree: ast.Module,
+) -> dict[int, dict[str, _EnumClass]]:
+    scope_classes: dict[int, dict[str, _EnumClass]] = {}
+
+    def collect(
+        scope: ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+        inherited_enum_type_names: set[str],
+        inherited_enum_module_names: set[str],
+        inherited_nonmember_names: set[str],
+    ) -> None:
+        bound_names = _scope_bindings(scope)
+        enum_type_names = inherited_enum_type_names - bound_names
+        enum_module_names = inherited_enum_module_names - bound_names
+        nonmember_names = inherited_nonmember_names - bound_names
+        enum_classes: dict[str, _EnumClass] = {}
+        for statement in scope.body:
+            bindings = _names_bound_by([statement])
+            enum_type_names.difference_update(bindings)
+            enum_module_names.difference_update(bindings)
+            nonmember_names.difference_update(bindings)
+            for name in bindings:
+                enum_classes.pop(name, None)
+            match statement:
+                case ast.Import():
+                    for alias in statement.names:
+                        if alias.name == "enum":
+                            enum_module_names.add(alias.asname or "enum")
+                case ast.ImportFrom(module="enum"):
+                    for alias in statement.names:
+                        imported_name = alias.asname or alias.name
+                        if alias.name in _ENUM_TYPE_NAMES:
+                            enum_type_names.add(imported_name)
+                        elif alias.name == _NONMEMBER_NAME:
+                            nonmember_names.add(imported_name)
+                case ast.ClassDef():
+                    if not statement.decorator_list and any(
+                        _direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases
+                    ):
+                        enum_classes[statement.name] = _EnumClass(
+                            _member_names(statement, nonmember_names, enum_module_names)
+                        )
+            for nested_scope in _nested_scopes([statement]):
+                collect(nested_scope, enum_type_names, enum_module_names, nonmember_names)
+        scope_classes[id(scope)] = enum_classes
+
+    collect(tree, set(), set(), set())
+    return scope_classes
+
+
+class _ValueVisitor(ast.NodeVisitor):
+    def __init__(self, scope_classes: dict[int, dict[str, _EnumClass]]) -> None:
+        self._scope_classes = scope_classes
+        self._scope_stack: list[tuple[ast.AST, set[str], dict[str, _EnumClass]]] = []
+        self.candidates: list[ast.Attribute] = []
+
+    def _visit_scope(self, node: ast.AST, bindings: set[str], children: Iterable[ast.AST]) -> None:
+        enum_classes = self._scope_classes.get(id(node), {})
+        self._scope_stack.append((node, bindings - enum_classes.keys(), enum_classes))
+        for child in children:
+            self.visit(child)
+        self._scope_stack.pop()
+
+    def _enum_class(self, class_name: str) -> _EnumClass | None:
+        inside_function = False
+        for scope, bindings, enum_classes in reversed(self._scope_stack):
+            if isinstance(scope, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+                inside_function = True
+            if inside_function and isinstance(scope, ast.ClassDef):
+                continue
+            if class_name in bindings:
+                return None
+            if enum_class := enum_classes.get(class_name):
+                return enum_class
+        return None
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._visit_scope(node, set(), node.body)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for child in [*node.decorator_list, *node.args.defaults, *node.args.kw_defaults, node.returns]:
+            if child is not None:
+                self.visit(child)
+        self._visit_scope(node, _function_bindings(node), node.body)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for child in [*node.args.defaults, *node.args.kw_defaults]:
+            if child is not None:
+                self.visit(child)
+        self._visit_scope(node, _function_bindings(node), [node.body])
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for child in [*node.decorator_list, *node.bases, *(keyword.value for keyword in node.keywords)]:
+            self.visit(child)
+        self._visit_scope(node, class_scope_binding_names(node), node.body)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_scope(node, _comprehension_bindings(node), [node.elt, *node.generators])
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_scope(node, _comprehension_bindings(node), [node.elt, *node.generators])
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_scope(node, _comprehension_bindings(node), [node.elt, *node.generators])
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_scope(node, _comprehension_bindings(node), [node.key, node.value, *node.generators])
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        match node:
+            case ast.Attribute(value=ast.Attribute(value=ast.Name(id=class_name), attr=member_name), attr="value"):
+                enum_class = self._enum_class(class_name)
+                if enum_class is not None and member_name in enum_class.members:
+                    self.candidates.append(node)
+        self.generic_visit(node)
+
+
+class RedundantEnumValueCheck(BaseCheck):
+    __slots__ = ()
+
+    @property
+    def check_id(self) -> str:
+        return CHECK_ID
+
+    @property
+    def error_code(self) -> str:
+        return ERROR_CODE
+
+    def get_prefilter_pattern(self) -> list[str] | None:
+        return ["StrEnum", "IntEnum", ".value"]
+
+    def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
+        scope_classes = _local_enum_classes(tree)
+        if not any(scope_classes.values()):
+            return CheckResult()
+        visitor = _ValueVisitor(scope_classes)
+        visitor.visit(tree)
+        if not visitor.candidates:
+            return CheckResult()
+        ignored_lines, format_suppressed, comments = find_ignored_lines_and_pytriage_comments(source, IGNORE_PATTERN)
+        source_lines = source.splitlines(keepends=True)
+        violations = []
+        suppression_usages: list[SuppressionUsage] = []
+        for candidate in sorted(visitor.candidates, key=lambda item: (item.lineno, item.col_offset)):
+            if record_suppression_usage_if_ignored(
+                suppression_usages,
+                comments,
+                ignored_lines=ignored_lines,
+                format_suppressed=format_suppressed,
+                check_id=CHECK_ID,
+                error_code=ERROR_CODE,
+                candidate_lines=(candidate.lineno,),
+            ):
+                continue
+            violations.append(
+                Violation(
+                    check_id=CHECK_ID,
+                    error_code=ERROR_CODE,
+                    line=candidate.lineno,
+                    col=byte_col_to_char_col(source_lines[candidate.lineno - 1], candidate.col_offset),
+                    message=(
+                        "Redundant enum `.value` access; pass the enum member directly. "
+                        f"Or add '# pytriage: {ERROR_CODE}' to suppress."
+                    ),
+                    fixable=False,
+                )
+            )
+        return CheckResult(violations, suppression_usages)
+
+    def fix(
+        self,
+        _filepath: Path,
+        violations: list[Violation],
+        _source: str,
+        _tree: ast.Module,
+        _encoding: str = "utf-8",
+    ) -> FixResult:
+        return FixResult.for_violations(violations, FixOutcome.DECLINED)

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -332,7 +332,7 @@ class RedundantEnumValueCheck(BaseCheck):
         return ERROR_CODE
 
     def get_prefilter_pattern(self) -> list[str] | None:
-        return ["StrEnum", "IntEnum", ".value"]
+        return [".value"]
 
     def check(self, _filepath: Path, tree: ast.Module, source: str) -> CheckResult:
         scope_classes = _local_enum_classes(tree)

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -59,6 +59,18 @@ def _value_rebinding_names(statement: ast.stmt) -> set[str]:
     }
 
 
+def _member_value_rebindings(statement: ast.stmt) -> set[tuple[str, str]]:
+    return {
+        (node.value.value.id, node.value.attr)
+        for node in iter_within_scope(statement)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.ctx, ast.Store | ast.Del)
+        and node.attr == "_value_"
+        and isinstance(node.value, ast.Attribute)
+        and isinstance(node.value.value, ast.Name)
+    }
+
+
 def _direct_enum_base(base: ast.expr, enum_type_names: set[str], enum_module_names: set[str]) -> bool:
     if isinstance(base, ast.Name):
         return base.id in enum_type_names
@@ -216,6 +228,9 @@ def _local_enum_classes(
                 enum_classes.pop(name, None)
             for name in _value_rebinding_names(statement):
                 enum_classes.pop(name, None)
+            for class_name, member_name in _member_value_rebindings(statement):
+                if enum_class := enum_classes.get(class_name):
+                    enum_classes[class_name] = _EnumClass(enum_class.members - {member_name})
             match statement:
                 case ast.Import():
                     for alias in statement.names:
@@ -236,6 +251,7 @@ def _local_enum_classes(
                         len(statement.bases) == 1
                         and "value" not in class_bindings
                         and "__new__" not in class_bindings
+                        and "__init__" not in class_bindings
                         and not statement.decorator_list
                         and not any(keyword.arg in (None, "metaclass") for keyword in statement.keywords)
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)

--- a/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_enum_value.py
@@ -55,19 +55,19 @@ def _names_bound_by(statements: list[ast.stmt]) -> set[str]:
     return names
 
 
-def _value_rebinding_names(statement: ast.stmt) -> set[str]:
+def _enum_attribute_rebinding_names(statement: ast.stmt) -> set[str]:
     return {
         node.value.id
         for node in iter_within_scope(statement)
         if isinstance(node, ast.Attribute)
         and isinstance(node.ctx, ast.Store | ast.Del)
         and isinstance(node.value, ast.Name)
-        and node.attr == "value"
+        and node.attr in {"value", "__getattribute__"}
     }
 
 
-def _member_value_rebindings(statement: ast.stmt) -> set[tuple[str, str]]:
-    return {
+def _member_value_rebindings(statement: ast.stmt, member_aliases: dict[str, tuple[str, str]]) -> set[tuple[str, str]]:
+    rebindings = {
         (node.value.value.id, node.value.attr)
         for node in iter_within_scope(statement)
         if isinstance(node, ast.Attribute)
@@ -76,6 +76,52 @@ def _member_value_rebindings(statement: ast.stmt) -> set[tuple[str, str]]:
         and isinstance(node.value, ast.Attribute)
         and isinstance(node.value.value, ast.Name)
     }
+    rebindings.update(
+        member_aliases[node.value.id]
+        for node in iter_within_scope(statement)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.ctx, ast.Store | ast.Del)
+        and node.attr == "_value_"
+        and isinstance(node.value, ast.Name)
+        and node.value.id in member_aliases
+    )
+    return rebindings
+
+
+def _member_alias_binding(
+    statement: ast.stmt,
+    enum_classes: dict[str, _EnumClass],
+) -> tuple[str, tuple[str, str]] | None:
+    match statement:
+        case ast.Assign(
+            targets=[ast.Name(id=alias_name)], value=ast.Attribute(value=ast.Name(id=class_name), attr=member_name)
+        ):
+            enum_class = enum_classes.get(class_name)
+            if enum_class is not None and member_name in enum_class.members:
+                return alias_name, (class_name, member_name)
+    return None
+
+
+def _ignored_member_names(class_node: ast.ClassDef) -> frozenset[str] | None:
+    for statement in class_node.body:
+        if isinstance(statement, ast.Assign):
+            if not any(isinstance(target, ast.Name) and target.id == "_ignore_" for target in statement.targets):
+                continue
+            value = statement.value
+        else:
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return frozenset(value.value.split())
+        if isinstance(value, ast.List | ast.Tuple) and all(
+            isinstance(element, ast.Constant) and isinstance(element.value, str) for element in value.elts
+        ):
+            return frozenset(
+                element.value
+                for element in value.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            )
+        return None
+    return frozenset()
 
 
 def _direct_enum_base(base: ast.expr, enum_type_names: set[str], enum_module_names: set[str]) -> bool:
@@ -145,7 +191,10 @@ def _member_names(
             else:
                 aliases.discard(name)
                 members.add(name)
-    return frozenset(members - aliases)
+    ignored_names = _ignored_member_names(class_node)
+    if ignored_names is None:
+        return frozenset()
+    return frozenset(members - aliases - ignored_names)
 
 
 def _function_bindings(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda) -> set[str]:
@@ -228,6 +277,7 @@ def _local_enum_classes(
         nonmember_names = inherited_nonmember_names - bound_names
         auto_names = inherited_auto_names - bound_names
         enum_classes: dict[str, _EnumClass] = {}
+        member_aliases: dict[str, tuple[str, str]] = {}
         for statement in scope.body:
             bindings = _names_bound_by([statement])
             enum_type_names.difference_update(bindings)
@@ -236,11 +286,19 @@ def _local_enum_classes(
             auto_names.difference_update(bindings)
             for name in bindings:
                 enum_classes.pop(name, None)
-            for name in _value_rebinding_names(statement):
+                member_aliases.pop(name, None)
+            for name in _enum_attribute_rebinding_names(statement):
                 enum_classes.pop(name, None)
-            for class_name, member_name in _member_value_rebindings(statement):
+            for class_name, member_name in _member_value_rebindings(statement, member_aliases):
                 if enum_class := enum_classes.get(class_name):
                     enum_classes[class_name] = _EnumClass(enum_class.members - {member_name})
+            if isinstance(statement, ast.ImportFrom) and any(alias.name == "*" for alias in statement.names):
+                enum_type_names.clear()
+                enum_module_names.clear()
+                nonmember_names.clear()
+                auto_names.clear()
+                enum_classes.clear()
+                member_aliases.clear()
             match statement:
                 case ast.Import():
                     for alias in statement.names:
@@ -263,6 +321,7 @@ def _local_enum_classes(
                         and "__new__" not in class_bindings
                         and "__init__" not in class_bindings
                         and "__getattribute__" not in class_bindings
+                        and "__str__" not in class_bindings
                         and not statement.decorator_list
                         and not any(keyword.arg in (None, "metaclass") for keyword in statement.keywords)
                         and any(_direct_enum_base(base, enum_type_names, enum_module_names) for base in statement.bases)
@@ -270,6 +329,9 @@ def _local_enum_classes(
                         enum_classes[statement.name] = _EnumClass(
                             _member_names(statement, nonmember_names, auto_names, enum_module_names)
                         )
+            if alias_binding := _member_alias_binding(statement, enum_classes):
+                alias_name, member_reference = alias_binding
+                member_aliases[alias_name] = member_reference
             for nested_scope in _nested_scopes([statement]):
                 collect(nested_scope, enum_type_names, enum_module_names, nonmember_names, auto_names)
         scope_classes[id(scope)] = enum_classes

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -61,6 +61,30 @@ def _check(source: str) -> CheckResult:
             (
                 "from enum import StrEnum\n\n"
                 "class State(StrEnum):\n"
+                "    OPEN = 'open'\n"
+                "    CLOSED = 'closed'\n\n"
+                "State.OPEN._value_ = 'changed'\n"
+                "value = State.CLOSED.value\n"
+            ),
+            ["State.CLOSED.value"],
+        ),
+        (
+            (
+                "from enum import StrEnum\n\n"
+                "class Other:\n"
+                "    class OPEN:\n"
+                "        _value_ = 'other'\n\n"
+                "class State(StrEnum):\n"
+                "    OPEN = 'open'\n\n"
+                "Other.OPEN._value_ = 'changed'\n"
+                "value = State.OPEN.value\n"
+            ),
+            ["State.OPEN.value"],
+        ),
+        (
+            (
+                "from enum import StrEnum\n\n"
+                "class State(StrEnum):\n"
                 "    OPEN = 'open'\n\n"
                 "class Container:\n"
                 "    State = object\n\n"
@@ -77,6 +101,8 @@ def _check(source: str) -> CheckResult:
         "qualified-auto",
         "function-local-enum",
         "annotated-runtime-value",
+        "unmodified-member-after-value-rebinding",
+        "unrelated-member-value-rebinding",
         "method-skips-class-binding",
     ],
 )
@@ -258,6 +284,21 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "from enum import StrEnum\n\n"
             "class State(StrEnum):\n"
             "    OPEN = 'open'\n\n"
+            "    def __init__(self, value):\n"
+            "        self._value_ = 'changed'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "State.OPEN._value_ = 'changed'\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
             "def read():\n"
             "    State = object\n"
             "    return State.OPEN.value\n"
@@ -293,6 +334,8 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "type-annotation-and-alias",
         "nested-class-namespace",
         "custom-new",
+        "custom-init",
+        "member-value-rebinding",
         "local-shadowing",
         "type-parameter-shadowing",
     ],

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -200,6 +200,14 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         ),
         (
             "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "    def __getattribute__(self, name):\n"
+            "        return 'custom'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
             "class Status(StrEnum):\n"
             "    READY = 'ready'\n\n"
             "    @property\n"
@@ -299,9 +307,32 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "from enum import StrEnum\n\n"
             "class State(StrEnum):\n"
             "    OPEN = 'open'\n\n"
+            "class OtherState:\n"
+            "    OPEN = object()\n\n"
+            "class Other:\n"
+            "    global State\n"
+            "    State = OtherState\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
             "def read():\n"
             "    State = object\n"
             "    return State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State:\n"
+            "    OPEN = object()\n\n"
+            "def build():\n"
+            "    class State(StrEnum):\n"
+            "        OPEN = 'local'\n\n"
+            "    def read():\n"
+            "        global State\n"
+            "        return State.OPEN.value\n\n"
+            "    return read()\n"
         ),
         (
             "from enum import StrEnum\n\n"
@@ -326,6 +357,7 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "nonmember-attribute",
         "qualified-nonmember-attribute",
         "decorated-enum-class",
+        "getattribute-override",
         "value-override",
         "inherited-value-override",
         "descriptor-attribute",
@@ -336,7 +368,9 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "custom-new",
         "custom-init",
         "member-value-rebinding",
+        "class-global-rebinding",
         "local-shadowing",
+        "global-declaration-in-nested-function",
         "type-parameter-shadowing",
     ],
 )

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -50,6 +50,10 @@ def _check(source: str) -> CheckResult:
             ["State.OPEN.value"],
         ),
         (
+            ("from enum import StrEnum\n\nclass State(StrEnum):\n    OPEN = 'open'\n\nvalue: str = State.OPEN.value\n"),
+            ["State.OPEN.value"],
+        ),
+        (
             (
                 "from enum import StrEnum\n\n"
                 "class State(StrEnum):\n"
@@ -67,6 +71,7 @@ def _check(source: str) -> CheckResult:
         "aliased-int-enum",
         "qualified-str-enum",
         "function-local-enum",
+        "annotated-runtime-value",
         "method-skips-class-binding",
     ],
 )
@@ -157,6 +162,37 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "value = Status.READY.value\n"
         ),
         (
+            "from enum import StrEnum\n"
+            "from typing import Literal\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "value: Literal[State.OPEN.value]\n\n"
+            "def read(*, value: Literal[State.OPEN.value]) -> Literal[State.OPEN.value]:\n"
+            "    return value\n\n"
+            "type StateValue = Literal[State.OPEN.value]\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State:\n"
+            "    class OPEN:\n"
+            "        value = 'module'\n\n"
+            "class Outer:\n"
+            "    class State(StrEnum):\n"
+            "        OPEN = 'outer'\n\n"
+            "    class Inner:\n"
+            "        value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    def __new__(cls, value):\n"
+            "        member = str.__new__(cls, value.upper())\n"
+            "        member._value_ = value\n"
+            "        return member\n\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
             "from enum import StrEnum\n\n"
             "class State(StrEnum):\n"
             "    OPEN = 'open'\n\n"
@@ -186,6 +222,9 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "qualified-nonmember-attribute",
         "decorated-enum-class",
         "value-override",
+        "type-annotation-and-alias",
+        "nested-class-namespace",
+        "custom-new",
         "local-shadowing",
         "type-parameter-shadowing",
     ],

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -125,6 +125,21 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "value = State.OPEN.value\n"
         ),
         (
+            "from enum import EnumType, StrEnum\n\n"
+            "class CustomEnumType(EnumType):\n"
+            "    pass\n\n"
+            "class State(StrEnum, metaclass=CustomEnumType):\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "State.value = property(lambda self: 'custom')\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
             "from enum import StrEnum\n\n"
             "class State(StrEnum):\n"
             "    OPEN = 'open'\n\n"
@@ -264,6 +279,8 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "member-alias",
         "class-alias",
         "class-rebinding",
+        "custom-metaclass",
+        "value-rebinding",
         "parameter-shadowing",
         "nonmember-attribute",
         "qualified-nonmember-attribute",

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -149,6 +149,15 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         ),
         (
             "from enum import StrEnum\n\n"
+            "class Status(StrEnum):\n"
+            "    READY = 'ready'\n\n"
+            "    @property\n"
+            "    def value(self):\n"
+            "        return self.upper()\n\n"
+            "value = Status.READY.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
             "class State(StrEnum):\n"
             "    OPEN = 'open'\n\n"
             "def read():\n"
@@ -176,6 +185,7 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "nonmember-attribute",
         "qualified-nonmember-attribute",
         "decorated-enum-class",
+        "value-override",
         "local-shadowing",
         "type-parameter-shadowing",
     ],

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -40,6 +40,10 @@ def _check(source: str) -> CheckResult:
             ["State.OPEN.value"],
         ),
         (
+            "import enum\n\nclass State(enum.StrEnum):\n    OPEN = enum.auto()\n\nvalue = State.OPEN.value\n",
+            ["State.OPEN.value"],
+        ),
+        (
             (
                 "def build():\n"
                 "    from enum import StrEnum as TextEnum\n\n"
@@ -70,6 +74,7 @@ def _check(source: str) -> CheckResult:
         "str-enum-multiple-members",
         "aliased-int-enum",
         "qualified-str-enum",
+        "qualified-auto",
         "function-local-enum",
         "annotated-runtime-value",
         "method-skips-class-binding",
@@ -162,6 +167,48 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "value = Status.READY.value\n"
         ),
         (
+            "from enum import StrEnum\n\n"
+            "class Override:\n"
+            "    @property\n"
+            "    def value(self):\n"
+            "        return self.upper()\n\n"
+            "class State(Override, StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class Metadata:\n"
+            "    value = 'metadata'\n\n"
+            "class Descriptor:\n"
+            "    def __get__(self, instance, owner):\n"
+            "        return Metadata()\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    METADATA = Descriptor()\n\n"
+            "value = State.METADATA.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class Factory:\n"
+            "    @staticmethod\n"
+            "    def auto():\n"
+            "        return 'metadata'\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    METADATA = Factory.auto()\n\n"
+            "value = State.METADATA.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class Factory:\n"
+            "    metadata = 'metadata'\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    METADATA = Factory.metadata\n\n"
+            "value = State.METADATA.value\n"
+        ),
+        (
             "from enum import StrEnum\n"
             "from typing import Literal\n\n"
             "class State(StrEnum):\n"
@@ -222,6 +269,10 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "qualified-nonmember-attribute",
         "decorated-enum-class",
         "value-override",
+        "inherited-value-override",
+        "descriptor-attribute",
+        "unproven-qualified-member-value",
+        "unproven-member-attribute",
         "type-annotation-and-alias",
         "nested-class-namespace",
         "custom-new",

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -341,6 +341,65 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
             "def read[State]():\n"
             "    return State.OPEN.value\n"
         ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    _ignore_ = ['OPEN']\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "member = State.OPEN\n"
+            "member._value_ = 'changed'\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "from other_module import *\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "State.__getattribute__ = lambda self, name: 'changed'\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "    def __str__(self):\n"
+            "        return 'custom'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    _ignore_ = 'OPEN'\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    _ignore_ = ('OPEN',)\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "ignore_names = ['OPEN']\n"
+            "class State(StrEnum):\n"
+            "    _ignore_ = ignore_names\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
     ],
     ids=[
         "ordinary-enum",
@@ -372,6 +431,14 @@ def test_check_reports_direct_local_enum_member_values(source: str, expressions:
         "local-shadowing",
         "global-declaration-in-nested-function",
         "type-parameter-shadowing",
+        "ignore-member",
+        "member-alias-value-rebinding",
+        "wildcard-import",
+        "getattribute-rebinding",
+        "str-override",
+        "ignore-string",
+        "ignore-tuple",
+        "ignore-unknown",
     ],
 )
 def test_check_skips_unproven_enum_values(source: str) -> None:

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -357,7 +357,7 @@ def test_check_identity_prefilter_and_fix_contract() -> None:
     assert check.error_code == "TR10"
     assert check.default_enabled is True
     assert check.cacheable is True
-    assert set(check.get_prefilter_pattern() or []) == {"StrEnum", "IntEnum", ".value"}
+    assert check.get_prefilter_pattern() == [".value"]
     assert check.fix(Path("test.py"), violations, source, tree).outcomes == (FixOutcome.DECLINED,)
 
 

--- a/tests/test_redundant_enum_value.py
+++ b/tests/test_redundant_enum_value.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from pre_commit_hooks.ast_checks._base import CheckResult, FixOutcome
+from pre_commit_hooks.ast_checks._cli import main
+from pre_commit_hooks.ast_checks.redundant_enum_value import RedundantEnumValueCheck
+
+
+def _check(source: str) -> CheckResult:
+    return RedundantEnumValueCheck().check(Path("test.py"), ast.parse(source), source)
+
+
+@pytest.mark.parametrize(
+    ("source", "expressions"),
+    [
+        (
+            (
+                "from enum import IntEnum, StrEnum, auto\n\n"
+                "class Status(StrEnum):\n"
+                "    READY = auto()\n"
+                "    DONE = auto()\n\n"
+                "class Code(IntEnum):\n"
+                "    OK = 200\n\n"
+                "first = Status.READY.value\n"
+                "second = Status.DONE.value\n"
+                "third = Code.OK.value\n"
+            ),
+            ["Status.READY.value", "Status.DONE.value", "Code.OK.value"],
+        ),
+        (
+            ("from enum import IntEnum as Number\n\nclass Code(Number):\n    OK = 200\n\nvalue = Code.OK.value\n"),
+            ["Code.OK.value"],
+        ),
+        (
+            ("import enum\n\nclass State(enum.StrEnum):\n    OPEN = 'open'\n\nvalue = State.OPEN.value\n"),
+            ["State.OPEN.value"],
+        ),
+        (
+            (
+                "def build():\n"
+                "    from enum import StrEnum as TextEnum\n\n"
+                "    class State(TextEnum):\n"
+                "        OPEN = 'open'\n\n"
+                "    return State.OPEN.value\n"
+            ),
+            ["State.OPEN.value"],
+        ),
+        (
+            (
+                "from enum import StrEnum\n\n"
+                "class State(StrEnum):\n"
+                "    OPEN = 'open'\n\n"
+                "class Container:\n"
+                "    State = object\n\n"
+                "    def read(self):\n"
+                "        return State.OPEN.value\n"
+            ),
+            ["State.OPEN.value"],
+        ),
+    ],
+    ids=[
+        "str-enum-multiple-members",
+        "aliased-int-enum",
+        "qualified-str-enum",
+        "function-local-enum",
+        "method-skips-class-binding",
+    ],
+)
+def test_check_reports_direct_local_enum_member_values(source: str, expressions: list[str]) -> None:
+    violations = _check(source)
+
+    assert [source.splitlines()[violation.line - 1][violation.col :] for violation in violations] == expressions
+    assert all(violation.fixable is False for violation in violations)
+    assert all("pass the enum member directly" in violation.message for violation in violations)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        ("from enum import Enum\n\nclass Kind(Enum):\n    ITEM = 'item'\n\nvalue = Kind.ITEM.value\n"),
+        "class Item:\n    value = 'item'\n\nvalue = Item.value\n",
+        ("from package import StrEnum\n\nclass State(StrEnum):\n    OPEN = 'open'\n\nvalue = State.OPEN.value\n"),
+        (
+            "from enum import StrEnum\n\n"
+            "class Base(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "class State(Base):\n"
+            "    CLOSED = 'closed'\n\n"
+            "value = State.CLOSED.value\n"
+        ),
+        ("from enum import StrEnum\n\nclass State(StrEnum):\n    OPEN = 'open'\n\nvalue = State.UNKNOWN.value\n"),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    ALIAS = OPEN\n\n"
+            "value = State.ALIAS.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "Alias = State\n"
+            "value = Alias.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "State = object\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "def read(State):\n"
+            "    return State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum, nonmember\n"
+            "from types import SimpleNamespace\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    METADATA = nonmember(SimpleNamespace(value='metadata'))\n\n"
+            "value = State.METADATA.value\n"
+        ),
+        (
+            "import enum\n"
+            "from types import SimpleNamespace\n\n"
+            "class State(enum.StrEnum):\n"
+            "    OPEN = 'open'\n"
+            "    METADATA = enum.nonmember(SimpleNamespace(value='metadata'))\n\n"
+            "value = State.METADATA.value\n"
+        ),
+        (
+            "from enum import StrEnum\n"
+            "from types import SimpleNamespace\n\n"
+            "def replace(_class):\n"
+            "    return SimpleNamespace(OPEN=SimpleNamespace(value='open'))\n\n"
+            "@replace\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "value = State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "def read():\n"
+            "    State = object\n"
+            "    return State.OPEN.value\n"
+        ),
+        (
+            "from enum import StrEnum\n\n"
+            "class State(StrEnum):\n"
+            "    OPEN = 'open'\n\n"
+            "def read[State]():\n"
+            "    return State.OPEN.value\n"
+        ),
+    ],
+    ids=[
+        "ordinary-enum",
+        "ordinary-value-attribute",
+        "imported-enum-base",
+        "indirect-inheritance",
+        "unknown-member",
+        "member-alias",
+        "class-alias",
+        "class-rebinding",
+        "parameter-shadowing",
+        "nonmember-attribute",
+        "qualified-nonmember-attribute",
+        "decorated-enum-class",
+        "local-shadowing",
+        "type-parameter-shadowing",
+    ],
+)
+def test_check_skips_unproven_enum_values(source: str) -> None:
+    assert _check(source) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_usage_lines"),
+    [
+        (
+            (
+                "from enum import StrEnum\n\n"
+                "class State(StrEnum):\n"
+                "    OPEN = 'open'\n"
+                "    CLOSED = 'closed'\n\n"
+                "first = State.OPEN.value  # pytriage: TR10\n"
+                "second = State.CLOSED.value\n"
+            ),
+            [7],
+        ),
+        (
+            (
+                "from enum import StrEnum\n\n"
+                "class State(StrEnum):\n"
+                "    OPEN = 'open'\n"
+                "    CLOSED = 'closed'\n\n"
+                "# fmt: off\n"
+                "first = State.OPEN.value\n"
+                "# fmt: on\n"
+                "second = State.CLOSED.value\n"
+            ),
+            [],
+        ),
+    ],
+    ids=["pytriage", "format-suppressed"],
+)
+def test_check_tracks_suppressed_enum_values(source: str, expected_usage_lines: list[int]) -> None:
+    check_result = _check(source)
+
+    assert len(check_result) == 1
+    assert [usage.line for usage in check_result.suppression_usages] == expected_usage_lines
+
+
+def test_check_covers_direct_members_and_expression_scopes() -> None:
+    source = (
+        "from enum import StrEnum\n"
+        "import pathlib\n\n"
+        "class State(StrEnum):\n"
+        "    _INTERNAL = 'internal'\n"
+        "    PENDING: str\n"
+        "    OPEN: str = 'open'\n\n"
+        "    def helper(self):\n"
+        "        return self\n\n"
+        "def read(default=State.OPEN.value):\n"
+        "    return default\n\n"
+        "async def async_read():\n"
+        "    return State.OPEN.value\n\n"
+        "callback_without_default = lambda: State.OPEN.value\n"
+        "callback = lambda value=State.OPEN.value: value\n"
+        "callback_required = lambda *, required: State.OPEN.value\n"
+        "as_list = [State.OPEN.value for item in range(1)]\n"
+        "as_set = {State.OPEN.value for item in range(1)}\n"
+        "as_generator = (State.OPEN.value for item in range(1))\n"
+        "as_dict = {item: State.OPEN.value for item in range(1)}\n"
+    )
+
+    assert len(_check(source)) == 9
+
+
+def test_check_identity_prefilter_and_fix_contract() -> None:
+    source = "from enum import IntEnum\n\nclass Status(IntEnum):\n    OK = 200\n\nvalue = Status.OK.value\n"
+    tree = ast.parse(source)
+    check = RedundantEnumValueCheck()
+    violations = check.check(Path("test.py"), tree, source)
+
+    assert check.check_id == "redundant-enum-value"
+    assert check.error_code == "TR10"
+    assert check.default_enabled is True
+    assert check.cacheable is True
+    assert set(check.get_prefilter_pattern() or []) == {"StrEnum", "IntEnum", ".value"}
+    assert check.fix(Path("test.py"), violations, source, tree).outcomes == (FixOutcome.DECLINED,)
+
+
+def test_cli_lists_selects_and_does_not_fix_redundant_enum_values(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filepath = tmp_path / "module.py"
+    source = "from enum import StrEnum\n\nclass Status(StrEnum):\n    OK = 'ok'\n\nvalue = Status.OK.value\n"
+    filepath.write_text(source)
+
+    assert main(["--list-checks"]) == 0
+    assert "redundant-enum-value: TR10" in capsys.readouterr().out
+    assert main(["--isolated", "--select", "redundant-enum-value", "--fix", str(filepath)]) == 1
+    assert filepath.read_text() == source
+
+
+def test_config_selects_redundant_enum_value(tmp_path: Path) -> None:
+    filepath = tmp_path / "module.py"
+    filepath.write_text(
+        "from enum import StrEnum\n\nclass Status(StrEnum):\n    OK = 'ok'\n\nvalue = Status.OK.value\n"
+    )
+    config = tmp_path / "pyproject.toml"
+    config.write_text('[tool.ruff-extra-rules]\nselect = ["redundant-enum-value"]\n')
+
+    assert main(["--config", str(config), str(filepath)]) == 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TR10, which detects unnecessary `.value` access on local `StrEnum` and `IntEnum` members.
  * Added inline suppression support; findings are report-only and do not apply automatic fixes.

* **Documentation**
  * Added rule documentation, usage examples, and changelog and README entries.

* **Configuration**
  * Updated selected lint checks to use more aggressive validation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->