### PR TITLE
fix(tr5): treat del as a blocking use so autofix can't strand it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 ## [Unreleased]
 
+### Fixed
+
+- `redundant-assignment` no longer reports (or auto-fixes) a value that is later deleted with `del`, since inlining it would leave the `del` statement with nothing to delete.
+
 ## [0.4.2] - 2026-09-07
 
 ### Fixed

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -11,7 +11,7 @@ from pre_commit_hooks.ast_checks._base import fast_get_source_segment, split_lin
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-type UsageContext = Literal["attribute_or_subscript_assignment", "augmented_assignment", "unknown"]
+type UsageContext = Literal["attribute_or_subscript_assignment", "augmented_assignment", "deletion", "unknown"]
 
 
 class PatternType(Enum):
@@ -641,6 +641,40 @@ class VariableTracker(ast.NodeVisitor):
 
         self.visit(node.value)
 
+    def visit_Delete(self, node: ast.Delete) -> None:
+        stmt_index = self._get_current_stmt_index()
+        for target in node.targets:
+            self._record_deletion_targets(target, stmt_index)
+        self.generic_visit(node)
+
+    def _record_deletion_targets(self, target: ast.expr, stmt_index: int) -> None:
+        if isinstance(target, ast.Name):
+            self._track_deletion_use(target, stmt_index)
+        elif isinstance(target, ast.Tuple | ast.List):
+            for elt in target.elts:
+                self._record_deletion_targets(elt, stmt_index)
+
+    def _track_deletion_use(self, target: ast.Name, stmt_index: int) -> None:
+        scope_id = self._get_current_scope_id()
+        var_name = target.id
+
+        if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
+            return
+
+        usage = UsageInfo(
+            var_name=var_name,
+            line=target.lineno,
+            col=target.col_offset,
+            stmt_index=stmt_index,
+            context="deletion",
+            scope_id=scope_id,
+            in_control_flow=self.control_flow_depth > 0,
+        )
+        key = (scope_id, var_name)
+        if key not in self.uses:
+            self.uses[key] = []
+        self.uses[key].append(usage)
+
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         self.parent_stack.append(node)
         self.visit(node.value)
@@ -961,6 +995,10 @@ def detect_redundancy(lifecycle: VariableLifecycle) -> PatternType | None:
 
     for use in lifecycle.uses:
         if use.context == "attribute_or_subscript_assignment":
+            return None
+
+    for use in lifecycle.uses:
+        if use.context == "deletion":
             return None
 
     if lifecycle.rhs_reference_reassigned_before_use:

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -101,6 +101,61 @@ def example():
     assert len(lifecycle.uses) == 2
 
 
+@pytest.mark.parametrize(
+    ("source", "var_name", "expected_contexts"),
+    [
+        (
+            """
+def example():
+    foo = "spam"
+    consume(foo)
+    del foo
+""",
+            "foo",
+            ["unknown", "deletion"],
+        ),
+        (
+            """
+def example():
+    obj = make()
+    del obj.attr
+""",
+            "obj",
+            ["unknown"],
+        ),
+        (
+            """
+def example():
+    foo = "spam"
+    consume(foo)
+    del [foo]
+""",
+            "foo",
+            ["unknown", "deletion"],
+        ),
+        (
+            """
+def example():
+    foo = "spam"
+    consume(foo)
+    del (foo,)
+""",
+            "foo",
+            ["unknown", "deletion"],
+        ),
+    ],
+    ids=[
+        "bare-name-deletion-after-a-load-use",
+        "attribute-deletion-tracks-base-as-ordinary-usage",
+        "list-target-deletion-after-a-load-use",
+        "tuple-target-deletion-after-a-load-use",
+    ],
+)
+def test_deletion_tracked_as_usage(source: str, var_name: str, expected_contexts: list[str]) -> None:
+    lifecycle = _lifecycle_for(source, var_name)
+    assert [use.context for use in lifecycle.uses] == expected_contexts
+
+
 def test_repeated_augmented_assignment_reuses_existing_uses_key() -> None:
     source = """
 def example():
@@ -750,6 +805,36 @@ def func():
         ),
         (
             """
+def func():
+    foo = "spam"
+    consume(foo)
+    del foo
+""",
+            "foo",
+            None,
+        ),
+        (
+            """
+def func():
+    foo = "spam"
+    consume(foo)
+    other = 1
+    del other
+""",
+            "foo",
+            PatternType.IMMEDIATE_SINGLE_USE,
+        ),
+        (
+            """
+def func():
+    foo = "spam"
+    del foo
+""",
+            "foo",
+            None,
+        ),
+        (
+            """
 def func(me):
     state = me.state(State)
     state.value = 5
@@ -1029,6 +1114,9 @@ async def func(obj):
         "immediate-use",
         "single-use-with-intervening-statements",
         "augmented-assignment-is-not-redundant",
+        "deletion-after-single-use-is-not-redundant",
+        "deletion-of-a-different-variable-does-not-block-reporting",
+        "deletion-as-the-only-use-is-not-redundant",
         "mutation-only-single-use-is-not-redundant",
         "snapshot-before-name-reassignment-is-not-redundant",
         "snapshot-before-name-augmented-reassignment-is-not-redundant",

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -390,6 +390,11 @@ def func():
     x += 1
 """,
         """
+def func():
+    global x
+    del x
+""",
+        """
 def outer():
     x = 1
     def inner():
@@ -417,6 +422,22 @@ def func(depot_data, depots):
     depot_iso_country = depot_data.iso_country  # pytriage: TR5
     return [x for x in depots if x.country == depot_iso_country]
 """,
+        """
+def func():
+    def inner(v): ...
+
+    foo = "spam"
+    inner(foo)
+    del foo
+""",
+        """
+def func():
+    def inner(v): ...
+
+    foo = "spam"
+    inner(foo)
+    del [foo]
+""",
     ],
     ids=[
         "multiple-uses",
@@ -427,6 +448,7 @@ def func(depot_data, depots):
         "fmt-off-wrapping-use-line-only",
         "inline-suppression-on-use-line-only",
         "global-variable",
+        "global-variable-deletion",
         "class-attributes",
         "tuple-unpacking",
         "no-uses",
@@ -461,6 +483,8 @@ def func(depot_data, depots):
         "long-variable-name",
         "long-chained-expression",
         "comprehension-false-positive-with-ignore-comment",
+        "deletion-after-single-use",
+        "deletion-after-single-use-list-target",
     ],
 )
 def test_check_reports_no_violations(source: str) -> None:


### PR DESCRIPTION
Closes #219.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated redundant-assignment checks to account for variables removed with `del`.
  * Prevented incorrect warnings and automatic fixes when removing an assignment would leave a `del` statement without a valid target.
  * Added coverage for direct, list, tuple, attribute, global, and local deletion cases.

* **Documentation**
  * Added an unreleased changelog entry describing the deletion-handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->