### PR TITLE
fix(tr5): stop child-scope shadowing from hiding unsafe autofixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 ### Fixed
 
 - `redundant-assignment` no longer reports (or auto-fixes) a value that is later deleted with `del`, since inlining it would leave the `del` statement with nothing to delete.
+- `redundant-assignment` no longer lets a nested function's own local variable of the same name suppress detection of an unrelated, genuinely redundant assignment in the enclosing scope.
+- `redundant-assignment --fix` no longer inlines a value into a call whose callee (or, for `obj.method(...)`, the object) isn't provably stable — reassigned, redefined, or otherwise not resolvable to a single, unshadowed name anywhere in the file — since doing so could change the order in which the value's side effects and the callee lookup run.
 
 ## [0.4.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Notes start at 0.0.50. Earlier tags shipped without them.
 
 - `redundant-assignment` no longer reports (or auto-fixes) a value that is later deleted with `del`, since inlining it would leave the `del` statement with nothing to delete.
 - `redundant-assignment` no longer lets a nested function's own local variable of the same name suppress detection of an unrelated, genuinely redundant assignment in the enclosing scope.
-- `redundant-assignment --fix` no longer inlines a value into a call whose callee (or, for `obj.method(...)`, the object) isn't provably stable — reassigned, redefined, or otherwise not resolvable to a single, unshadowed name anywhere in the file — since doing so could change the order in which the value's side effects and the callee lookup run.
+- `redundant-assignment --fix` no longer inlines a value into a call whose callee (or, for `obj.method(...)`, the object) isn't provably stable — reassigned, redefined, or otherwise not resolvable to a single, unshadowed name anywhere in the file — since doing so could change the order in which the value's side effects and the callee lookup run. See [ADR-0061](docs/adr/0061-redundant-assignment-autofix-rebindable-callee-guard.md).
 
 ## [0.4.2] - 2026-09-07
 

--- a/docs/adr/0061-redundant-assignment-autofix-rebindable-callee-guard.md
+++ b/docs/adr/0061-redundant-assignment-autofix-rebindable-callee-guard.md
@@ -1,0 +1,32 @@
+# redundant-assignment autofix declines to reorder an effectful RHS past a rebindable callee
+
+## Context
+
+Issue [#194](https://github.com/alessio-locatelli/ruff-extra-rules/issues/194): [ADR-0032](0032-redundant-assignment-autofix-safety-criteria.md) lets `should_autofix()` inline an Attribute/Call RHS into a call-site argument when the assignment's one use is the very next statement:
+
+```py
+x = replace()
+return func(x)
+```
+
+Python evaluates a call's callee expression before its arguments, so the original code evaluates `replace()` (in the assignment statement) before it ever looks up `func` (in the next statement). The autofixed form,
+
+```py
+return func(replace())
+```
+
+evaluates `func` first and `replace()` second — the opposite order. ADR-0032 already requires nothing effectful to run between the assignment and the use, but that condition only protects against effects already visible _within_ the statements being merged; it says nothing about the callee lookup the merge newly promotes ahead of the RHS's own evaluation. If `replace()` has the side effect of rebinding `func`, the two versions call different functions. The same reasoning applies whether the argument is positional or keyword, and whether the callee is a bare name (`func(x)`) or an attribute access (`obj.method(x)`), since `obj` is looked up before its arguments the same way a bare name is.
+
+## Decision
+
+Before inlining an Attribute/Call RHS into a use that sits directly in a `Call`'s argument list (positional or keyword, not itself the callee), `should_autofix()` requires that the call's callee — the bare name itself, or the base name of a plain `name.attr` chain — is provably stable: never reassigned, deleted, shadowed, or imported anywhere in the file (the same whole-file `shadowed` set [ADR-0060](0060-redundant-assignment-positional-argument-echo.md) already computes), and if it's also the subject of a `def`/`async def` anywhere in the file, that definition must be the single, undecorated, top-level one ADR-0060's own `functions` index already requires for its callee-resolution guarantee, _and_ it must appear earlier in the file than the call being inlined into. A nested, conditional, redefined, or decorated `def` doesn't give that stability guarantee at all; a single top-level one only gives it once its own `def` line has actually executed, which a call positioned earlier in the file — whether at module level directly, or inside a function invoked before that point — cannot assume. For the same reason ADR-0060 treats a wildcard import as making no name in the file trustworthy, a file containing `from module import *` disqualifies every callee outright, since any name could be rebound by the star-import without saying which.
+
+A callee expression that isn't a bare name or a `name.attr` chain — an attribute access through a subscript (`obj[index].method(x)`), a call (`get_func()(x)`), or anything else not statically resolvable to a base name — is treated the same as a rebindable name: there's no static evidence it's safe, so the conservative default is to decline.
+
+This covers a use that is a direct argument of some `Call` in its immediate context — positional, keyword, or unpacked via `*args`/`**kwargs`. It doesn't walk out through further layers of nesting (e.g. `outer(inner(x))`, where `x` is `inner`'s argument but the reordering risk also touches `outer`'s callee) — a narrower case ADR-0032's argument-count cap already keeps rare in practice.
+
+## Consequences
+
+- `func(x)` / `func(key=x)` / `obj.method(x)` inlining an Attribute or Call RHS is now skipped when `func` (or `obj`) is reassigned, deleted, shadowed by a parameter, imported, bound by a nested/conditional/redefined/decorated `def`, or otherwise bound anywhere else in the file — the same evidence ADR-0060 already treats as disqualifying, plus the `def`-specific stability requirement above. This is a MINOR change per [docs/releases.md](../releases.md): a violation that was previously auto-fixed can now be reported as fixable=false instead.
+- A Constant or Name RHS is unaffected — ADR-0032 already allows those unconditionally, and moving a side-effect-free lookup earlier or later can't change what a rebound callee would have looked up to.
+- This does not defend against dynamic rebinding invisible to static analysis (e.g. `globals()["func"] = other` as a side effect of the RHS call) — the same category of gap ADR-0060 already accepts for callee resolution generally, and one this codebase has no machinery to close without evaluating arbitrary code.

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -59,6 +59,7 @@ class UsageInfo:
     fstring_field_span: tuple[int, int] | None = None
     is_keyword_argument_echo: bool = False
     is_positional_argument_echo: bool = False
+    is_call_argument_with_rebindable_callee: bool = False
 
 
 @dataclass(slots=True)
@@ -83,9 +84,25 @@ class VariableLifecycle:
         return first_use.stmt_index <= self.assignment.stmt_index + 1
 
 
+def _parameter_names(arguments: ast.arguments) -> set[str]:
+    names = {arg.arg for arg in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs)}
+    if arguments.vararg is not None:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg is not None:
+        names.add(arguments.kwarg.arg)
+    return names
+
+
 def _unwind_to_base_name(node: ast.expr) -> ast.Name | None:
     base = node
     while isinstance(base, ast.Attribute | ast.Subscript):
+        base = base.value
+    return base if isinstance(base, ast.Name) else None
+
+
+def _unwind_attribute_chain_to_base_name(node: ast.expr) -> ast.Name | None:
+    base = node
+    while isinstance(base, ast.Attribute):
         base = base.value
     return base if isinstance(base, ast.Name) else None
 
@@ -211,8 +228,11 @@ def _collect_module_binding_facts(tree: ast.Module) -> tuple[bool, dict[str, int
 
 def _index_unique_undecorated_functions(
     tree: ast.Module,
+    *,
+    has_wildcard_import: bool,
+    all_function_name_counts: dict[str, int],
+    shadowed: set[str],
 ) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
-    has_wildcard_import, all_function_name_counts, shadowed = _collect_module_binding_facts(tree)
     if has_wildcard_import:
         return {}
 
@@ -241,7 +261,16 @@ class VariableTracker(ast.NodeVisitor):
         self._comment_only_lines = comment_only_lines
         self._trailing_comment_lines = trailing_comment_lines
 
-        self.functions = _index_unique_undecorated_functions(tree)
+        has_wildcard_import, function_name_counts, shadowed_names = _collect_module_binding_facts(tree)
+        self.functions = _index_unique_undecorated_functions(
+            tree,
+            has_wildcard_import=has_wildcard_import,
+            all_function_name_counts=function_name_counts,
+            shadowed=shadowed_names,
+        )
+        self.shadowed_names = shadowed_names
+        self.has_wildcard_import = has_wildcard_import
+        self.function_name_counts = function_name_counts
         self._call_positional_info: dict[int, tuple[bool, dict[int, int]]] = {}
 
         self.current_scope_id = 0
@@ -252,6 +281,7 @@ class VariableTracker(ast.NodeVisitor):
         self.suspension_points: dict[int, list[tuple[int, int, int, ast.stmt | None]]] = {}
         self.global_vars: set[tuple[int, str]] = set()
         self.nonlocal_vars: set[tuple[int, str]] = set()
+        self.scope_locals: dict[int, set[str]] = {}
 
         self.currently_assigning: set[str] = set()
 
@@ -270,6 +300,7 @@ class VariableTracker(ast.NodeVisitor):
         self.current_stmt: ast.stmt | None = None
 
         self.scope_parents: dict[int, int] = {}
+        self.class_scope_ids: set[int] = set()
 
     def _enter_scope(self) -> None:
         parent_scope_id = self._get_current_scope_id()
@@ -294,13 +325,33 @@ class VariableTracker(ast.NodeVisitor):
     def _get_current_stmt_index(self) -> int:
         return self.stmt_index_stack[-1] if self.stmt_index_stack else 0
 
-    def _get_child_scopes(self, scope_id: int) -> list[int]:
-        children = []
-        for child_id, parent_id in self.scope_parents.items():
-            if parent_id == scope_id:
-                children.append(child_id)
-                children.extend(self._get_child_scopes(child_id))
-        return children
+    def _register_local_binding(self, scope_id: int, var_name: str) -> None:
+        if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
+            return
+        self.scope_locals.setdefault(scope_id, set()).add(var_name)
+
+    def _scope_has_local_binding(self, scope_id: int, var_name: str) -> bool:
+        if self.assignments.get((scope_id, var_name)):
+            return True
+        return var_name in self.scope_locals.get(scope_id, ())
+
+    def _get_closure_reachable_scopes(self, scope_id: int, var_name: str) -> list[int]:
+        reachable: list[int] = []
+        frontier = [child_id for child_id, parent_id in self.scope_parents.items() if parent_id == scope_id]
+        while frontier:
+            next_frontier: list[int] = []
+            for child_id in frontier:
+                # A class body's own bindings (methods included) never shadow names for the
+                # methods nested inside it -- Python's LEGB lookup skips class scopes entirely.
+                is_class_scope = child_id in self.class_scope_ids
+                if not is_class_scope and self._scope_has_local_binding(child_id, var_name):
+                    continue
+                reachable.append(child_id)
+                next_frontier.extend(
+                    grandchild_id for grandchild_id, parent_id in self.scope_parents.items() if parent_id == child_id
+                )
+            frontier = next_frontier
+        return reachable
 
     def _get_source_segment(self, node: ast.expr) -> str:
         return fast_get_source_segment(self.source, self._ast_lines, node) or ""
@@ -320,17 +371,27 @@ class VariableTracker(ast.NodeVisitor):
             self.nonlocal_vars.add((scope_id, name))
         self.generic_visit(node)
 
+    def visit_TypeAlias(self, node: ast.TypeAlias) -> None:
+        self._register_local_binding(self._get_current_scope_id(), node.name.id)
+        self.generic_visit(node)
+
     def _visit_defaults(self, arguments: ast.arguments) -> None:
         for default in (*arguments.defaults, *arguments.kw_defaults):
             if default is not None:
                 self.visit(default)
 
     def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._register_local_binding(self._get_current_scope_id(), node.name)
         for decorator in node.decorator_list:
             self.visit(decorator)
         self._visit_defaults(node.args)
 
         self._enter_scope()
+        self.scope_locals[self._get_current_scope_id()] = _parameter_names(node.args) | {
+            type_param.name
+            for type_param in node.type_params
+            if isinstance(type_param, ast.TypeVar | ast.ParamSpec | ast.TypeVarTuple)
+        }
         try_depth = self.try_depth
         self.try_depth = 0
 
@@ -400,6 +461,19 @@ class VariableTracker(ast.NodeVisitor):
 
     visit_TryStar = visit_Try  # noqa: N815
 
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name is not None:
+            self._register_local_binding(self._get_current_scope_id(), node.name)
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import | ast.ImportFrom) -> None:
+        scope_id = self._get_current_scope_id()
+        for alias in node.names:
+            self._register_local_binding(scope_id, (alias.asname or alias.name).split(".")[0])
+        self.generic_visit(node)
+
+    visit_ImportFrom = visit_Import  # noqa: N815
+
     def visit_With(self, node: ast.With | ast.AsyncWith) -> None:
         self.control_flow_depth += 1
         stmt_index = self._get_current_stmt_index()
@@ -419,6 +493,21 @@ class VariableTracker(ast.NodeVisitor):
             self.visit(case)
         self.control_flow_depth -= 1
         self.parent_stack.pop()
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        if node.name is not None:
+            self._register_local_binding(self._get_current_scope_id(), node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        if node.name is not None:
+            self._register_local_binding(self._get_current_scope_id(), node.name)
+        self.generic_visit(node)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest is not None:
+            self._register_local_binding(self._get_current_scope_id(), node.rest)
+        self.generic_visit(node)
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
         self.lambda_depth += 1
@@ -463,10 +552,12 @@ class VariableTracker(ast.NodeVisitor):
         self._visit_comprehension(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._register_local_binding(self._get_current_scope_id(), node.name)
         for decorator in node.decorator_list:
             self.visit(decorator)
 
         self._enter_scope()
+        self.class_scope_ids.add(self._get_current_scope_id())
 
         for stmt in node.body:
             if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef):
@@ -586,6 +677,11 @@ class VariableTracker(ast.NodeVisitor):
         scope_id = self._get_current_scope_id()
         stmt_index = self._get_current_stmt_index()
 
+        if self._is_simple_name_target(node.target) and node.value is None:
+            assert isinstance(node.target, ast.Name)
+            self._register_local_binding(scope_id, node.target.id)
+            return
+
         if self._is_simple_name_target(node.target) and node.value is not None:
             assert isinstance(node.target, ast.Name)
             var_name = node.target.id
@@ -593,6 +689,7 @@ class VariableTracker(ast.NodeVisitor):
             if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
                 return
 
+            self._register_local_binding(scope_id, var_name)
             self.currently_assigning.add(var_name)
             rhs_source = self._get_source_segment(node.value)
 
@@ -661,6 +758,8 @@ class VariableTracker(ast.NodeVisitor):
         if (scope_id, var_name) in self.global_vars | self.nonlocal_vars:
             return
 
+        self._register_local_binding(scope_id, var_name)
+
         usage = UsageInfo(
             var_name=var_name,
             line=target.lineno,
@@ -690,6 +789,11 @@ class VariableTracker(ast.NodeVisitor):
         self._track_rebinding_use(var_name, node.target.lineno, node.target.col_offset, scope_id, stmt_index)
 
     def _track_rebinding_use(self, var_name: str, line: int, col: int, scope_id: int, stmt_index: int) -> None:
+        if self.lambda_depth == 0:
+            # A walrus target inside a lambda binds to the lambda's own scope (PEP 572), which this
+            # tracker doesn't model separately -- registering it here would wrongly shadow the name
+            # for the enclosing function's other, unrelated uses.
+            self._register_local_binding(scope_id, var_name)
         usage = UsageInfo(
             var_name=var_name,
             line=line,
@@ -741,6 +845,10 @@ class VariableTracker(ast.NodeVisitor):
 
         is_keyword_argument_echo = isinstance(immediate_parent, ast.keyword) and immediate_parent.arg == node.id
         is_positional_argument_echo = self._is_positional_argument_echo(node, immediate_parent)
+        enclosing_call = self._enclosing_call_for_argument(node, immediate_parent)
+        is_call_argument_with_rebindable_callee = enclosing_call is not None and self._callee_is_rebindable(
+            enclosing_call
+        )
 
         usage = UsageInfo(
             var_name=node.id,
@@ -760,12 +868,35 @@ class VariableTracker(ast.NodeVisitor):
             fstring_field_span=fstring_field_span,
             is_keyword_argument_echo=is_keyword_argument_echo,
             is_positional_argument_echo=is_positional_argument_echo,
+            is_call_argument_with_rebindable_callee=is_call_argument_with_rebindable_callee,
         )
 
         key = (scope_id, node.id)
         if key not in self.uses:
             self.uses[key] = []
         self.uses[key].append(usage)
+
+    def _enclosing_call_for_argument(self, node: ast.Name, immediate_parent: ast.AST | None) -> ast.Call | None:
+        if isinstance(immediate_parent, ast.Call) and node is not immediate_parent.func:
+            return immediate_parent
+        if isinstance(immediate_parent, ast.keyword | ast.Starred) and immediate_parent.value is node:
+            grandparent = self.parent_stack[-2] if len(self.parent_stack) >= 2 else None
+            if isinstance(grandparent, ast.Call):
+                return grandparent
+        return None
+
+    def _callee_is_rebindable(self, call: ast.Call) -> bool:
+        if self.has_wildcard_import:
+            return True
+        base = _unwind_attribute_chain_to_base_name(call.func)
+        if base is None:
+            return True
+        if base.id in self.shadowed_names:
+            return True
+        if self.function_name_counts.get(base.id, 0) == 0:
+            return False
+        definition = self.functions.get(base.id)
+        return definition is None or definition.lineno >= call.lineno
 
     def _positional_info_for(self, call: ast.Call) -> tuple[bool, dict[int, int]]:
         cached = self._call_positional_info.get(id(call))
@@ -811,7 +942,7 @@ class VariableTracker(ast.NodeVisitor):
                 all_uses = self.uses.get(key, [])
                 relevant_uses = [use for use in all_uses if use.stmt_index >= assignment.stmt_index]
 
-                child_scopes = self._get_child_scopes(scope_id)
+                child_scopes = self._get_closure_reachable_scopes(scope_id, var_name)
 
                 is_captured_by_nonlocal = any(
                     (child_scope_id, var_name) in self.nonlocal_vars for child_scope_id in child_scopes

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/analysis.py
@@ -300,6 +300,7 @@ class VariableTracker(ast.NodeVisitor):
         self.current_stmt: ast.stmt | None = None
 
         self.scope_parents: dict[int, int] = {}
+        self.scope_children: dict[int, list[int]] = {}
         self.class_scope_ids: set[int] = set()
 
     def _enter_scope(self) -> None:
@@ -308,6 +309,7 @@ class VariableTracker(ast.NodeVisitor):
         child_scope_id = self.current_scope_id
 
         self.scope_parents[child_scope_id] = parent_scope_id
+        self.scope_children.setdefault(parent_scope_id, []).append(child_scope_id)
 
         self.scope_stack.append(child_scope_id)
         self.stmt_index_stack.append(0)
@@ -337,7 +339,7 @@ class VariableTracker(ast.NodeVisitor):
 
     def _get_closure_reachable_scopes(self, scope_id: int, var_name: str) -> list[int]:
         reachable: list[int] = []
-        frontier = [child_id for child_id, parent_id in self.scope_parents.items() if parent_id == scope_id]
+        frontier = list(self.scope_children.get(scope_id, ()))
         while frontier:
             next_frontier: list[int] = []
             for child_id in frontier:
@@ -347,9 +349,7 @@ class VariableTracker(ast.NodeVisitor):
                 if not is_class_scope and self._scope_has_local_binding(child_id, var_name):
                     continue
                 reachable.append(child_id)
-                next_frontier.extend(
-                    grandchild_id for grandchild_id, parent_id in self.scope_parents.items() if parent_id == child_id
-                )
+                next_frontier.extend(self.scope_children.get(child_id, ()))
             frontier = next_frontier
         return reachable
 

--- a/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
+++ b/src/pre_commit_hooks/ast_checks/redundant_assignment/semantic.py
@@ -565,10 +565,14 @@ def should_autofix(
     if not lifecycle.is_immediate_use:
         return False
 
-    if isinstance(rhs_node, ast.Attribute):
-        return _effectful_rhs_use_is_safe_to_inline(lifecycle.uses[0])
+    use = lifecycle.uses[0]
+    if use.is_call_argument_with_rebindable_callee:
+        return False
 
-    if isinstance(rhs_node, ast.Call) and _effectful_rhs_use_is_safe_to_inline(lifecycle.uses[0]):
+    if isinstance(rhs_node, ast.Attribute):
+        return _effectful_rhs_use_is_safe_to_inline(use)
+
+    if isinstance(rhs_node, ast.Call) and _effectful_rhs_use_is_safe_to_inline(use):
         if len(rhs_node.args) <= 2 and not rhs_node.keywords:
             return True
         if len(rhs_node.args) == 0 and len(rhs_node.keywords) <= 2:

--- a/tests/redundant_assignment/test_analysis.py
+++ b/tests/redundant_assignment/test_analysis.py
@@ -766,9 +766,513 @@ def outer():
     )
 
 
+@pytest.mark.parametrize(
+    ("source", "var_name", "expected_use_count"),
+    [
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        x = "inner-value"
+        consume(x)
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner(x):
+        consume(x)
+
+    inner(1)
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        x = 0
+        x += 1
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        x += 1
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        import x
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    helper = "outer-value"
+    consume(helper)
+
+    def inner():
+        def helper():
+            return 1
+        consume(helper)
+
+    inner()
+""",
+            "helper",
+            1,
+        ),
+        (
+            """
+def outer():
+    exc = "outer-value"
+    consume(exc)
+
+    def inner():
+        try:
+            pass
+        except Exception as exc:
+            consume(exc)
+
+    inner()
+""",
+            "exc",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        del x
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        consume(x := 1)
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        x: str
+        consume(x)
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner(values):
+        match values:
+            case [*x]:
+                consume(x)
+
+    inner([1])
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner(value):
+        match value:
+            case {**x}:
+                consume(x)
+
+    inner({})
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        type x = int
+        consume(x)
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner[x]():
+        consume(x)
+
+    inner()
+""",
+            "x",
+            1,
+        ),
+    ],
+    ids=[
+        "nested-function-own-assignment",
+        "nested-function-parameter",
+        "nested-function-augmented-assignment-after-plain-assignment",
+        "nested-function-augmented-assignment-only",
+        "nested-function-import",
+        "nested-function-own-def",
+        "nested-function-except-as",
+        "nested-function-del",
+        "nested-function-walrus",
+        "nested-function-bare-annotation",
+        "nested-function-match-star",
+        "nested-function-match-mapping-rest",
+        "nested-function-type-alias",
+        "nested-function-type-parameter",
+    ],
+)
+def test_nested_scope_local_shadowing_does_not_extend_outer_lifecycle(
+    source: str, var_name: str, expected_use_count: int
+) -> None:
+    lifecycle = _lifecycle_for(source, var_name)
+    assert len(lifecycle.uses) == expected_use_count
+    assert all(use.scope_id == lifecycle.assignment.scope_id for use in lifecycle.uses)
+
+
+def test_nested_class_method_of_same_name_does_not_block_outer_closure() -> None:
+    source = """
+def outer():
+    x = "outer-value"
+
+    class Container:
+        def x(self):
+            return x
+
+    return Container
+"""
+    lifecycle = _lifecycle_for(source, "x")
+    assert len(lifecycle.uses) == 1
+    assert lifecycle.uses[0].scope_id != lifecycle.assignment.scope_id
+
+
+def test_match_wildcard_patterns_do_not_register_local_bindings() -> None:
+    source = """
+def outer():
+    x = "outer-value"
+
+    def inner(values):
+        match values:
+            case [*_]:
+                return x
+            case {"a": 1}:
+                return x
+
+    return inner
+"""
+    lifecycle = _lifecycle_for(source, "x")
+    assert len(lifecycle.uses) == 2
+    assert all(use.scope_id != lifecycle.assignment.scope_id for use in lifecycle.uses)
+
+
+def test_nested_scope_real_closure_still_extends_outer_lifecycle() -> None:
+    source = """
+def outer():
+    value = calculate()
+
+    def inner():
+        return value
+
+    return inner
+"""
+    lifecycle = _lifecycle_for(source, "value")
+    assert len(lifecycle.uses) == 1
+    assert lifecycle.uses[0].scope_id != lifecycle.assignment.scope_id
+
+
+def test_walrus_inside_lambda_does_not_shadow_enclosing_functions_own_closure() -> None:
+    source = """
+def outer():
+    x = replace()
+    consume(x)
+
+    def inner():
+        f = lambda: (x := 1)
+        return x
+
+    return inner
+"""
+    lifecycle = _lifecycle_for(source, "x")
+    assert len(lifecycle.uses) == 3
+    assert any(use.scope_id != lifecycle.assignment.scope_id for use in lifecycle.uses)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            """
+def f():
+    x = replace()
+    return func(x)
+""",
+            False,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return func(x)
+
+
+def rebind():
+    global func
+    func = other
+""",
+            True,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return obj.method(x)
+
+
+def rebind():
+    global obj
+    obj = other
+""",
+            True,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return func(key=x)
+
+
+def rebind():
+    global func
+    func = other
+""",
+            True,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return x
+""",
+            False,
+        ),
+        (
+            """
+from somewhere import *
+
+
+def f():
+    x = replace()
+    return func(x)
+""",
+            True,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return func(*x)
+
+
+def rebind():
+    global func
+    func = other
+""",
+            True,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return func(*x)
+""",
+            False,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return [*x]
+""",
+            False,
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return obj[index].method(x)
+
+
+def rebind():
+    global index
+    index = other_index
+""",
+            True,
+        ),
+        (
+            """
+def outer(cond):
+    if cond:
+        def func():
+            return 1
+
+    x = replace()
+    return func(x)
+""",
+            True,
+        ),
+        (
+            """
+def func():
+    return 1
+
+
+def f():
+    x = replace()
+    return func(x)
+""",
+            False,
+        ),
+        (
+            """
+@decorator
+def func():
+    return 1
+
+
+def f():
+    x = replace()
+    return func(x)
+""",
+            True,
+        ),
+        (
+            """
+x = replace()
+func(x)
+
+
+def func(value):
+    return value
+""",
+            True,
+        ),
+    ],
+    ids=[
+        "unshadowed-callee-safe",
+        "rebindable-bare-callee",
+        "rebindable-attribute-base",
+        "rebindable-callee-keyword-argument",
+        "not-a-call-argument",
+        "wildcard-import-makes-every-callee-rebindable",
+        "rebindable-callee-starred-argument",
+        "unshadowed-callee-starred-argument-safe",
+        "starred-in-non-call-context-not-flagged",
+        "subscripted-attribute-base-unresolvable",
+        "nested-function-definition-rebindable",
+        "unique-top-level-function-safe",
+        "decorated-top-level-function-rebindable",
+        "callee-defined-after-use-rebindable",
+    ],
+)
+def test_is_call_argument_with_rebindable_callee(source: str, *, expected: bool) -> None:
+    lifecycle = _lifecycle_for(source, "x")
+    assert lifecycle.uses[0].is_call_argument_with_rebindable_callee is expected
+
+
 def test_get_source_segment_returns_empty_string_without_end_position() -> None:
     node = ast.Constant(value=1, lineno=-1, col_offset=-1)
     assert _tracker("x = 1")._get_source_segment(node) == ""
+
+
+def test_register_local_binding_skips_global_and_nonlocal_names() -> None:
+    tracker = _tracker("x = 1")
+    tracker.global_vars.add((0, "x"))
+    tracker._register_local_binding(0, "x")
+    assert "x" not in tracker.scope_locals.get(0, set())
+
+
+def test_annotation_on_non_simple_target_is_not_tracked() -> None:
+    source = """
+def f(obj):
+    obj.attr: int = compute()
+"""
+    tracker = _tracker(source)
+    tracker.visit(ast.parse(source))
+    assert tracker.assignments == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/redundant_assignment/test_check.py
+++ b/tests/redundant_assignment/test_check.py
@@ -1281,6 +1281,20 @@ def example():
 """,
             "'x'",
         ),
+        (
+            """
+def outer():
+    x = "outer-value"
+    consume(x)
+
+    def inner():
+        x = "inner-value"
+        consume(x)
+
+    inner()
+""",
+            "'x'",
+        ),
     ],
     ids=[
         "single-use-return",
@@ -1291,6 +1305,7 @@ def example():
         "await-only-on-usage",
         "non-closure-detected",
         "annotated-assignment-without-value",
+        "outer-variable-not-suppressed-by-nested-shadowing",
     ],
 )
 def test_check_reports_flagged_violation(source: str, substring: str | None) -> None:
@@ -1590,8 +1605,40 @@ def f():
 """,
             "'tree'",
         ),
+        (
+            """
+def f():
+    x = replace()
+    return func(x)
+
+
+def rebind():
+    global func
+    func = other
+""",
+            "'x'",
+        ),
+        (
+            """
+def f():
+    x = replace()
+    return obj.method(x)
+
+
+def rebind():
+    global obj
+    obj = other
+""",
+            "'x'",
+        ),
     ],
-    ids=["multiline-rhs", "complex-call-args", "long-use-line"],
+    ids=[
+        "multiline-rhs",
+        "complex-call-args",
+        "long-use-line",
+        "call-argument-rebindable-callee",
+        "call-argument-rebindable-attribute-base",
+    ],
 )
 def test_check_does_not_mark_unfixable_violation_fixable(source: str, message_filter: str) -> None:
     matching = [v for v in _check(source) if message_filter in v.message]


### PR DESCRIPTION
Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/194

Closes https://github.com/alessio-locatelli/ruff-extra-rules/issues/224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redundant-assignment detection when nested scopes reuse variable names.
  * Prevented `redundant-assignment --fix` from inlining values into calls when the callee or attribute base may be rebound, avoiding changes to evaluation order or behavior.

* **Documentation**
  * Added documentation describing the safeguards for redundant-assignment autofixes.

* **Tests**
  * Expanded coverage for nested scopes, closures, rebinding, imports, annotations, and call arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->